### PR TITLE
Terms & Defs vocab

### DIFF
--- a/1.1/terms_and_defns.ttl
+++ b/1.1/terms_and_defns.ttl
@@ -1,0 +1,159 @@
+@prefix cs: <http://www.opengis.net/def/geosparql/terms-and-definitions/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix td: <http://www.opengis.net/def/geosparql/terms-and-definitions/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+cs:
+    a owl:Ontology , skos:ConceptScheme ;
+    dcterms:created "2021-06-22"^^xsd:date ;
+	dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
+    dcterms:modified "2021-06-22"^^xsd:date ;
+    dcterms:provenance "Each term (Concept) listed here indicates its own provenance since they are derived from other vocabularies and non-vocabulary sources."@en ;
+	dcterms:publisher [
+		a sdo:Organization ;
+		sdo:name "Open Geospatial Consortium" ;
+		sdo:url "https://www.ogc.org"^^xsd:anyURI ;
+	] ;
+    owl:versionInfo "OGC GeoSPARQL 1.1" ;
+    skos:definition "A vocabulary (taxonomy) of the Terms and Definitions listed by the GeoSPARQL 1.1 standard. These terms appear as a vocabulary resource (this file) and are also listed in Clause 4 of the GeoSPARQL 1.1 Specification"@en ;
+    skos:hasTopConcept
+        td:Subject ,
+        td:Predicate ,
+        td:Object ,
+        td:Resource ,
+        td:Class ,
+        td:Property ,
+        td:ObjectProperty ;
+        # td:DatatypeProperty ,
+        # td:AnnotationProperty 
+    skos:prefLabel "GeoSPARQL Terms & Definitions" ;
+.
+
+# Concept Template
+# td:XXX a skos:Concept ;
+#     dcterms:provenance ""@en ;
+#     rdfs:isDefinedBy <> ;
+#     skos:definition ""@en ;
+#     skos:inScheme cs: ;
+#     skos:prefLabel ""@en ;
+#     skos:topConceptOf cs: ;
+# .
+
+
+td:SemanticWeb a skos:Collection ;
+    dcterms:provenance "This Colelction was created for GeoSPARQL 1.1's Specification's Terms & Definitions Clause"@en ;
+    skos:definition "Concepts from the Semantic Web domain"@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "Semantic Web Concepts"@en ;
+    skos:member        
+        td:Subject ,
+        td:Predicate ,
+        td:Object ,
+        td:Resource ,
+        td:Class ,
+        td:Property ,
+        td:ObjectProperty ;
+        # td:DatatypeProperty ,
+        # td:AnnotationProperty 
+.
+
+td:Subject a skos:Concept ;
+    dcterms:provenance "From the RDF Concepts Vocabulary (RDF)"@en ;
+    rdfs:isDefinedBy rdf: ;
+    skos:definition "The subject of the subject RDF statement."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "RDF Subject"@en ;
+    skos:scopeNote """The RDF Concepts Vocabulary (RDF)'s models all connected ideas through the use of triples - 3-part association - made of subject, predicated & objects. This term indicate the subject of a triple.
+    
+In this set of terms, this object is names 'RDF Subject' to distinguish it from non-RDF resources, given that the word 'subject' is general in nature."""@en ;
+    skos:topConceptOf cs: ;
+.
+
+td:Predicate a skos:Concept ;
+    dcterms:provenance "From the RDF Concepts Vocabulary (RDF)"@en ;
+    rdfs:isDefinedBy rdf: ;
+    skos:definition "The predicate of the subject RDF statement."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "RDF Predicate"@en ;
+    skos:scopeNote """The RDF Concepts Vocabulary (RDF)'s models all connected ideas through the use of triples - 3-part association - made of subject, predicated & objects. This term indicate the predicate of a triple.
+    
+In this set of terms, this object is names 'RDF Predicate' to distinguish it from non-RDF resources."""@en ;
+    skos:topConceptOf cs: ;
+.
+
+td:Object a skos:Concept ;
+    dcterms:provenance "From the RDF Concepts Vocabulary (RDF)"@en ;
+    rdfs:isDefinedBy <http://www.w3.org/2000/01/rdf-schema#> ;
+    skos:definition "The object of the subject RDF statement."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "RDF Object"@en ;
+    skos:scopeNote """The RDF Concepts Vocabulary (RDF)'s models all connected ideas through the use of triples - 3-part association - made of subject, predicated & objects. This term indicate the object of a triple.
+    
+In this set of terms, this object is names 'RDF Object' to distinguish it from non-RDF resources, given that the word 'object' is general in nature."""@en ;
+    skos:topConceptOf cs: ;
+.
+
+td:Resource a skos:Concept ;
+    dcterms:provenance "From the RDF Schema vocabulary (RDFS)"@en ;
+    owl:equivalentClass rdfs:Resource ;
+    rdfs:isDefinedBy rdfs: ;
+    skos:definition "The class resource, everything."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "RDFS Resource"@en ;
+    skos:scopeNote """The RDF Schema vocabulary (RDFS)'s 'Resource' is the most general RDF element and all things defined by RDF are some specialization of 'Resource'. 
+    
+In this set of terms, this object is names 'RDFS Resource' to distinguish it from non-RDF resources, given that the word 'resource' is general in nature."""@en ;
+    skos:topConceptOf cs: ;
+.
+
+td:Class a skos:Concept ;
+    dcterms:provenance "From the RDF Schema vocabulary (RDFS)"@en ;
+    owl:equivalentClass rdfs:Class ;
+    rdfs:isDefinedBy rdfs: ;
+    skos:definition "The class resource, everything."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "RDFS Class"@en ;
+    skos:scopeNote """The RDF Schema vocabulary (RDFS)'s 'Class' is set notion, i.e. a type of thing for which there are a number of individuals of that type (there could be zero individuals). For example, the class of 'Hammer' is a set of individuals - individual hammers - with certain properties that are defined to be the essential properties of a hammer.
+    
+In this set of terms, this object is names 'RDFS Class' to distinguish it from non-RDF resources, given that the word 'class' is general in nature."""@en ;
+    skos:topConceptOf cs: ;
+.
+
+td:Property a skos:Concept ;
+    dcterms:provenance "From the RDF Schema vocabulary (RDFS)"@en ;
+    owl:equivalentClass rdfs:Property ;
+    rdfs:isDefinedBy rdfs: ;
+    skos:definition "The class of RDF properties."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "RDFS Property"@en ;
+    skos:scopeNote """The RDF Schema vocabulary (RDFS)'s 'Property' is the class of all types of things that can be properties of an individual of any class.
+    
+In this set of terms, this object is names 'RDFS Property' to distinguish it from non-RDF resources, given that the word 'class' is general in nature."""@en ;
+    skos:example """owl:ObjectProperty is a special type of rdf:Property that links the subject of an RDF triple to the object of that triple where the object is not a simple data type."""@en ;
+    skos:example """owl:DatatypeProperty is a special type of rdf:Property that links the subject of an RDF triple to the object of that triple where the object is a simple data type, such as a literal text value."""@en ;
+    skos:topConceptOf cs: ;
+.
+
+td:ObjectProperty a skos:Concept ;
+    dcterms:provenance "The OWL 2 Schema vocabulary (OWL 2)"@en ;
+    owl:equivalentClass owl:ObjectProperty ;
+    rdfs:isDefinedBy <http://www.w3.org/2002/07/owl> ;
+    skos:definition "The class of object properties."@en ;
+    skos:inScheme cs: ;
+    skos:prefLabel "OWL Object Property"@en ;
+    skos:scopeNote """The OWL 2 Schema vocabulary (OWL 2)'s 'ObjectProperty' is a subclass of rdfs:Property that links the subject of an RDF triple to the object of that triple where the object is not a simple data type."""@en ;
+    skos:example [
+        a prof:resourceDescriptor ;
+        dcterms:format "text/turtle" ;
+        prof:hasArtifact "<feature_x> geo:hasGeometry <geometry_y> .";
+    ] ,
+    """A specific instance of geoSPARQL's `Feature` class, <feature_x>, is related to a complex object that is of GeoSPARQL's `Geometry` class by the GeoSPARQL's RDF predicate `hasGeometry`. Here the predicate `hasGeometry` is an OWL2 object of type `ObjectProperty`."""@en ;
+    skos:topConceptOf cs: ;
+.


### PR DESCRIPTION
This is a start to a Terms & Defs vocab in SKOS that will be auto-converted to ASCIIDOC for Clause 4 in the Specification though an enhancement to pyLODE.

I have defined a few RDF concepts and placed them into an "Semanitc Web" Collection within the ConceptScheme to group them nicely.

These are really difficult to define due to the unhelpful nature of RDF/RDFS/OWL definitions like, for `rdfClass` _"The class resource, everything."_. I've faithfully reproduced the original definitions abut then added what I think we actually want people to read in a `scopteNote`. 

@dr-shorthair what do you make of this pattern of original defn -> `skos:definition` + useful defn -> `skos:skopeNote`? Should we instead just add the other useful den to a single `skos:definition`? 

I've also indicated that some of the SKOS Concepts here are `owl:equivalentClass` to the originally defined things. This may be unnecessary: such relations will only be potentially relevant for RDF/OWL things and not for non Semantic Web definitions, e.g. spatial things.

@rob-metalinkage please could you also review to see what the OGC NA might make of vocabs like these?