### PR TITLE
Update geo.ttl: remove spaces and newlines

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -136,17 +136,11 @@ skos:prefLabel a owl:AnnotationProperty .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      A GML serialization of a geometry object.
-    """@en ;
-	rdfs:comment """
-      A GML serialization of a geometry object.
-    """@en ;
+	dc:description """A GML serialization of a geometry object."""@en ;
+	rdfs:comment """A GML serialization of a geometry object."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "GML Literal"@en ;
-	skos:definition """
-      A GML serialization of a geometry object.
-    """@en ;
+	skos:definition """A GML serialization of a geometry object."""@en ;
 	skos:prefLabel "GML Literal"@en .
 # 
 # http://www.opengis.net/ont/geosparql#wktLiteral
@@ -155,17 +149,11 @@ skos:prefLabel a owl:AnnotationProperty .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      A Well-known Text serialization of a geometry object.
-    """@en ;
-	rdfs:comment """
-      A Well-known Text serialization of a geometry object.
-    """@en ;
+	dc:description """A Well-known Text serialization of a geometry object."""@en ;
+	rdfs:comment """A Well-known Text serialization of a geometry object."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "Well-known Text Literal"@en ;
-	skos:definition """
-      A Well-known Text serialization of a geometry object.
-    """@en ;
+	skos:definition """A Well-known Text serialization of a geometry object."""@en ;
 	skos:prefLabel "Well-known Text Literal"@en .
 # 
 # http://www.w3.org/2001/XMLSchema#date
@@ -190,20 +178,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The default geometry to be used in spatial calculations.
-      It is Usually the most detailed geometry.
-    """@en ;
-	rdfs:comment """
-      The default geometry to be used in spatial calculations.
-      It is Usually the most detailed geometry.
-    """@en ;
+	dc:description """The default geometry to be used in spatial calculations. It is Usually the most detailed geometry."""@en ;
+	rdfs:comment """The default geometry to be used in spatial calculations. It is Usually the most detailed geometry."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "defaultGeometry"@en ;
-	skos:definition """
-      The default geometry to be used in spatial calculations.
-      It is Usually the most detailed geometry.
-    """@en ;
+	skos:definition """The default geometry to be used in spatial calculations. It is Usually the most detailed geometry."""@en ;
 	skos:prefLabel "defaultGeometry"@en .
 # 
 # http://www.opengis.net/ont/geosparql#ehContains
@@ -214,20 +193,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*TFF*FF*
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*TFF*FF*
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*TFF*FF*"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*TFF*FF"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "contains"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*TFF*FF*
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*TFF*FF*"""@en ;
 	skos:prefLabel "contains"@en .
 # 
 # http://www.opengis.net/ont/geosparql#ehCoveredBy
@@ -238,20 +208,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFF*TFT**
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFF*TFT**
-    """@en ;
+	dc:description """Exists if the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFF*TFT**"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFF*TFT**"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "coveredBy"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFF*TFT**
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFF*TFT**"""@en ;
 	skos:prefLabel "coveredBy"@en .
 # 
 # http://www.opengis.net/ont/geosparql#ehCovers
@@ -262,20 +223,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: T*TFT*FF*
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: T*TFT*FF*
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: T*TFT*FF*"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: T*TFT*FF*"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "covers"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: T*TFT*FF*
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: T*TFT*FF*"""@en ;
 	skos:prefLabel "covers"@en .
 # 
 # http://www.opengis.net/ont/geosparql#ehDisjoint
@@ -286,20 +238,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
+	dc:description """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "disjoint"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
 	skos:prefLabel "disjoint"@en .
 # 
 # http://www.opengis.net/ont/geosparql#ehEquals
@@ -310,20 +253,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "equals"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
 	skos:prefLabel "equals"@en .
 # 
 # http://www.opengis.net/ont/geosparql#ehInside
@@ -334,20 +268,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFF*FFT**
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFF*FFT**
-    """@en ;
+	dc:description """Exists if the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFF*FFT**"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFF*FFT**"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "inside"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFF*FFT**
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFF*FFT**"""@en ;
 	skos:prefLabel "inside"@en .
 # 
 # http://www.opengis.net/ont/geosparql#ehMeet
@@ -358,23 +283,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "meet"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
 	skos:prefLabel "meet"@en .
 # 
 # http://www.opengis.net/ont/geosparql#ehOverlap
@@ -385,20 +298,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "overlap"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
 	skos:prefLabel "overlap"@en .
 # 
 # http://www.opengis.net/ont/geosparql#hasGeometry
@@ -409,17 +313,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      A spatial representation for a given feature.
-    """@en ;
-	rdfs:comment """
-      A spatial representation for a given feature.
-    """@en ;
+	dc:description """A spatial representation for a given feature."""@en ;
+	rdfs:comment """A spatial representation for a given feature. """@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "hasGeometry"@en ;
-	skos:definition """
-      A spatial representation for a given feature.
-    """@en ;
+	skos:definition """A spatial representation for a given feature."""@en ;
 	skos:prefLabel "hasGeometry"@en .
 # 
 # http://www.opengis.net/ont/geosparql#rcc8dc
@@ -430,20 +328,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FFTFFTTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FFTFFTTTT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FFTFFTTTT """@en ;
+	rdfs:comment """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FFTFFTTTT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "disconnected"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FFTFFTTTT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject is spatially disjoint  from the object SpatialObject. DE-9IM: FFTFFTTTT"""@en ;
 	skos:prefLabel "disconnected"@en .
 # 
 # http://www.opengis.net/ont/geosparql#rcc8ec
@@ -454,20 +343,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject. DE-9IM: FFTFTTTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject. DE-9IM: FFTFTTTTT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FFTFTTTTT"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FFTFTTTTT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "externally connected"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject. DE-9IM: FFTFTTTTT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FFTFTTTTT"""@en ;
 	skos:prefLabel "externally connected"@en .
 # 
 # http://www.opengis.net/ont/geosparql#rcc8eq
@@ -478,20 +358,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "equals"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
 	skos:prefLabel "equals"@en .
 # 
 # http://www.opengis.net/ont/geosparql#rcc8ntpp
@@ -502,20 +373,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFFTFFTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFFTFFTTT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFFTFFTTT"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFFTFFTTT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "non-tangential proper part"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFFTFFTTT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFFTFFTTT"""@en ;
 	skos:prefLabel "non-tangential proper part"@en .
 # 
 # http://www.opengis.net/ont/geosparql#rcc8ntppi
@@ -526,20 +388,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: TTTFFTFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: TTTFFTFFT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: TTTFFTFFT"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: TTTFFTFFT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "non-tangential proper part inverse"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: TTTFFTFFT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: TTTFFTFFT"""@en ;
 	skos:prefLabel "non-tangential proper part inverse"@en .
 # 
 # http://www.opengis.net/ont/geosparql#rcc8po
@@ -550,20 +403,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: TTTTTTTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: TTTTTTTTT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: TTTTTTTTT"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: TTTTTTTTT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "partially overlapping"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: TTTTTTTTT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: TTTTTTTTT"""@en ;
 	skos:prefLabel "partially overlapping"@en .
 # 
 # http://www.opengis.net/ont/geosparql#rcc8tpp
@@ -574,20 +418,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFFTTFTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFFTTFTTT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFFTTFTTT"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFFTTFTTT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "tangential proper part"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFFTTFTTT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFFTTFTTT"""@en ;
 	skos:prefLabel "tangential proper part"@en .
 # 
 # http://www.opengis.net/ont/geosparql#rcc8tppi
@@ -598,20 +433,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: TTTFTTFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: TTTFTTFFT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: TTTFTTFFT"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: TTTFTTFFT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "tangential proper part inverse"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: TTTFTTFFT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: TTTFTTFFT"""@en ;
 	skos:prefLabel "tangential proper part inverse"@en .
 # 
 # http://www.opengis.net/ont/geosparql#sfContains
@@ -622,20 +448,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*****FF*
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*****FF*
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*****FF*"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*****FF*"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "contains"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*****FF*
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*****FF*"""@en ;
 	skos:prefLabel "contains"@en .
 # 
 # http://www.opengis.net/ont/geosparql#sfCrosses
@@ -646,20 +463,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially crosses the
-      object SpatialObject. DE-9IM: T*T******
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially crosses the
-      object SpatialObject. DE-9IM: T*T******
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially crosses the object SpatialObject. DE-9IM: T*T******"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially crosses the object SpatialObject. DE-9IM: T*T******"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "crosses"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially crosses the
-      object SpatialObject. DE-9IM: T*T******
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially crosses the object SpatialObject. DE-9IM: T*T******"""@en ;
 	skos:prefLabel "crosses"@en .
 # 
 # http://www.opengis.net/ont/geosparql#sfDisjoint
@@ -670,20 +478,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
+	dc:description """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "disjoint"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
 	skos:prefLabel "disjoint"@en .
 # 
 # http://www.opengis.net/ont/geosparql#sfEquals
@@ -694,20 +493,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "equals"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
 	skos:prefLabel "equals"@en .
 # 
 # http://www.opengis.net/ont/geosparql#sfIntersects
@@ -718,23 +508,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is not spatially disjoint
-      from the object SpatialObject.
-      DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is not spatially disjoint
-      from the object SpatialObject.
-      DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
-    """@en ;
+	dc:description """Exists if the subject SpatialObject is not spatially disjoint from the object SpatialObject. DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject is not spatially disjoint from the object SpatialObject. DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "intersects"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is not spatially disjoint
-      from the object SpatialObject.
-      DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject is not spatially disjoint from the object SpatialObject. DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****"""@en ;
 	skos:prefLabel "intersects"@en .
 # 
 # http://www.opengis.net/ont/geosparql#sfOverlaps
@@ -745,20 +523,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "overlaps"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
 	skos:prefLabel "overlaps"@en .
 # 
 # http://www.opengis.net/ont/geosparql#sfTouches
@@ -769,23 +538,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially touches the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially touches the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
+	dc:description """Exists if the subject SpatialObject spatially touches the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject spatially touches the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "touches"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially touches the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject spatially touches the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
 	skos:prefLabel "touches"@en .
 # 
 # http://www.opengis.net/ont/geosparql#sfWithin
@@ -796,20 +553,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially within the
-      object SpatialObject. DE-9IM: T*F**F***
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially within the
-      object SpatialObject. DE-9IM: T*F**F***
-    """@en ;
+	dc:description """Exists if the subject SpatialObject is spatially within the object SpatialObject. DE-9IM: T*F**F***"""@en ;
+	rdfs:comment """Exists if the subject SpatialObject is spatially within the object SpatialObject. DE-9IM: T*F**F***"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "within"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially within the
-      object SpatialObject. DE-9IM: T*F**F***
-    """@en ;
+	skos:definition """Exists if the subject SpatialObject is spatially within the object SpatialObject. DE-9IM: T*F**F***"""@en ;
 	skos:prefLabel "within"@en .
 # 
 # 
@@ -830,17 +578,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The GML serialization of a geometry
-    """@en ;
-	rdfs:comment """
-      The GML serialization of a geometry
-    """@en ;
+	dc:description """The GML serialization of a geometry"""@en ;
+	rdfs:comment """The GML serialization of a geometry"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "asGML"@en ;
-	skos:definition """
-      The GML serialization of a geometry
-    """@en ;
+	skos:definition """The GML serialization of a geometry"""@en ;
 	skos:prefLabel "asGML"@en .
 # 
 # http://www.opengis.net/ont/geosparql#asWKT
@@ -852,17 +594,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The WKT serialization of a geometry
-    """@en ;
-	rdfs:comment """
-      The WKT serialization of a geometry
-    """@en ;
+	dc:description """The WKT serialization of a geometry"""@en ;
+	rdfs:comment """The WKT serialization of a geometry"""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "asWKT"@en ;
-	skos:definition """
-      The WKT serialization of a geometry
-    """@en ;
+	skos:definition """The WKT serialization of a geometry"""@en ;
 	skos:prefLabel "asWKT"@en .
 # 
 # http://www.opengis.net/ont/geosparql#coordinateDimension
@@ -873,20 +609,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The number of measurements or axes needed to describe the position of this
-      geometry in a coordinate system.
-    """@en ;
-	rdfs:comment """
-      The number of measurements or axes needed to describe the position of this
-      geometry in a coordinate system.
-    """@en ;
+	dc:description """The number of measurements or axes needed to describe the position of this geometry in a coordinate system."""@en ;
+	rdfs:comment """The number of measurements or axes needed to describe the position of this geometry in a coordinate system."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "coordinateDimension"@en ;
-	skos:definition """
-      The number of measurements or axes needed to describe the position of this
-      geometry in a coordinate system.
-    """@en ;
+	skos:definition """The number of measurements or axes needed to describe the position of this geometry in a coordinate system."""@en ;
 	skos:prefLabel "coordinateDimension"@en .
 # 
 # http://www.opengis.net/ont/geosparql#dimension
@@ -897,26 +624,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The topological dimension of this geometric object, which
-      must be less than or equal to the coordinate dimension.
-      In non-homogeneous collections, this will return the largest
-      topological dimension of the contained objects.
-    """@en ;
-	rdfs:comment """
-      The topological dimension of this geometric object, which
-      must be less than or equal to the coordinate dimension.
-      In non-homogeneous collections, this will return the largest
-      topological dimension of the contained objects.
-    """@en ;
+	dc:description """The topological dimension of this geometric object, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this will return the largest topological dimension of the contained objects."""@en ;
+	rdfs:comment """The topological dimension of this geometric object, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this will return the largest topological dimension of the contained objects."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "dimension"@en ;
-	skos:definition """
-      The topological dimension of this geometric object, which
-      must be less than or equal to the coordinate dimension.
-      In non-homogeneous collections, this will return the largest
-      topological dimension of the contained objects.
-    """@en ;
+	skos:definition """The topological dimension of this geometric object, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this will return the largest topological dimension of the contained objects."""@en ;
 	skos:prefLabel "dimension"@en .
 # 
 # http://www.opengis.net/ont/geosparql#hasSerialization
@@ -927,17 +639,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Connects a geometry object with its text-based serialization.
-    """@en ;
-	rdfs:comment """
-      Connects a geometry object with its text-based serialization.
-    """@en ;
+	dc:description """Connects a geometry object with its text-based serialization."""@en ;
+	rdfs:comment """Connects a geometry object with its text-based serialization."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "has serialization"@en ;
-	skos:definition """
-      Connects a geometry object with its text-based serialization.
-    """@en ;
+	skos:definition """Connects a geometry object with its text-based serialization."""@en ;
 	skos:prefLabel "has serialization"@en .
 # 
 # http://www.opengis.net/ont/geosparql#isEmpty
@@ -948,23 +654,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      (true) if this geometric object is the empty Geometry. If
-      true, then this geometric object represents the empty point
-      set for the coordinate space.
-    """@en ;
-	rdfs:comment """
-      (true) if this geometric object is the empty Geometry. If
-      true, then this geometric object represents the empty point
-      set for the coordinate space.
-    """@en ;
+	dc:description """(true) if this geometric object is the empty Geometry. If true, then this geometric object represents the empty point set for the coordinate space."""@en ;
+	rdfs:comment """(true) if this geometric object is the empty Geometry. If true, then this geometric object represents the empty point set for the coordinate space."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "isEmpty"@en ;
-	skos:definition """
-      (true) if this geometric object is the empty Geometry. If
-      true, then this geometric object represents the empty point
-      set for the coordinate space.
-    """@en ;
+	skos:definition """(true) if this geometric object is the empty Geometry. If true, then this geometric object represents the empty point set for the coordinate space."""@en ;
 	skos:prefLabel "isEmpty"@en .
 # 
 # http://www.opengis.net/ont/geosparql#isSimple
@@ -975,20 +669,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      (true) if this geometric object has no anomalous geometric
-      points, such as self intersection or self tangency.
-    """@en ;
-	rdfs:comment """
-      (true) if this geometric object has no anomalous geometric
-      points, such as self intersection or self tangency.
-    """@en ;
+	dc:description """(true) if this geometric object has no anomalous geometric points, such as self intersection or self tangency."""@en ;
+	rdfs:comment """(true) if this geometric object has no anomalous geometric points, such as self intersection or self tangency."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "isSimple"@en ;
-	skos:definition """
-      (true) if this geometric object has no anomalous geometric
-      points, such as self intersection or self tangency.
-    """@en ;
+	skos:definition """(true) if this geometric object has no anomalous geometric points, such as self intersection or self tangency."""@en ;
 	skos:prefLabel "isSimple"@en .
 # 
 # http://www.opengis.net/ont/geosparql#spatialDimension
@@ -999,20 +684,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The number of measurements or axes needed to describe the spatial position of
-      this geometry in a coordinate system.
-    """@en ;
-	rdfs:comment """
-      The number of measurements or axes needed to describe the spatial position of
-      this geometry in a coordinate system.
-    """@en ;
+	dc:description """The number of measurements or axes needed to describe the spatial position of this geometry in a coordinate system."""@en ;
+	rdfs:comment """The number of measurements or axes needed to describe the spatial position of this geometry in a coordinate system."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "spatialDimension"@en ;
-	skos:definition """
-      The number of measurements or axes needed to describe the spatial position of
-      this geometry in a coordinate system.
-    """@en ;
+	skos:definition """The number of measurements or axes needed to describe the spatial position of this geometry in a coordinate system."""@en ;
 	skos:prefLabel "spatialDimension"@en .
 # 
 # 
@@ -1032,23 +708,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      This class represents the top-level feature type. This class is
-      equivalent to GFI_Feature defined in ISO 19156:2011, and it is
-      superclass of all feature types.
-    """@en ;
-	rdfs:comment """
-      This class represents the top-level feature type. This class is
-      equivalent to GFI_Feature defined in ISO 19156:2011, and it is
-      superclass of all feature types.
-    """@en ;
+	dc:description """This class represents the top-level feature type. This class is equivalent to GFI_Feature defined in ISO 19156:2011, and it is superclass of all feature types."""@en ;
+	rdfs:comment """This class represents the top-level feature type. This class is equivalent to GFI_Feature defined in ISO 19156:2011, and it is superclass of all feature types."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "Feature"@en ;
-	skos:definition """
-      This class represents the top-level feature type. This class is
-      equivalent to GFI_Feature defined in ISO 19156:2011, and it is
-      superclass of all feature types.
-    """@en ;
+	skos:definition """This class represents the top-level feature type. This class is equivalent to GFI_Feature defined in ISO 19156:2011, and it is superclass of all feature types."""@en ;
 	skos:prefLabel "Feature"@en .
 # 
 # http://www.opengis.net/ont/geosparql#Geometry
@@ -1058,23 +722,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The class represents the top-level geometry type. This class is
-      equivalent to the UML class GM_Object defined in ISO 19107, and
-      it is superclass of all geometry types.
-    """@en ;
-	rdfs:comment """
-      The class represents the top-level geometry type. This class is
-      equivalent to the UML class GM_Object defined in ISO 19107, and
-      it is superclass of all geometry types.
-    """@en ;
+	dc:description """The class represents the top-level geometry type. This class is equivalent to the UML class GM_Object defined in ISO 19107, and it is superclass of all geometry types."""@en ;
+	rdfs:comment """The class represents the top-level geometry type. This class is equivalent to the UML class GM_Object defined in ISO 19107, and it is superclass of all geometry types."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "Geometry"@en ;
-	skos:definition """
-      The class represents the top-level geometry type. This class is
-      equivalent to the UML class GM_Object defined in ISO 19107, and
-      it is superclass of all geometry types.
-    """@en ;
+	skos:definition """The class represents the top-level geometry type. This class is equivalent to the UML class GM_Object defined in ISO 19107, and it is superclass of all geometry types."""@en ;
 	skos:prefLabel "Geometry"@en .
 # 
 # http://www.opengis.net/ont/geosparql#SpatialObject
@@ -1083,20 +735,11 @@ xsd:date a rdfs:Datatype .
 	dc:contributor "Matthew Perry" ;
 	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
 	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The class spatial-object represents everything that can have
-      a spatial representation. It is superclass of feature and geometry.
-    """@en ;
-	rdfs:comment """
-      The class spatial-object represents everything that can have
-      a spatial representation. It is superclass of feature and geometry.
-    """@en ;
+	dc:description """The class spatial-object represents everything that can have a spatial representation. It is superclass of feature and geometry."""@en ;
+	rdfs:comment """The class spatial-object represents everything that can have a spatial representation. It is superclass of feature and geometry."""@en ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
 	rdfs:label "SpatialObject"@en ;
-	skos:definition """
-      The class spatial-object represents everything that can have
-      a spatial representation. It is superclass of feature and geometry.
-    """@en ;
+	skos:definition """The class spatial-object represents everything that can have a spatial representation. It is superclass of feature and geometry."""@en ;
 	skos:prefLabel "SpatialObject"@en .
 # 
 # 


### PR DESCRIPTION
Remove unnecessary/unwanted spaces and newlines in annotation text (see [issue 50](https://github.com/opengeospatial/ogc-geosparql/issues/50)).