### PR TITLE
Add example anchors and links

### DIFF
--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -754,7 +754,7 @@ funcs:sfWithin a skos:Concept ;
 
 DE-9IM: T*F**F***"""@en ;
     skos:prefLabel "within"@en ;
-    skos:example geosparql-doc:annexB_example1 .
+    skos:example geosparql-doc:annexB_example2 .
 
 funcs:symDifference a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;

--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -7,7 +7,7 @@ PREFIX rules: <http://www.opengis.net/def/rule/geosparql/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX status: <http://www.opengis.net/def/status/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-
+PREFIX geosparql-doc: <http://www.opengis.net/spec/geosparql/1.1/specification.html#> #To be changed once the definitive IRI of the HTML documentation is known.
 
 <http://www.opengis.net/def/geosparql/funcsrules> 
     a owl:Ontology , skos:ConceptScheme ;
@@ -330,7 +330,8 @@ funcs:distance a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query function that returns the distance between the two closest points of the input geometries."@en ;
-    skos:prefLabel "distance"@en .
+    skos:prefLabel "distance"@en ;
+    skos:example geosparql-doc:annexB_example4 .
 
 funcs:ehContains a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
@@ -661,7 +662,8 @@ funcs:sfContains a skos:Concept ;
     skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument.
 
 DE-9IM: T*****FF*"""@en ;
-    skos:prefLabel "contains"@en .
+    skos:prefLabel "contains"@en ;
+    skos:example geosparql-doc:annexB_example1 .
 
 funcs:sfCrosses a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
@@ -737,7 +739,8 @@ funcs:sfTouches a skos:Concept ;
     skos:definition """A query function that returns true if the input geometries touch.
 
 DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
-    skos:prefLabel "touches"@en .
+    skos:prefLabel "touches"@en ;
+    skos:example geosparql-doc:annexB_example3 .
 
 funcs:sfWithin a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
@@ -750,7 +753,8 @@ funcs:sfWithin a skos:Concept ;
     skos:definition """A query function that returns true if the first geometry argument is spatially within the second geometry argument. 
 
 DE-9IM: T*F**F***"""@en ;
-    skos:prefLabel "within"@en .
+    skos:prefLabel "within"@en ;
+    skos:example geosparql-doc:annexB_example1 .
 
 funcs:symDifference a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
@@ -772,7 +776,8 @@ funcs:union a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query function that returns a geometry consisting of all points that are part of at least one input geometry."@en ;
-    skos:prefLabel "union"@en .
+    skos:prefLabel "union"@en ;
+    skos:example geosparql-doc:annexB_example3 .
 
 rules:ehContains a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
@@ -1014,7 +1019,8 @@ rules:sfOverlaps a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects overlap based on their associated primary geometry objects."@en ;
-    skos:prefLabel "overlaps"@en .
+    skos:prefLabel "overlaps"@en ;
+    skos:example geosparql-doc:annexB_example5 .
 
 rules:sfTouches a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -197,7 +197,7 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """A spatial representation for a given feature."""@en ;
 	skos:prefLabel "hasGeometry"@en ;
-	skos:example geosparql-doc:annexB_example1 ;
+	skos:example geosparql-doc:annexB_example1 ,  geosparql-doc:annexB_example2 , geosparql-doc:annexB_example3 , geosparql-doc:annexB_example4 ;
 .
 
 :hasBoundingBox

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -2,6 +2,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix geosparql: <http://www.opengis.net/ont/geosparql> .
 @prefix geosparql-spec: <http://www.opengis.net/spec/geosparql/1.1> .
+@prefix geosparql-doc: <http://www.opengis.net/spec/geosparql/1.1/specification.html#> . #To be changed once the definitive IRI of the HTML documentation is known.
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -74,6 +75,7 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """A Well-known Text serialization of a geometry object."""@en ;
 	skos:prefLabel "Well-known Text Literal"@en ;
+	skos:example geosparql-doc:annexB_example2 ;
 .
 
 :geoJSONLiteral
@@ -195,6 +197,7 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """A spatial representation for a given feature."""@en ;
 	skos:prefLabel "hasGeometry"@en ;
+	skos:example geosparql-doc:annexB_example1 ;
 .
 
 :hasBoundingBox
@@ -426,6 +429,7 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """The WKT serialization of a geometry"""@en ;
 	skos:prefLabel "as WKT"@en ;
+	skos:example geosparql-doc:annexB_example1 , geosparql-doc:annexB_example2 , geosparql-doc:annexB_example3 , geosparql-doc:annexB_example4 , geosparql-doc:annexB_example5 ;
 .
 
 :asGeoJSON
@@ -528,6 +532,7 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """This class represents the top-level feature type. This class is equivalent to GFI_Feature defined in ISO 19156:2011, and it is superclass of all feature types."""@en ;
 	skos:prefLabel "Feature"@en ;
+	skos:example geosparql-doc:annexB_example1 , geosparql-doc:annexB_example2 , geosparql-doc:annexB_example3 , geosparql-doc:annexB_example4 , geosparql-doc:annexB_example5 ;
 .
 
 :Geometry
@@ -536,10 +541,12 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """The class represents the top-level geometry type. This class is equivalent to the UML class GM_Object defined in ISO 19107, and it is superclass of all geometry types."""@en ;
 	skos:prefLabel "Geometry"@en ;
+	skos:example geosparql-doc:annexB_example1 , geosparql-doc:annexB_example2 , geosparql-doc:annexB_example3 , geosparql-doc:annexB_example4 , geosparql-doc:annexB_example5 ;
 .
 
-:SpatialMeasure a owl:Class ;
-  rdfs:isDefinedBy geosparql: , geosparql-spec: ;
+:SpatialMeasure
+	a owl:Class ;
+  	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """This class represents a measurement of some dimension of a feature's spatial presence."""@en ;
 	skos:prefLabel "Spatial Measure"@en ;
 .

--- a/1.1/spec/17-Annex-B.adoc
+++ b/1.1/spec/17-Annex-B.adoc
@@ -98,6 +98,7 @@ my:FExactGeom a sf:Point ;
 
 This Section illustrates the use of GeoSPARQL functions through a series of example queries.
 
+[[exampleB1]]
 *Example 1*: _Find all features that feature `my:A` contains, where spatial calculations are based on_ `my:hasExactGeometry`.
 
 ```sparql
@@ -124,6 +125,7 @@ WHERE {
 |`my:F`
 |===
 
+[[exampleB2]]
 *Example 2*: _Find all features that are within a transient bounding box geometry, where spatial calculations are based on_ `my:hasPointGeometry`.
 
 ```sparql
@@ -149,6 +151,7 @@ WHERE { ?f my:hasPointGeometry ?fGeom .
 |`my:D`
 |===
 
+[[exampleB3]]
 *Example 3*: _Find all features that touch the union of feature `my:A` and feature `my:D`,
 where computations are based on_ `my:hasExactGeometry`.
 
@@ -176,6 +179,7 @@ WHERE { ?f my:hasExactGeometry ?fGeom .
 |`my:C`
 |===
 
+[[exampleB4]]
 *Example 4*: _Find the 3 closest features to feature my:C, where computations are based on_ `my:hasExactGeometry`.
 
 ```sparql
@@ -207,6 +211,7 @@ LIMIT 3
 
 This section illustrates the query transformation strategy for implementing GeoSPARQL rules.
 
+[[exampleB5]]
 *Example 5*: _Find all features or geometries that overlap feature_ `my:A`.
 
 *Original Query*:

--- a/1.1/spec/17-Annex-B.adoc
+++ b/1.1/spec/17-Annex-B.adoc
@@ -98,7 +98,7 @@ my:FExactGeom a sf:Point ;
 
 This Section illustrates the use of GeoSPARQL functions through a series of example queries.
 
-[[exampleB1]]
+[[annexB_example1]]
 *Example 1*: _Find all features that feature `my:A` contains, where spatial calculations are based on_ `my:hasExactGeometry`.
 
 ```sparql
@@ -125,7 +125,7 @@ WHERE {
 |`my:F`
 |===
 
-[[exampleB2]]
+[[annexB_example2]]
 *Example 2*: _Find all features that are within a transient bounding box geometry, where spatial calculations are based on_ `my:hasPointGeometry`.
 
 ```sparql
@@ -151,7 +151,7 @@ WHERE { ?f my:hasPointGeometry ?fGeom .
 |`my:D`
 |===
 
-[[exampleB3]]
+[[annexB_example3]]
 *Example 3*: _Find all features that touch the union of feature `my:A` and feature `my:D`,
 where computations are based on_ `my:hasExactGeometry`.
 
@@ -179,7 +179,7 @@ WHERE { ?f my:hasExactGeometry ?fGeom .
 |`my:C`
 |===
 
-[[exampleB4]]
+[[annexB_example4]]
 *Example 4*: _Find the 3 closest features to feature my:C, where computations are based on_ `my:hasExactGeometry`.
 
 ```sparql
@@ -211,7 +211,7 @@ LIMIT 3
 
 This section illustrates the query transformation strategy for implementing GeoSPARQL rules.
 
-[[exampleB5]]
+[[annexB_example5]]
 *Example 5*: _Find all features or geometries that overlap feature_ `my:A`.
 
 *Original Query*:


### PR DESCRIPTION
This PR adds ID attributes to examples in the documentation. These ID's can be used in the ontology to form skos:example links. 