### PR TITLE
DGGS WKT literval v2

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -84,6 +84,14 @@ geosparql:
 	skos:prefLabel "KML Literal"@en ;
 .
 
+:dggsWktLiteral
+	a rdfs:Datatype ;
+	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
+	skos:definition """A textual serialization of a Discrete Global Grid (DGGS) geometry object."""@en ;
+	skos:example """ "<https://w3id.org/dggs/auspix> OrdinateList (R3234)"^^<http://www.opengis.net/ont/geosparql#dggsWktLiteral>""" ;
+	skos:prefLabel "DGGS Well-Known Text Literal"@en ;
+.
+
 # #################################################################
 # #
 # #    Object Properties
@@ -410,6 +418,16 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """The KML serialization of a geometry"""@en ;
 	skos:prefLabel "as KML"@en ;
+.	
+
+:asDggsWkt
+	a owl:DatatypeProperty ;
+	rdfs:subPropertyOf :hasSerialization;
+	rdfs:domain :Geometry ;
+	rdfs:range :dggsWktLiteral ;
+	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
+	skos:definition """The Discrete Global Grid System (DGGS) serialization of a geometry"""@en ;	
+	skos:prefLabel "as DGGS"@en ;
 .	
 
 :coordinateDimension

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -563,6 +563,70 @@ geo:asKML a rdf:Property,
     rdfs:range geo:kmlLiteral .
 ```
 
+==== Requirements for DGGS Serialization (serialization=DGGS)
+
+This section establishes the requirements for representing geometry data in RDF as represented in a Discrete Global Grid System (DGGS), in text. The form of representation is known as a _DGGS Well-Known Text_ geometry representation.
+
+===== RDFS Datatypes
+
+This section defines one RDFS Datatype: `+http://www.opengis.net/ont/geosparql#dggsWktLiteral+`.
+
+*RDFS Datatype: geo:dggsWktLiteral*
+
+```
+geo:dggsWktLiteral a rdfs:Datatype;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;
+    rdfs:label "DGGS Well-Known Text Literal"@en;
+    rdfs:comment "A textual serialization of a Discrete Global Grid (DGGS) geometry object."@en .
+```
+
+Valid `geo:dggsWktLiteral` instances are formed by encoding geometry information as text and as required by a particular DGGS and in accordance with the _Discrete Global Grid System Abstract Specification_ [[21]]. An indication of the particular DGGS, as well as the geometric information must also be indicated in the literal as per the following _ABNF_ [22] syntax specification:
+
+```
+dggsWktLiteral ::= "<" IRI ">" SP geometric-data
+```
+
+The token `IRI` (Internationalized Resource Identifiers) is essentially a web address and is defined in [23] and the token `SP` (a single white space character is defined in [22]. `geometric-data` is potentially specific to the DGGS and is not specified here.
+
+|===
+|*Req XX* All `geo:dggsWktLiteral` instances shall consist of a DGGS identifier, an IRI, and a DGGS geometry serialization formulated according to the identifierd DGGS.
+|`/req/geometry-extension/dggs-literal`
+|===
+
+The example `geo:dggsWktLiteral` below encodes a point geometry according to the _AusPIX_ DGGS [24]. The DGGS geometry type is indicated with the token `OrdinateList` and the point, enclosed in parenthesis, is identified with the AusPIX-specific 'Cell ID' of _R3234_.:
+
+```
+"<https://w3id.org/dggs/auspix> OrdinateList (R3234)"^^<http://www.opengis.net/ont/geosparql#dggsWktLiteral>
+```
+
+|===
+|*Req XX* An empty RDFS Literal of type `geo:dggsWktLiteral` shall be interpreted as an empty geometry.
+|`/req/geometry-extension/dggs-literal-empty`
+|===
+
+===== Serialization Properties
+
+The `geo:asDggsWkt` property is defined to link a geometry with its DGGS WKT serialization.
+
+*Property: geo:asDggsWkt*
+
+|===
+|*Req XX* Implementations shall allow the RDF property `geo:asDggsWkt` to be used in SPARQL graph patterns.
+|`/req/geometry-extension/geometry-as-dggswkt-literal`
+|===
+
+The property `geo:asDggsWkt` is used to link a Geometry instance with its serialization.
+
+```
+geo:asDggsWkt a rdf:Property,
+              owl:DatatypeProperty;
+    rdfs:subPropertyOf geo:hasSerialization;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1>;
+    rdfs:label "as DGGS WKT"@en;
+    rdfs:comment "The DGGS Well-Known Text serialization of a geometry."@en;
+    rdfs:domain geo:Geometry;
+    rdfs:range geo:dggsWktLiteral .
+```
 
 ==== Non-topological Query Functions
 

--- a/1.1/spec/18-Bibliography.adoc
+++ b/1.1/spec/18-Bibliography.adoc
@@ -62,3 +62,11 @@ Recommendation (27 October 2009)
 [[XSD2]]
 [20] W3C XML Schema Part 2, _XML Schema Part 2: Datatypes (Second Edition)_, W3C Recommendation (28 October 2004)
 
+[[DGGSAS]]
+[21] Open Geospatial Consortium, _Abstract Standard Topic 21 - Discrete Global Grid Systems - Part 1 Core Reference system and Operations and Equal Area Earth Reference System_, Open Geospatial Consortium Standard (2021). <http://www.opengis.net/doc/AS/dggs/2.0>
+
+[[IETF5234]]
+[22] Internet Engineering Task Force, _RFC 5234: Internet Standard 68: Augmented BNF for Syntax Specifications: ABNF_. IETF Request for Comment, 2008. <https://tools.ietf.org/html/std68>
+
+[[IETF]]
+[23] Internet Engineering Task Force, _RFC 3987: Internationalized Resource Identifiers (IRIs)_. IETF Request for Comment, January 2005. <https://tools.ietf.org/html/rfc3987>


### PR DESCRIPTION
This is an updated re-issuing of PR #52.

I have not defined the literal content other than the DGGS identifier (an IRI) as the content should be left to DGGS specs.

I have included an example of a simple DGGS literal for AusPIX.

Closes #2 