### PR TITLE
GeoJSON literals for GeoSPARQL

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -181,7 +181,6 @@ skos:prefLabel a owl:AnnotationProperty .
 	rdfs:comment """
       A GeoJSON serialization of a geometry object.
     """@en ;
-	rdfs:subClassOf rdf:JSON ;
 	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.1> ;
 	rdfs:label "GeoJSON Literal"@en ;

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -167,6 +167,27 @@ skos:prefLabel a owl:AnnotationProperty .
       A Well-known Text serialization of a geometry object.
     """@en ;
 	skos:prefLabel "Well-known Text Literal"@en .
+	
+# 
+# http://www.opengis.net/ont/geosparql#wktLiteral
+
+:geoJSONLiteral a rdfs:Datatype ;
+	dc:contributor "Timo Homburg" ;
+	dc:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
+	dc:date "2020-10-30"^^xsd:date ;
+	dc:description """
+      A GeoJSON serialization of a geometry object.
+    """@en ;
+	rdfs:comment """
+      A GeoJSON serialization of a geometry object.
+    """@en ;
+	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.1> ;
+	rdfs:label "GeoJSON Literal"@en ;
+	skos:definition """
+      A GeoJSON serialization of a geometry object.
+    """@en ;
+	skos:prefLabel "GeoJSON Literal"@en .
+	
 # 
 # http://www.w3.org/2001/XMLSchema#date
 
@@ -864,6 +885,30 @@ xsd:date a rdfs:Datatype .
       The WKT serialization of a geometry
     """@en ;
 	skos:prefLabel "asWKT"@en .
+	
+# 
+# http://www.opengis.net/ont/geosparql#asGeoJSON
+
+:asGeoJSON a owl:DatatypeProperty ;
+	rdfs:subPropertyOf :hasSerialization ;
+	rdfs:domain :Geometry ;
+	rdfs:range :geoJSONLiteral ;
+	dc:contributor "Timo Homburg" ;
+	dc:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
+	dc:date "2020-10-30"^^xsd:date ;
+	dc:description """
+      The GeoJSON serialization of a geometry
+    """@en ;
+	rdfs:comment """
+      The GeoJSON serialization of a geometry
+    """@en ;
+	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.1> ;
+	rdfs:label "asGeoJSON"@en ;
+	skos:definition """
+      The GeoJSON serialization of a geometry
+    """@en ;
+	skos:prefLabel "asGeoJSON"@en .	
+
 # 
 # http://www.opengis.net/ont/geosparql#coordinateDimension
 

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -181,6 +181,7 @@ skos:prefLabel a owl:AnnotationProperty .
 	rdfs:comment """
       A GeoJSON serialization of a geometry object.
     """@en ;
+	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> .
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.1> ;
 	rdfs:label "GeoJSON Literal"@en ;
 	skos:definition """
@@ -893,6 +894,7 @@ xsd:date a rdfs:Datatype .
 	rdfs:subPropertyOf :hasSerialization, rdf:json ;
 	rdfs:domain :Geometry ;
 	rdfs:range :geoJSONLiteral ;
+	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> .
 	dc:contributor "Timo Homburg" ;
 	dc:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
 	dc:date "2020-10-30"^^xsd:date ;

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -181,7 +181,8 @@ skos:prefLabel a owl:AnnotationProperty .
 	rdfs:comment """
       A GeoJSON serialization of a geometry object.
     """@en ;
-	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> .
+	rdfs:subClassOf rdf:JSON ;
+	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.1> ;
 	rdfs:label "GeoJSON Literal"@en ;
 	skos:definition """
@@ -891,7 +892,7 @@ xsd:date a rdfs:Datatype .
 # http://www.opengis.net/ont/geosparql#asGeoJSON
 
 :asGeoJSON a owl:DatatypeProperty ;
-	rdfs:subPropertyOf :hasSerialization, rdf:json ;
+	rdfs:subPropertyOf :hasSerialization;
 	rdfs:domain :Geometry ;
 	rdfs:range :geoJSONLiteral ;
 	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> .

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -890,7 +890,7 @@ xsd:date a rdfs:Datatype .
 # http://www.opengis.net/ont/geosparql#asGeoJSON
 
 :asGeoJSON a owl:DatatypeProperty ;
-	rdfs:subPropertyOf :hasSerialization ;
+	rdfs:subPropertyOf :hasSerialization, rdf:json ;
 	rdfs:domain :Geometry ;
 	rdfs:range :geoJSONLiteral ;
 	dc:contributor "Timo Homburg" ;

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -358,6 +358,71 @@ geo:asGML a rdf:Property;
     rdfs:range geo:gmlLiteral .
 ```
 
+
+==== Requirements for GeoJSON Serialization (serialization=GEOJSON)
+
+This section establishes the requirements for representing geometry data in RDF based on GeoJSON.
+
+===== RDFS Datatypes
+
+This section defines one RDFS Datatype: `+http://www.opengis.net/ont/geosparql#geoJSONLiteral+`.
+
+*RDFS Datatype: geo:geoJSONLiteral*
+
+```
+geo:geoJSONLiteral a rdfs:Datatype;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;
+    rdfs:label "GeoJSON Literal"@en;
+    rdfs:comment "A GeoJSON serialization of a geometry object."@en .
+```
+
+Valid `geo:geoJSONLiteral`s are formed by encoding geometry information as a Geometry object as defined in the GeoJSON specification [RFC 7946].
+
+|===
+|*Req XX* All `geo:geoJSONLiteral`s shall consist of the Geometry objects as defined in the GeoJSON specification [RFC 7946].
+|`/req/geometry-extension/geoJSON-literal1`
+|===
+
+|===
+|*Req XX* All RDFS Literals of type `geo:geoJSONLiteral` do not contain a CRS definition. All literals of this type shall according to the GeoJSON specification only be encoded in and assumed to use the WGS84 geodetic longitude-latitude spatial reference system (urn:ogc:def:crs:OGC::CRS84).
+|`/req/geometry-extension/geoJSON-literal-crs`
+|===
+
+The example `geo:geoJSONLiteral` below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:
+
+```
+"{\"type\":\"Point\", \"coordinates\":[-83.38,33.95]}"^^<http://www.opengis.net/ont/geosparql#geoJSONLiteral>
+```
+
+|===
+|*Req XX* An empty RDFS Literal of type `geo:geoJSONLiteral` shall be interpreted as an empty geometry, i.e. {"geometry":null} in GeoJSON .
+|`/req/geometry-extension/geoJSON-literal-empty`
+|===
+
+===== Serialization Properties
+
+The `geo:asGeoJSON` property is defined to link a geometry with its GeoJSON serialization.
+
+*Property: geo:asGeoJSON*
+
+|===
+|*Req XX* Implementations shall allow the RDF property `geo:asGeoJSON` to be used in SPARQL graph patterns.
+|`/req/geometry-extension/geometry-as-geojson-literal`
+|===
+
+The property `geo:asGeoJSON` is used to link a geometric element with its GeoJSON serialization.
+
+```
+geo:asGeoJSON a rdf:Property,
+            owl:DatatypeProperty;
+    rdfs:subPropertyOf geo:hasSerialization;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;
+    rdfs:label "as GeoJSON"@en;
+    rdfs:comment "The GeoJSON serialization of a geometry."@en;
+    rdfs:domain geo:Geometry;
+    rdfs:range geo:geoJSONLiteral .
+```
+
 ==== Non-topological Query Functions
 
 This clause defines SPARQL functions for performing non-topological spatial operations.

--- a/1.1/spec/13-Part-10.adoc
+++ b/1.1/spec/13-Part-10.adoc
@@ -75,7 +75,7 @@ This section establishes the requirements for representing geometry data in RDF 
 
 ===== Geometry Class Hierarchy
 
-The GeoJSON-LD specification presents a geometry class hierarchy. It is straightforward to represent this class hierarchy in RDFS and OWL by constructing URIs for geometry classes using the following pattern: `+https://purl.org/geojson/vocab#{geometry class}+` and by asserting appropriate `rdfs:subClassOf` statements.
+The GeoJSON-LD specification presents a set of geometry classes. It is straightforward to represent this set of classes in RDFS and OWL by constructing URIs for geometry classes using the following pattern: `+https://purl.org/geojson/vocab#{geometry class}+` and by asserting appropriate `rdfs:subClassOf` statements.
 
 The example RDF snippet below encodes the Polygon class from GeoJSON-LD.
 
@@ -84,9 +84,7 @@ geojson:Polygon a rdfs:Class,
              owl:Class;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;
     rdfs:label "Polygon"@en;
-    rdfs:subClassOf geojson:Surface;
-    rdfs:comment "A planar surface defined by 1 exterior boundary and 0 or 
-                  more interior boundaries"@en .
+    rdfs:subClassOf sf:Geometry .
 ```
 
 |===

--- a/1.1/spec/13-Part-10.adoc
+++ b/1.1/spec/13-Part-10.adoc
@@ -68,26 +68,3 @@ gml:Polygon a rdfs:Class,
 |*Req 27* Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the GML schema that implements `GM_Object` using the specified _version_ of GML [OGC 07-036].
 |`/req/rdfs-entailment-extension/gml-geometry-types`
 |===
-
-==== Requirements for GeoJSON Serialization (serialization=GeoJSON)
-
-This section establishes the requirements for representing geometry data in RDF based on GeoJSON as defined by Simple Features [RFC 7946].
-
-===== Geometry Class Hierarchy
-
-The GeoJSON-LD specification presents a set of geometry classes. It is straightforward to represent this set of classes in RDFS and OWL by constructing URIs for geometry classes using the following pattern: `+https://purl.org/geojson/vocab#{geometry class}+` and by asserting appropriate `rdfs:subClassOf` statements.
-
-The example RDF snippet below encodes the Polygon class from GeoJSON-LD.
-
-```
-geojson:Polygon a rdfs:Class, 
-             owl:Class;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;
-    rdfs:label "Polygon"@en;
-    rdfs:subClassOf sf:Geometry .
-```
-
-|===
-|*Req XX* Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of GeoJSON-LD.
-|`/req/rdfs-entailment-extension/geojson-geometry-types`
-|===

--- a/1.1/spec/13-Part-10.adoc
+++ b/1.1/spec/13-Part-10.adoc
@@ -75,21 +75,21 @@ This section establishes the requirements for representing geometry data in RDF 
 
 ===== Geometry Class Hierarchy
 
-The Simple Features specification presents a geometry class hierarchy. It is straightforward to represent this class hierarchy in RDFS and OWL by constructing URIs for geometry classes using the following pattern: `+http://www.opengis.net/ont/sf#{geometry class}+` and by asserting appropriate `rdfs:subClassOf` statements.
+The GeoJSON-LD specification presents a geometry class hierarchy. It is straightforward to represent this class hierarchy in RDFS and OWL by constructing URIs for geometry classes using the following pattern: `+https://purl.org/geojson/vocab#{geometry class}+` and by asserting appropriate `rdfs:subClassOf` statements.
 
-The example RDF snippet below encodes the Polygon class from Simple Features 1.0.
+The example RDF snippet below encodes the Polygon class from GeoJSON-LD.
 
 ```
-sf:Polygon a rdfs:Class, 
+geojson:Polygon a rdfs:Class, 
              owl:Class;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0>;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;
     rdfs:label "Polygon"@en;
-    rdfs:subClassOf sf:Surface;
+    rdfs:subClassOf geojson:Surface;
     rdfs:comment "A planar surface defined by 1 exterior boundary and 0 or 
                   more interior boundaries"@en .
 ```
 
 |===
-|*Req XX* Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of Simple Features [ISO 19125-1].
+|*Req XX* Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of GeoJSON-LD.
 |`/req/rdfs-entailment-extension/geojson-geometry-types`
 |===

--- a/1.1/spec/13-Part-10.adoc
+++ b/1.1/spec/13-Part-10.adoc
@@ -68,3 +68,28 @@ gml:Polygon a rdfs:Class,
 |*Req 27* Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the GML schema that implements `GM_Object` using the specified _version_ of GML [OGC 07-036].
 |`/req/rdfs-entailment-extension/gml-geometry-types`
 |===
+
+==== Requirements for GeoJSON Serialization (serialization=GeoJSON)
+
+This section establishes the requirements for representing geometry data in RDF based on GeoJSON as defined by Simple Features [RFC 7946].
+
+===== Geometry Class Hierarchy
+
+The Simple Features specification presents a geometry class hierarchy. It is straightforward to represent this class hierarchy in RDFS and OWL by constructing URIs for geometry classes using the following pattern: `+http://www.opengis.net/ont/sf#{geometry class}+` and by asserting appropriate `rdfs:subClassOf` statements.
+
+The example RDF snippet below encodes the Polygon class from Simple Features 1.0.
+
+```
+sf:Polygon a rdfs:Class, 
+             owl:Class;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0>;
+    rdfs:label "Polygon"@en;
+    rdfs:subClassOf sf:Surface;
+    rdfs:comment "A planar surface defined by 1 exterior boundary and 0 or 
+                  more interior boundaries"@en .
+```
+
+|===
+|*Req XX* Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of Simple Features [ISO 19125-1].
+|`/req/rdfs-entailment-extension/geojson-geometry-types`
+|===


### PR DESCRIPTION
I have extended the Geometry Extension section of the GeoSPARQL specification to include a definition for a GeoJSON literal.
The ontology has also been extended by a geo:asGeoJSON property and a geo:geoJSONLiteral.

I had the following considerations:
- I chose to represent GeoJSON using a GeoJSON literal and not using the rdf:json relation because other serializations of geometries in JSON exist, for example ESRIJSON, TopoJSON, or even pure JSON files with lat/lon geocoordinates attached. Whether or not to leave it this way is a matter of discussion
- GeoJSON literals do not allow the definition of a CRS in the literal as opposed to WKT and GML as the GeoJSON standard only allows one CRS (WGS84) to be used
- GeoJSON literals are defined by the Geometry Object of the GeoJSON specification, e.g. {"type":"Point","coordinates":[-83.38,33.95]}
- An empty literal is equivalent to the statement {"geometry":null} 
However, how do we define equivalences for POINT(EMPTY), POLYGON(EMPTY) etc.? Is this necessary?
Should we define an empty Point as {"type":"Point","coordinates":[]} a.s.o. ?
- Requirement definitions currently do not contain a number as we might modify the numbering later on

I was not sure whether it is needed to extend the RDFS Entailment section.
In my opinion, we could just reuse the Geometry class definitions of SimpleFeatures which were used for defining the WKTLiterals.
But I am open to any other suggestions.
