### PR TITLE
Add property :hasDefaultGeometry to geo.ttl

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -197,6 +197,16 @@ geosparql:
 	skos:prefLabel "hasGeometry"@en ;
 .
 
+:hasDefaultGeometry 
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf geo:hasGeometry ;
+	rdfs:domain geo:Feature ;
+	rdfs:range geo:Geometry ;
+	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
+	skos:definition """The default geometry to be used in spatial calculations, usually the most detailed geometry."""@en ;
+	skos:prefLabel "has Default Geometry"@en ;
+.
+
 :hasBoundingBox
 	a owl:ObjectProperty ;
 	rdfs:subPropertyOf :hasGeometry ;

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -194,7 +194,7 @@ geosparql:
 	rdfs:range :Geometry ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """A spatial representation for a given feature."""@en ;
-	skos:prefLabel "hasGeometry"@en ;
+	skos:prefLabel "has geometry"@en ;
 .
 
 :hasDefaultGeometry 
@@ -204,7 +204,7 @@ geosparql:
 	rdfs:range geo:Geometry ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """The default geometry to be used in spatial calculations, usually the most detailed geometry."""@en ;
-	skos:prefLabel "has Default Geometry"@en ;
+	skos:prefLabel "has default geometry"@en ;
 .
 
 :hasBoundingBox


### PR DESCRIPTION
Add property :hasDefaultGeometry to geo.ttl in version 1.1.  It is still absent in version 1.0 (assuming it won't be published again).
Fixes #123 