### PR TITLE
Update geo.ttl: resolve conflict between defaultGeometry and hasDefaultGeometry

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -115,7 +115,21 @@ geosparql:
 	rdfs:range :Geometry ;
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """The default geometry to be used in spatial calculations. It is usually the most detailed geometry."""@en ;
+	owl:sameAs :hasDefaultGeometry ;
+	skos:note "Duplicate properties defaultGeometry and hasDefaultGeometry exist because of an inconsistency between ontology and documentation in GeoSPARQL 1.0." ;
 	skos:prefLabel "default geometry"@en ;
+.
+
+:hasDefaultGeometry 
+	a owl:ObjectProperty ;
+	rdfs:subPropertyOf :hasGeometry ;
+	rdfs:domain :Feature ;
+	rdfs:range :Geometry ;
+	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
+	skos:definition """The default geometry to be used in spatial calculations. It is usually the most detailed geometry."""@en ;
+	owl:sameAs :defaultGeometry ;
+	skos:note "Duplicate properties defaultGeometry and hasDefaultGeometry exist because of an inconsistency between ontology and documentation in GeoSPARQL 1.0." ;
+	skos:prefLabel "has default geometry"@en ;
 .
 
 :ehContains 
@@ -198,16 +212,6 @@ geosparql:
 	skos:definition """A spatial representation for a given feature."""@en ;
 	skos:prefLabel "has geometry"@en ;
   skos:example geosparql-doc:annexB_example1 ,  geosparql-doc:annexB_example2 , geosparql-doc:annexB_example3 , geosparql-doc:annexB_example4 ;
-.
-
-:hasDefaultGeometry 
-	a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasGeometry ;
-	rdfs:domain :Feature ;
-	rdfs:range :Geometry ;
-	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
-	skos:definition """The default geometry to be used in spatial calculations, usually the most detailed geometry."""@en ;
-	skos:prefLabel "has default geometry"@en ;
 .
 
 :hasBoundingBox

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -116,7 +116,7 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """The default geometry to be used in spatial calculations. It is usually the most detailed geometry."""@en ;
 	owl:sameAs :hasDefaultGeometry ;
-	skos:note "Duplicate properties defaultGeometry and hasDefaultGeometry exist because of an inconsistency between ontology and documentation in GeoSPARQL 1.0." ;
+	skos:note """Duplicate properties defaultGeometry and hasDefaultGeometry exist because of an inconsistency between ontology and documentation in GeoSPARQL 1.0. Only hasDefaultGeometry is described in the documention.""" ;
 	skos:prefLabel "default geometry"@en ;
 .
 
@@ -128,7 +128,7 @@ geosparql:
 	rdfs:isDefinedBy geosparql: , geosparql-spec: ;
 	skos:definition """The default geometry to be used in spatial calculations. It is usually the most detailed geometry."""@en ;
 	owl:sameAs :defaultGeometry ;
-	skos:note "Duplicate properties defaultGeometry and hasDefaultGeometry exist because of an inconsistency between ontology and documentation in GeoSPARQL 1.0." ;
+	skos:note """Duplicate properties defaultGeometry and hasDefaultGeometry exist because of an inconsistency between ontology and documentation in GeoSPARQL 1.0. Only hasDefaultGeometry is described in the documention.""" ;
 	skos:prefLabel "has default geometry"@en ;
 .
 


### PR DESCRIPTION
Define` hasDefaultGeometry` and `defaultGeometry` as duplicates.
Fixes [issue 128](https://github.com/opengeospatial/ogc-geosparql/issues/128) and [issue 30](https://github.com/opengeospatial/ogc-geosparql/issues/30).