### PR TITLE
Update 07-Part-04.adoc - terms and definitions

### DIFF
--- a/1.1/spec/07-Part-04.adoc
+++ b/1.1/spec/07-Part-04.adoc
@@ -1,4 +1,11 @@
 == Terms and definitions
 
-For the purposes of this document, the terms and definitions given in the above references apply.
+The terms and definitions given in the above references apply to the GeoSPARQL specification, with the exception of the terms defined below.
 
+**coordinate system:**  A set of mathematical rules for specifying how coordinates are to be assigned to points.
+
+**coordinate reference system:** A **__coordinate system__** that is related to an object by a  **__datum__**.
+
+**datum:** Parameter or set of parameters that define the position of the origin, the scale, and the orientation of a **__coordinate system__**.
+
+**spatial reference system:**  A system for establishing spatial positions. A spatial reference system can use geographic identifiers (e.g. names like "Paris" or "Africa"), coordinates (in which case it is a **__coordinate reference system__**) or identifiers with structured geometry (in which case it is a Discrete Global Grid System (DGGS)). 

--- a/1.1/spec/07-Part-04.adoc
+++ b/1.1/spec/07-Part-04.adoc
@@ -2,10 +2,10 @@
 
 The terms and definitions given in the above references apply to the GeoSPARQL specification, with the exception of the terms defined below.
 
-**coordinate system:**  A set of mathematical rules for specifying how coordinates are to be assigned to points.
+**coordinate system**:  A set of mathematical rules for specifying how coordinates are to be assigned to points.
 
-**coordinate reference system:** A **__coordinate system__** that is related to an object by a  **__datum__**.
+**coordinate reference system**: A **__coordinate system__** that is related to an object by a  **__datum__**.
 
 **datum:** Parameter or set of parameters that define the position of the origin, the scale, and the orientation of a **__coordinate system__**.
 
-**spatial reference system:**  A system for establishing spatial positions. A spatial reference system can use geographic identifiers (e.g. names like "Paris" or "Africa"), coordinates (in which case it is a **__coordinate reference system__**) or identifiers with structured geometry (in which case it is a Discrete Global Grid System (DGGS)). 
+**spatial reference system**:  A system for establishing spatial positions. A spatial reference system can use geographic identifiers (e.g. names like "Paris" or "Africa"), coordinates (in which case it is a **__coordinate reference system__**) or identifiers with structured geometry (in which case it is a Discrete Global Grid System (DGGS)). 


### PR DESCRIPTION
This PR adds terms and definitions for spatial referencing. In the current state, use of the terms CRS and SRS is confusing. The definitions now clearly state that coordinate reference systems are a subset of spatial reference systems,

See also [this comment](https://github.com/opengeospatial/ogc-geosparql/issues/10#issuecomment-825168038) from a  discussion about definition of terms in the ontology.

Notes:

1. I think it would be good to add other terms that are important for understanding GeoSPARQL to section 4 too, as a convenience for the user/reader.
2. If we agree on these definitions. I can go through the ontology and documentation to check for proper usage of CRS and SRS, and make changes where required, in a new PR.