### PR TITLE
KML Literal definition

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -61,39 +61,27 @@
 	dc:contributor "Timo Homburg" ;
 	dc:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
 	dc:date "2020-10-30"^^xsd:date ;
-	dc:description """
-      A GeoJSON serialization of a geometry object.
-    """@en ;
-	rdfs:comment """
-      A GeoJSON serialization of a geometry object.
-    """@en ;
+	dc:description """A GeoJSON serialization of a geometry object."""@en ;
+	rdfs:comment """A GeoJSON serialization of a geometry object."""@en ;
 	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.1> ;
 	rdfs:label "GeoJSON Literal"@en ;
-	skos:definition """
-      A GeoJSON serialization of a geometry object.
-    """@en ;
+	skos:definition """A GeoJSON serialization of a geometry object."""@en ;
 	skos:prefLabel "GeoJSON Literal"@en .
 	
 # 
-# http://www.opengis.net/ont/geosparql#geoJSONLiteral
+# http://www.opengis.net/ont/geosparql#kmlLiteral
 
 :kmlLiteral a rdfs:Datatype ;
 	dc:contributor "Timo Homburg" ;
 	dc:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
 	dc:date "2021-01-04"^^xsd:date ;
-	dc:description """
-      A KML serialization of a geometry object.
-    """@en ;
-	rdfs:comment """
-      A KML serialization of a geometry object.
-    """@en ;
+	dc:description """A KML serialization of a geometry object."""@en ;
+	rdfs:comment """A KML serialization of a geometry object."""@en ;
 	rdfs:seeAlso <https://www.ogc.org/standards/kml/> ;
 	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.1> ;
 	rdfs:label "KML Literal"@en ;
-	skos:definition """
-      A KML serialization of a geometry object.
-    """@en ;
+	skos:definition """A KML serialization of a geometry object."""@en ;
 	skos:prefLabel "KML Literal"@en .
 	
 # 

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -55,7 +55,7 @@
 	skos:prefLabel "Well-known Text Literal"@en .
 	
 # 
-# http://www.opengis.net/ont/geosparql#wktLiteral
+# http://www.opengis.net/ont/geosparql#geoJSONLiteral
 
 :geoJSONLiteral a rdfs:Datatype ;
 	dc:contributor "Timo Homburg" ;
@@ -74,6 +74,27 @@
       A GeoJSON serialization of a geometry object.
     """@en ;
 	skos:prefLabel "GeoJSON Literal"@en .
+	
+# 
+# http://www.opengis.net/ont/geosparql#geoJSONLiteral
+
+:kmlLiteral a rdfs:Datatype ;
+	dc:contributor "Timo Homburg" ;
+	dc:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
+	dc:date "2021-01-04"^^xsd:date ;
+	dc:description """
+      A KML serialization of a geometry object.
+    """@en ;
+	rdfs:comment """
+      A KML serialization of a geometry object.
+    """@en ;
+	rdfs:seeAlso <https://www.ogc.org/standards/kml/> ;
+	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.1> ;
+	rdfs:label "KML Literal"@en ;
+	skos:definition """
+      A KML serialization of a geometry object.
+    """@en ;
+	skos:prefLabel "KML Literal"@en .
 	
 # 
 # http://www.w3.org/2001/XMLSchema#date
@@ -528,7 +549,7 @@ xsd:date a rdfs:Datatype .
 	rdfs:subPropertyOf :hasSerialization;
 	rdfs:domain :Geometry ;
 	rdfs:range :geoJSONLiteral ;
-	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> .
+	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> ;
 	dc:contributor "Timo Homburg" ;
 	dc:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
 	dc:date "2020-10-30"^^xsd:date ;
@@ -544,6 +565,30 @@ xsd:date a rdfs:Datatype .
       The GeoJSON serialization of a geometry
     """@en ;
 	skos:prefLabel "asGeoJSON"@en .	
+	
+# 
+# http://www.opengis.net/ont/geosparql#asKML
+
+:asKML a owl:DatatypeProperty ;
+	rdfs:subPropertyOf :hasSerialization;
+	rdfs:domain :Geometry ;
+	rdfs:range :kmlLiteral ;
+	rdfs:seeAlso <https://www.ogc.org/standards/kml> ;
+	dc:contributor "Timo Homburg" ;
+	dc:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
+	dc:date "2021-01-04"^^xsd:date ;
+	dc:description """
+      The KML serialization of a geometry
+    """@en ;
+	rdfs:comment """
+      The KML serialization of a geometry
+    """@en ;
+	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.1> ;
+	rdfs:label "asKML"@en ;
+	skos:definition """
+      The KML serialization of a geometry
+    """@en ;
+	skos:prefLabel "asKML"@en .	
 
 # 
 # http://www.opengis.net/ont/geosparql#coordinateDimension

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -429,7 +429,7 @@ This section establishes the requirements for representing geometry data in RDF 
 
 ===== RDFS Datatypes
 
-This section defines one RDFS Datatype: `+http://www.opengis.net/ont/geosparql#geoJSONLiteral+`.
+This section defines one RDFS Datatype: `+http://www.opengis.net/ont/geosparql#kmlLiteral+`.
 
 *RDFS Datatype: geo:kmlLiteral*
 

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -477,7 +477,7 @@ The `geo:asKML` property is defined to link a geometry with its KML serializatio
 The property `geo:asKML` is used to link a geometric element with its KML serialization.
 
 ```
-geo:asGeoJSON a rdf:Property,
+geo:asKML a rdf:Property,
             owl:DatatypeProperty;
     rdfs:subPropertyOf geo:hasSerialization;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -380,7 +380,7 @@ Valid `geo:geoJSONLiteral`s are formed by encoding geometry information as a Geo
 
 |===
 |*Req XX* All `geo:geoJSONLiteral`s shall consist of the Geometry objects as defined in the GeoJSON specification [RFC 7946].
-|`/req/geometry-extension/geoJSON-literal1`
+|`/req/geometry-extension/geoJSON-literal`
 |===
 
 |===
@@ -444,7 +444,7 @@ Valid `geo:kmlLiteral`s are formed by encoding geometry information as a Geometr
 
 |===
 |*Req XX* All `geo:kmlLiteral`s shall consist of the Geometry objects as defined in the KML specification [https://www.ogc.org/standards/kml/].
-|`/req/geometry-extension/kml-literal1`
+|`/req/geometry-extension/kml-literal`
 |===
 
 |===

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -423,6 +423,71 @@ geo:asGeoJSON a rdf:Property,
     rdfs:range geo:geoJSONLiteral .
 ```
 
+==== Requirements for KML Serialization (serialization=KML)
+
+This section establishes the requirements for representing geometry data in RDF based on KML.
+
+===== RDFS Datatypes
+
+This section defines one RDFS Datatype: `+http://www.opengis.net/ont/geosparql#geoJSONLiteral+`.
+
+*RDFS Datatype: geo:kmlLiteral*
+
+```
+geo:kmlLiteral a rdfs:Datatype;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;
+    rdfs:label "KML Literal"@en;
+    rdfs:comment "A KML serialization of a geometry object."@en .
+```
+
+Valid `geo:kmlLiteral`s are formed by encoding geometry information as a Geometry object as defined in the KML specification [https://www.ogc.org/standards/kml/].
+
+|===
+|*Req XX* All `geo:kmlLiteral`s shall consist of the Geometry objects as defined in the KML specification [https://www.ogc.org/standards/kml/].
+|`/req/geometry-extension/kml-literal1`
+|===
+
+|===
+|*Req XX* All RDFS Literals of type `geo:kmlLiteral` do not contain a CRS definition. All literals of this type shall according to the KML specification only be encoded in and assumed to use the WGS84 geodetic longitude-latitude spatial reference system (urn:ogc:def:crs:OGC::CRS84).
+|`/req/geometry-extension/kml-literal-crs`
+|===
+
+The example `geo:kmlLiteral` below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:
+
+```
+"<Point xmlns=\"http://www.opengis.net/kml/2.2\"><coordinates>-83.38,33.95</coordinates></Point>"^^<http://www.opengis.net/ont/geosparql#kmlLiteral>
+```
+
+|===
+|*Req XX* An empty RDFS Literal of type `geo:kmlLiteral` shall be interpreted as an empty geometry .
+|`/req/geometry-extension/kml-literal-empty`
+|===
+
+===== Serialization Properties
+
+The `geo:asKML` property is defined to link a geometry with its KML serialization.
+
+*Property: geo:asKML*
+
+|===
+|*Req XX* Implementations shall allow the RDF property `geo:asKML` to be used in SPARQL graph patterns.
+|`/req/geometry-extension/geometry-as-kml-literal`
+|===
+
+The property `geo:asKML` is used to link a geometric element with its KML serialization.
+
+```
+geo:asGeoJSON a rdf:Property,
+            owl:DatatypeProperty;
+    rdfs:subPropertyOf geo:hasSerialization;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;
+    rdfs:label "as KML"@en;
+    rdfs:comment "The KML serialization of a geometry."@en;
+    rdfs:domain geo:Geometry;
+    rdfs:range geo:kmlLiteral .
+```
+
+
 ==== Non-topological Query Functions
 
 This clause defines SPARQL functions for performing non-topological spatial operations.


### PR DESCRIPTION
This definition if approved closes issue #69 

KML like GeoJSON requires a WGS84 coordinate reference system for every geometry to be defined.

KML, as opposed to other literals, does not define an empty geometry.
It requires at least one coordinate to be present in the coordinate tag of every geometry according to the KML specification. 

However, we may define an empty KML geometry as the empty literal (as proposed in my draft of the specification). 

Apart from that, I see no issues in including KML literals into GeoSPARQL.



