### PR TITLE
Citation of the working document

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ To see in-progress HTML & PDF versions of the GeoSPARQL 1.1 standard - specifica
 
 * [GeoSPARQL auto-built documentation](https://opengeospatial.github.io/ogc-geosparql/)
 
+If you want to cite the living document of the in-progress standard we encourage you to use the following BibTeX statement:
+
+@article{ogcgeosparql11,
+  title={OGC GeoSPARQL - A geographic query language for RDF data: GeoSPARQL 1.1 draft},
+  author={Perry, Matthew and Herring, John and Car, Nicholas J. and Homburg, Timo and J.D. Cox, Simon},
+  journal={OGC implementation standard draft}
+}
+
 ## Updates of GeoSPARQL
 
 ### Rationale

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ To see in-progress HTML & PDF versions of the GeoSPARQL 1.1 standard - specifica
 
 If you want to cite the living document of the in-progress standard we encourage you to use the following BibTeX statement:
 
+``
 @article{ogcgeosparql11,
   title={OGC GeoSPARQL - A geographic query language for RDF data: GeoSPARQL 1.1 draft},
   author={Perry, Matthew and Herring, John and Car, Nicholas J. and Homburg, Timo and J.D. Cox, Simon},
-  journal={OGC implementation standard draft}
+  journal={OGC implementation standard draft},
+  url={https://opengeospatial.github.io/ogc-geosparql/}
 }
+``
 
 ## Updates of GeoSPARQL
 


### PR DESCRIPTION
It appears there is a need for people to already cite the working documents we produce in the continuous integration process, as shown by issue #130 
I think we should give people guidance and define how we want to be cited, by providing a BibTeX definition.
As I am not sure how to best define it I copied a common one from Google Scholar and updated it.
We can modify it until we are satisfied and add it to the Readme.