### PR TITLE
Update geo.ttl

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -67,6 +67,7 @@ geosparql:
 	a rdfs:Datatype ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """A GML serialization of a geometry object."""@en ;
+	rdfs:seeAlso <https://portal.ogc.org/files/?artifact_id=20509> ; # Can the URI be replaced with one that is guaranteed to be persistent?
 	skos:prefLabel "GML Literal"@en ;
 .
 
@@ -74,6 +75,7 @@ geosparql:
 	a rdfs:Datatype ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """A Well-known Text serialization of a geometry object."""@en ;
+	rdfs:seeAlso <https://portal.ogc.org/files/?artifact_id=25355> ; # Can the URI be replaced with one that is guaranteed to be persistent?
 	skos:prefLabel "Well-known Text Literal"@en ;
 	skos:example geosparql-doc:annexB_example2 ;
 .
@@ -99,6 +101,7 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """A textual serialization of a Discrete Global Grid (DGGS) geometry object."""@en ;
 	skos:example """ "<https://w3id.org/dggs/auspix> OrdinateList (R3234)"^^<http://www.opengis.net/ont/geosparql#dggsWktLiteral>""" ;
+	rdfs:seeAlso <http://www.opengis.net/doc/AS/dggs/2.0> ;
 	skos:prefLabel "DGGS Well-Known Text Literal"@en ;
 .
 
@@ -124,6 +127,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*TFF*FF*"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "contains"@en ;
 .
 
@@ -133,6 +137,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFF*TFT**"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "covered by"@en ;
 .
 
@@ -142,6 +147,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: T*TFT*FF*"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "covers"@en ;
 .
 
@@ -151,6 +157,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "disjoint"@en ;
 .
 
@@ -160,6 +167,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "equals"@en ;
 .
 
@@ -169,6 +177,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFF*FFT**"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "inside"@en ;
 .
 
@@ -178,6 +187,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "meet"@en ;
 .
 
@@ -187,6 +197,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "overlap"@en ;
 .
 
@@ -277,6 +288,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject is spatially disjoint  from the object SpatialObject. DE-9IM: FFTFFTTTT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "disconnected"@en ;
 .
 
@@ -286,6 +298,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FFTFTTTTT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "externally connected"@en ;
 .
 
@@ -295,6 +308,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "equals"@en ;
 .
 
@@ -304,6 +318,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFFTFFTTT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "non-tangential proper part"@en ;
 .
 
@@ -313,6 +328,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: TTTFFTFFT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "non-tangential proper part inverse"@en ;
 .
 
@@ -322,6 +338,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: TTTTTTTTT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "partially overlapping"@en ;
 .
 
@@ -331,6 +348,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFFTTFTTT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "tangential proper part"@en ;
 .
 
@@ -340,6 +358,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: TTTFTTFFT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "tangential proper part inverse"@en ;
 .
 
@@ -349,6 +368,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*****FF*"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "contains"@en ;
 .
 
@@ -358,6 +378,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially crosses the object SpatialObject. DE-9IM: T*T******"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "crosses"@en ;
 .
 
@@ -367,6 +388,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "disjoint"@en ;
 .
 
@@ -376,6 +398,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "equals"@en ;
 .
 
@@ -385,6 +408,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject is not spatially disjoint from the object SpatialObject. DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "intersects"@en ;
 .
 
@@ -394,6 +418,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "overlaps"@en ;
 .
 
@@ -403,6 +428,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject spatially touches the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "touches"@en ;
 .
 
@@ -412,6 +438,7 @@ geosparql:
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """Exists if the subject SpatialObject is spatially within the object SpatialObject. DE-9IM: T*F**F***"""@en ;
+	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "within"@en ;
 .
 
@@ -516,6 +543,7 @@ geosparql:
 	rdfs:range xsd:boolean ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """(true) if this geometric object has no anomalous geometric points, such as self intersection or self tangency."""@en ;
+	rdfs:seeAlso <https://portal.ogc.org/files/?artifact_id=25355>
 	skos:prefLabel "is simple"@en ;
 .
 
@@ -540,7 +568,7 @@ geosparql:
 	rdfs:subClassOf :SpatialObject ;
 	owl:disjointWith :Geometry ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
-	skos:definition """This class represents the top-level feature type. This class is equivalent to GFI_Feature defined in ISO 19156:2011, and it is superclass of all feature types."""@en ;
+	skos:definition """A spatial phenomenon in a universe of discourse. A Feature can be discrete (having a well-defined boundary or extent, for example an apple or a river) or can be continuous (for example: temperature, elevation).."""@en ;
 	skos:prefLabel "Feature"@en ;
 	skos:example geosparql-doc:annexB_example1 , geosparql-doc:annexB_example2 , geosparql-doc:annexB_example3 , geosparql-doc:annexB_example4 , geosparql-doc:annexB_example5 ;
 .
@@ -549,7 +577,7 @@ geosparql:
 	a owl:Class ;
 	rdfs:subClassOf :SpatialObject ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
-	skos:definition """The class represents the top-level geometry type. This class is equivalent to the UML class GM_Object defined in ISO 19107, and it is superclass of all geometry types."""@en ;
+	skos:definition """A coherent set of direct positions in Euclidian space. A direct position holds the coordinates for a position within a coordinate reference system (CRS)."""@en ;
 	skos:prefLabel "Geometry"@en ;
 	skos:example geosparql-doc:annexB_example1 , geosparql-doc:annexB_example2 , geosparql-doc:annexB_example3 , geosparql-doc:annexB_example4 , geosparql-doc:annexB_example5 ;
 .
@@ -557,13 +585,13 @@ geosparql:
 :SpatialMeasure
 	a owl:Class ;
   	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
-	skos:definition """This class represents a measurement of some dimension of a feature's spatial presence."""@en ;
+	skos:definition """A measurement or estimate of one or more dimensions of a Feature's spatial presence. It can be used to convey an idea of the size of a Feature."""@en ;
 	skos:prefLabel "Spatial Measure"@en ;
 .
 
 :SpatialObject
 	a owl:Class ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
-	skos:definition """The class spatial-object represents everything that can have a spatial representation. It is superclass of feature and geometry."""@en ;
+	skos:definition """Anything spatial (having or being a shape, size or position). Subclasses are expected to be used for instance data."""@en ;
 	skos:prefLabel "Spatial Object"@en ;
 .


### PR DESCRIPTION
Update ontology definitions.  Resolves [issue 10](https://github.com/opengeospatial/ogc-geosparql/issues/10).

I have tried to look up persistent URIs for OGC standard documents in http://www.opengis.net/def/docs. But is was not very successful:

- I could not find a URI for "Simple feature access -Part 1: Common architecture"
- I did find a URI for the GML 3.2.1 standard: http://www.opengis.net/def/docs/07-036. But its data do not include a reference to the document itself.