### PR TITLE
Provide namespace prefixes for all /req/ & /conf/ IRIs

### DIFF
--- a/1.1/spec/08-Part-05.adoc
+++ b/1.1/spec/08-Part-05.adoc
@@ -30,19 +30,28 @@ The following IRI namespace prefixes are used throughout this document:
 
 [frame=none, grid=none, cols="1, 6"]
 |===
-| ogc: | http://www.opengis.net/
 | eg: | http://example.com/
-| geo: | http://www.opengis.net/ont/geosparql#
-| geof: | http://www.opengis.net/def/function/geosparql/
-| geor: | http://www.opengis.net/def/rule/geosparql/
-| sf: | http://www.opengis.net/ont/sf#
-| skos: | http://www.w3.org/2004/02/skos/core#
 | gml: | http://www.opengis.net/ont/gml#
 | my: | http://example.org/ApplicationSchema#
-| xsd: | http://www.w3.org/2001/XMLSchema#
+| ogc: | http://www.opengis.net/
+| owl: | http://www.w3.org/2002/07/owl#
 | rdf: | http://www.w3.org/1999/02/22-rdf-syntax-ns# 
 | rdfs: | http://www.w3.org/2000/01/rdf-schema#
-| owl: | http://www.w3.org/2002/07/owl#
+| skos: | http://www.w3.org/2004/02/skos/core#
+| xsd: | http://www.w3.org/2001/XMLSchema#
+|===
+
+The following IRI namespaces, also used throughout this document, are defined within this stnaard:
+
+[frame=none, grid=none, cols="1, 6, 2"]
+|===
+| geo: | http://www.opengis.net/ont/geosparql# | Ontology
+| geof: | http://www.opengis.net/def/function/geosparql/ | Functions
+| geor: | http://www.opengis.net/def/rule/geosparql/ | Rules
+| geoconf: | http://www.opengis.net/def/geosparqlgeoconf: | Conformance Class
+| georeq: | http://www.opengis.net/def/geosparqlgeoreq: | Requirements
+| sf: | http://www.opengis.net/ont/sf# | Simple Features
+| td: | http://www.opengis.net/def/geosparql/td/ | Terms & Definitions
 |===
 
 === Placeholder IRIs

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -1,12 +1,12 @@
 == Core
 
-This clause establishes the *core* requirements class, with IRI `/req/core`, which has a single corresponding conformance class, *core*, with IRI `/conf/core`. This requirements class defines a set of classes and properties for representing geospatial data. The resulting vocabulary can be used to construct SPARQL graph patterns for querying appropriately modeled geospatial data. RDFS and OWL vocabulary have both been used so that the vocabulary can be understood by systems that support only RDFS entailment and by systems that support OWL-based reasoning.
+This clause establishes the *core* requirements class, with IRI `georeq:core`, which has a single corresponding conformance class, *core*, with IRI `geoconf:core`. This requirements class defines a set of classes and properties for representing geospatial data. The resulting vocabulary can be used to construct SPARQL graph patterns for querying appropriately modeled geospatial data. RDFS and OWL vocabulary have both been used so that the vocabulary can be understood by systems that support only RDFS entailment and by systems that support OWL-based reasoning.
 
 === SPARQL
 
 |===
 | *Req 1* Implementations shall support the SPARQL Query Language for RDF <<SPARQL>>, the SPARQL Protocol <<SPARQLPROT>> and the SPARQL Query Results XML <<SPARQLRESX>> and JSON <<SPARQLRESJ>> Formats.
-| `/req/core/sparql-protocol`
+| `georeq:core/sparql-protocol`
 |===
 
 === Classes
@@ -28,7 +28,7 @@ geo:SpatialObject a rdfs:Class, owl:Class ;
 
 |===
 | *Req 2* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] to be used in SPARQL graph patterns.
-|`/req/core/spatial-object-class`
+|`georeq:core/spatial-object-class`
 |===
 
 *Example:*
@@ -56,7 +56,7 @@ geo:Feature a rdfs:Class, owl:Class ;
 
 |===
 | *Req 4* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] to be used in SPARQL graph patterns.
-|`/req/core/feature-class`
+|`georeq:core/feature-class`
 |===
 
 ==== Class: geo:SpatialMeasure
@@ -75,7 +75,7 @@ NOTE: Properties for Spatial Measure may need to indicate a use a unit of measur
 
 |===
 | *Req 3* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`] to be used in SPARQL graph patterns.
-|`/req/core/spatial-measure-class`
+|`georeq:core/spatial-measure-class`
 |===
 
 === Standard Properties for geo:SpatialObject
@@ -89,7 +89,7 @@ Properties are defined for associating geometries with features.
 |===
 | *Req 9* Implementations shall allow the properties http://www.opengis.net/ont/geosparql#hasGeometry[`geo:hasGeometry`], 
 http://www.opengis.net/ont/geosparql#hasDefaultGeometry[`geo:hasDefaultGeometry`], http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`], http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`], http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] http://www.opengis.net/ont/geosparql#hasCentroid[`geo:hasCentroid`], http://www.opengis.net/ont/geosparql#hasBoundingBox[`geo:hasBoundingBox`] and http://www.opengis.net/ont/geosparql#hasSpatialResolution[`geo:hasSpatialResolution`] to be used in SPARQL graph patterns.
-|`/req/geometry-extension/feature-properties`
+|`georeq:geometry-extension/feature-properties`
 |===
 
 ==== Property: geo:hasGeometry

--- a/1.1/spec/10-Part-07.adoc
+++ b/1.1/spec/10-Part-07.adoc
@@ -1,6 +1,6 @@
 == Topology Vocabulary Extension (relation_family)
 
-This clause establishes the _Topology Vocabulary Extension (relation_family)_ parameterized requirements class, with IRI `/req/topology-vocab-extension`, which has a single corresponding conformance class _Topology Vocabulary Extension (relation_family)_, with IRI `/conf/topology-vocab-extension`. This requirements class defines a vocabulary for asserting and querying topological relations between spatial objects. The class is parameterized so that different families of topological relations may be used, e.g. RCC8, Egenhofer. These relations are generalized so that they may connect features as well as geometries.
+This clause establishes the _Topology Vocabulary Extension (relation_family)_ parameterized requirements class, with IRI `georeq:topology-vocab-extension`, which has a single corresponding conformance class _Topology Vocabulary Extension (relation_family)_, with IRI `geoconf:topology-vocab-extension`. This requirements class defines a vocabulary for asserting and querying topological relations between spatial objects. The class is parameterized so that different families of topological relations may be used, e.g. RCC8, Egenhofer. These relations are generalized so that they may connect features as well as geometries.
 
 A Dimensionally Extended 9-Intersection Model (DE-9IM) pattern, which specifies the spatial dimension of the intersections of the interiors, boundaries and exteriors of two geometric objects, is used to describe each spatial relation. Possible pattern values are `-1 (empty)`, `0, 1, 2, T (true) = {0, 1, 2}`, `F (false) = {-1}`, `* (don’t care) = {-1, 0, 1, 2}`. In the following descriptions, the notation `X/Y` is used denote applying a spatial relation to geometry types `X` and `Y` (i.e., `x` _relation_ `y` where `x` is of type `X` and `y` is of type `Y`). The symbol `P` is used for 0- dimensional geometries (e.g. points). The symbol `L` is used for 1-dimensional geometries (e.g. lines), and the symbol `A` is used for 2-dimensional geometries (e.g. polygons). Consult the Simple Features specification <<ISO19125-1>> for a more detailed description of DE-9IM intersection patterns.
 
@@ -16,7 +16,7 @@ This clause defines requirements for the _Simple Features_ relation family.
 
 |===
 | *Req 5* Implementations shall allow the properties http://www.opengis.net/ont/geosparql#sfEquals[`geo:sfEquals`], http://www.opengis.net/ont/geosparql#sfDisjoint[`geo:sfDisjoint`], http://www.opengis.net/ont/geosparql#sfIntersects[`geo:sfIntersects`], http://www.opengis.net/ont/geosparql#sfTouches[`geo:sfTouches`], http://www.opengis.net/ont/geosparql#sfCrosses[`geo:sfCrosses`], http://www.opengis.net/ont/geosparql#sfWithin[`geo:sfWithin`], http://www.opengis.net/ont/geosparql#sfContains[`geo:sfContains`], http://www.opengis.net/ont/geosparql#sfOverlaps[`geo:sfOverlaps`] to be used in SPARQL graph patterns.
-|`/req/topology-vocab-extension/sf-spatial-relations`
+|`georeq:topology-vocab-extension/sf-spatial-relations`
 |===
 
 Topological relations in the _Simple Features_ family are summarized in <<sf_relations>>. Multi-row intersection patterns should be interpreted as a logical `OR` of each row.
@@ -43,7 +43,7 @@ This clause defines requirements for the 9-intersection model for binary topolog
 
 |===
 | *Req 6* Implementations shall allow the properties http://www.opengis.net/ont/geosparql#ehEquals[`geo:ehEquals`], http://www.opengis.net/ont/geosparql#ehDisjoint[`geo:ehDisjoint`], http://www.opengis.net/ont/geosparql#ehMeet[`geo:ehMeet`], http://www.opengis.net/ont/geosparql#ehOverlap[`geo:ehOverlap`], http://www.opengis.net/ont/geosparql#ehCovers[`geo:ehCovers`], http://www.opengis.net/ont/geosparql#ehCoveredBy[`geo:ehCoveredBy`], http://www.opengis.net/ont/geosparql#ehInside[`geo:ehInside`], http://www.opengis.net/ont/geosparql#ehContains[`geo:ehContains`] to be used in SPARQL graph patterns.
-|`/req/topology-vocab-extension/eh-spatial-relations`
+|`georeq:topology-vocab-extension/eh-spatial-relations`
 |===
 
 Topological relations in the _Egenhofer_ family are summarized in <<genhofer_relations>>. Multi-row intersection patterns should be interpreted as a logical `OR` of each row.
@@ -69,7 +69,7 @@ This clause defines requirements for the region connection calculus basic 8 (_RC
 
 |===
 | *Req 7* Implementations shall allow the properties http://www.opengis.net/ont/geosparql#rcc8eq[`geo:rcc8eq`], http://www.opengis.net/ont/geosparql#rcc8dc[`geo:rcc8dc`], http://www.opengis.net/ont/geosparql#rcc8ec[`geo:rcc8ec`], http://www.opengis.net/ont/geosparql#rcc8po[`geo:rcc8po`], http://www.opengis.net/ont/geosparql#rcc8tppi[`geo:rcc8tppi`], http://www.opengis.net/ont/geosparql#rcc8tpp[`geo:rcc8tpp`], http://www.opengis.net/ont/geosparql#rcc8ntpp[`geo:rcc8ntpp`], http://www.opengis.net/ont/geosparql#rcc8ntppi[`geo:rcc8ntppi`] to be used in SPARQL graph patterns.
-|`/req/topology-vocab-extension/rcc8-spatial-relations`
+|`georeq:topology-vocab-extension/rcc8-spatial-relations`
 |===
 
 Topological relations in the _RCC8_ family are summarized in <<rcc8_relations>>.

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -1,6 +1,6 @@
 == Geometry Extension (serialization, version)
 
-This clause establishes the _Geometry Extension (serialization, version)_ parameterized requirements class, with IRI `/req/geometry-extension`, which has a single corresponding conformance class _Geometry Extension (serialization, version)_, with IRI `/conf/geometry-extension`. This requirements class defines a vocabulary for asserting and querying information about geometry data, and it defines query functions for operating on geometry data.
+This clause establishes the _Geometry Extension (serialization, version)_ parameterized requirements class, with IRI `georeq:geometry-extension`, which has a single corresponding conformance class _Geometry Extension (serialization, version)_, with IRI `geoconf:geometry-extension`. This requirements class defines a vocabulary for asserting and querying information about geometry data, and it defines query functions for operating on geometry data.
 
 As part of the vocabulary, an RDFS datatype is defined for encoding detailed geometry information as a literal value. A literal representation of a geometry is needed so that geometric values may be treated as a single unit. Such a representation allows geometries to be passed to external functions for computations and to be returned from a query.
 
@@ -43,7 +43,7 @@ geo:Geometry a rdfs:Class, owl:Class ;
 
 |===
 | *Req 8* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`] to be used in SPARQL graph patterns.
-|`/req/geometry-extension/geometry-class`
+|`georeq:geometry-extension/geometry-class`
 |===
 
 === Standard Properties for geo:Geometry
@@ -52,7 +52,7 @@ Properties are defined for describing geometry metadata.
 
 |===
 | *Req 10* Implementations shall allow the properties http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`], http://www.opengis.net/ont/geosparql#coordinateDimension[`geo:coordinateDimension`], http://www.opengis.net/ont/geosparql#spatialDimension[`geo:spatialDimension`], http://www.opengis.net/ont/geosparql#isEmpty[`geo:isEmpty`], http://www.opengis.net/ont/geosparql#isSimple[`geo:isSimple`], http://www.opengis.net/ont/geosparql#hasSerialization[`geo:hasSerialization`] to be used in SPARQL graph patterns.
-|`/req/geometry-extension/geometry-properties`
+|`georeq:geometry-extension/geometry-properties`
 |===
 
 ==== Property: geo:dimension
@@ -173,7 +173,7 @@ geo:wktLiteral a rdfs:Datatype ;
 
 |===
 | *Req 11* All RDFS Literals of type http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] shall consist of an optional IRI identifying the coordinate reference system and a required Well Known Text (WKT) description of a geometric value. Valid http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiterals`] are formed by either a WKT string as defined in <<ISO13249>> or by concatenating a valid absolute IRI, as defined in <<IETF3987>>, enclose in angled brackets (`<` & `>`) followed by a single space (Unicode U+0020 character) as a separator, and a WKT string as defined in <<ISO13249>>.
-|`/req/geometry-extension/wkt-literal`
+|`georeq:geometry-extension/wkt-literal`
 |===
 
 The following _ABNF_ <<IETF5234>> syntax specification formally defines this literal:
@@ -190,14 +190,14 @@ In the absence of a leading spatial reference system IRI, the following spatial 
 
 |===
 | *Req 12* The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[`+<http://www.opengis.net/def/crs/OGC/1.3/CRS84>+`] shall be assumed as the spatial reference system for http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] instances that do not specify an explicit spatial reference system IRI.
-|`/req/geometry-extension/wkt-literal-default-srs`
+|`georeq:geometry-extension/wkt-literal-default-srs`
 |===
 
 The OGC maintains a set of SRS IRIs under the `+http://www.opengis.net/def/crs/+` namespace and IRIs from this set are recommended for use, however others may also be used, as long as they are valid IRIs.
 
 |===
 | *Req 13* Coordinate tuples within http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] shall be interpreted using the axis order defined in the spatial reference system used.
-|`/req/geometry-extension/wkt-axis-order`
+|`georeq:geometry-extension/wkt-axis-order`
 |===
 
 The example http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system:
@@ -214,7 +214,7 @@ A second example below encodes the same point as encoded in the example above bu
 
 |===
 | *Req 14* An empty RDFS Literal of type http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] shall be interpreted as an empty geometry.
-|`/req/geometry-extension/wkt-literal-empty`
+|`georeq:geometry-extension/wkt-literal-empty`
 |===
 
 ===== Property: geo:asWKT
@@ -223,7 +223,7 @@ The `geo:asWKT` property is defined to link a geometry with its WKT serializatio
 
 |===
 | *Req 15* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asWKT[`geo:asWKT`] to be used in SPARQL graph patterns.
-|`/req/geometry-extension/geometry-as-wkt-literal`
+|`georeq:geometry-extension/geometry-as-wkt-literal`
 |===
 
 The property http://www.opengis.net/ont/geosparql#asWKT[`geo:asWKT`] is used to link a geometric element with its WKT serialization.
@@ -248,7 +248,7 @@ The function http://www.opengis.net/def/function/geosparql/asWKT[`geof:asWKT`] c
 
 |===
 | *Req 15.x* Implementations shall support http://www.opengis.net/def/function/geosparql/asWKT[`geof:asWKT`] as a SPARQL extension function.
-|`/req/geometry-extension/asWKT-function`
+|`georeq:geometry-extension/asWKT-function`
 |===
 
 ==== Geography Markup Language (serialization=GML)
@@ -269,7 +269,7 @@ Valid http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] instance
 
 |===
 | *Req 16* All http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] instances shall consist of a valid element from the GML schema that implements a subtype of `GM_Object` as defined in <<OGC07-036>>.
-|`/req/geometry-extension/gml-literal`
+|`georeq:geometry-extension/gml-literal`
 |===
 
 The example http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] below encodes a point geometry in the WGS 84 geodetic longitude-latitude spatial reference system using GML version 3.2:
@@ -286,12 +286,12 @@ The example http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] be
 
 |===
 | *Req 17* An empty http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] shall be interpreted as an empty geometry.
-|`/req/geometry-extension/gml-literal-empty`
+|`georeq:geometry-extension/gml-literal-empty`
 |===
 
 |===
 | *Req 18* Implementations shall document supported GML profiles.
-|`/req/geometry-extension/gml-profile`
+|`georeq:geometry-extension/gml-profile`
 |===
 
 ===== Property: geo:asGML
@@ -300,7 +300,7 @@ This document defines the http://www.opengis.net/ont/geosparql#asGML[`geo:asGML`
 
 |===
 | *Req 19* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asGML[`geo:asGML`] to be used in SPARQL graph patterns.
-|`/req/geometry-extension/geometry-as-gml-literal`
+|`georeq:geometry-extension/geometry-as-gml-literal`
 |===
 
 
@@ -326,7 +326,7 @@ The function http://www.opengis.net/def/function/geosparql/asGML[`geof:asGML`] c
 
 |===
 | *Req 19.x* Implementations shall support http://www.opengis.net/def/function/geosparql/asGML[`geof:asGML`] as a SPARQL extension function.
-|`/req/geometry-extension/asGML-function`
+|`georeq:geometry-extension/asGML-function`
 |===
 
 ==== GeoJSON (serialization=GEOJSON)
@@ -347,12 +347,12 @@ Valid http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral`] 
 
 |===
 | *Req 20* All http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral`] instances shall consist of the Geometry objects as defined in the GeoJSON specification <<GEOJSON>>.
-|`/req/geometry-extension/geojson-literal`
+|`georeq:geometry-extension/geojson-literal`
 |===
 
 |===
 | *Req 21* RDFS Literals of type http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral`] do not contain a SRS definition. All literals of this type shall, according to the GeoJSON specification, be encoded only in, and be assumed to use, the WGS84 geodetic longitude-latitude spatial reference system (http://www.opengis.net/def/crs/OGC/1.3/CRS84[`http://www.opengis.net/def/crs/OGC/1.3/CRS84`]).
-|`/req/geometry-extension/geojson-literal-srs`
+|`georeq:geometry-extension/geojson-literal-srs`
 |===
 
 The example http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral`] below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:
@@ -365,7 +365,7 @@ The example http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLite
 
 |===
 | *Req 22* An empty RDFS Literal of type http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral`] shall be interpreted as an empty geometry, i.e. `{"geometry": null}` in GeoJSON .
-|`/req/geometry-extension/geojson-literal-empty`
+|`georeq:geometry-extension/geojson-literal-empty`
 |===
 
 ===== Property: geo:asGeoJSON
@@ -374,7 +374,7 @@ The http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] property is 
 
 |===
 | *Req 23* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] to be used in SPARQL graph patterns.
-|`/req/geometry-extension/geometry-as-geojson-literal`
+|`georeq:geometry-extension/geometry-as-geojson-literal`
 |===
 
 The property http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] is used to link a geometric element with its GeoJSON serialization.
@@ -399,7 +399,7 @@ The function http://www.opengis.net/def/function/geosparql/asGeoJSON[`geof:asGeo
 
 |===
 | *Req 23.x* Implementations shall support http://www.opengis.net/def/function/geosparql/asGeoJSON[`geof:asGeoJSON`] as a SPARQL extension function.
-|`/req/geometry-extension/asGeoJSON-function`
+|`georeq:geometry-extension/asGeoJSON-function`
 |===
 
 ==== Keyhole Markup Language (serialization=KML)
@@ -420,12 +420,12 @@ Valid http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] instance
 
 |===
 | *Req 24* All http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] instances shall consist of the Geometry objects as defined in the KML specification <<OGCKML>>.
-|`/req/geometry-extension/kml-literal`
+|`georeq:geometry-extension/kml-literal`
 |===
 
 |===
 | *Req 25* RDFS Literals of type http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] do not contain a SRS definition. All literals of this type shall according to the KML specification only be encoded in and assumed to use the WGS84 geodetic longitude-latitude spatial reference system (http://www.opengis.net/def/crs/OGC/1.3/CRS84[`http://www.opengis.net/def/crs/OGC/1.3/CRS84`]).
-|`/req/geometry-extension/kml-literal-srs`
+|`georeq:geometry-extension/kml-literal-srs`
 |===
 
 The example http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:
@@ -440,7 +440,7 @@ The example http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] be
 
 |===
 | *Req 26* An empty RDFS Literal of type http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] shall be interpreted as an empty geometry .
-|`/req/geometry-extension/kml-literal-empty`
+|`georeq:geometry-extension/kml-literal-empty`
 |===
 
 ===== Property: geo:asKML
@@ -449,7 +449,7 @@ The http://www.opengis.net/ont/geosparql#asKML[`geo:asKML`] property is defined 
 
 |===
 | *Req 27* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asKML[`geo:asKML`] to be used in SPARQL graph patterns.
-|`/req/geometry-extension/geometry-as-kml-literal`
+|`georeq:geometry-extension/geometry-as-kml-literal`
 |===
 
 The property http://www.opengis.net/ont/geosparql#asKML[`geo:asKML`] is used to link a geometric element with its KML serialization.
@@ -474,7 +474,7 @@ The function http://www.opengis.net/def/function/geosparql/asKML[`geof:asKML`] c
 
 |===
 | *Req 27.x* Implementations shall support http://www.opengis.net/def/function/geosparql/asKML[`geof:asKML`] as a SPARQL extension function.
-|`/req/geometry-extension/asKML-function`
+|`georeq:geometry-extension/asKML-function`
 |===
 
 ==== Discrete Global Grid System (serialization=DGGS)
@@ -499,12 +499,12 @@ Valid http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`] instan
 
 |===
 | *Req 28* All RDFS Literals of type http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`] shall consist of a DGGS geometry serialization formulated according to a specific DGGS.
-|`/req/geometry-extension/dggs-literal`
+|`georeq:geometry-extension/dggs-literal`
 |===
 
 |===
 | *Req 29* An empty RDFS Literal of type http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`], or one of its data subtypes, shall be interpreted as an empty `geo:Geometry`.
-|`/req/geometry-extension/dggs-literal-empty`
+|`georeq:geometry-extension/dggs-literal-empty`
 |===
 
 ===== RDFS Datatype: geo:auspixDggsLiteral
@@ -529,7 +529,7 @@ NOTE: What `R3234` means is not handled by GeoSPARQL but by the AusPIX DGGS spec
 
 |===
 | *Req 30* All RDFS Literals of type http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`] shall consist of a DGGS geometry serialization formulated according to the AusPIX DGGS.
-|`/req/geometry-extension/auspix-dggs-literal`
+|`georeq:geometry-extension/auspix-dggs-literal`
 |===
 
 ===== Property: geo:asDGGS
@@ -538,7 +538,7 @@ The http://www.opengis.net/ont/geosparql#asDGGS[`geo:asDGGS`] property is define
 
 |===
 | *Req 30* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asDGGS[`geo:asDGGS`] to be used in SPARQL graph patterns.
-|`/req/geometry-extension/geometry-as-dggs-literal`
+|`georeq:geometry-extension/geometry-as-dggs-literal`
 |===
 
 The property http://www.opengis.net/ont/geosparql#asDGGS[`geo:asDGGS`] is used to link a Geometry instance with its serialization.
@@ -565,7 +565,7 @@ The function http://www.opengis.net/def/function/geosparql/asDGGS[`geof:asDGGS`]
 
 |===
 | *Req 15.x* Implementations shall support http://www.opengis.net/def/function/geosparql/asDGGS[`geof:asDGGS`] as a SPARQL extension function.
-|`/req/geometry-extension/asDGGS-function`
+|`georeq:geometry-extension/asDGGS-function`
 |===
 
 === Non-topological Query Functions
@@ -579,7 +579,7 @@ http://www.opengis.net/def/function/geosparql/area[`geof:area`],http://www.openg
 http://www.opengis.net/def/function/geosparql/numGeometries[`geof:numGeometries`],
 http://www.opengis.net/def/function/geosparql/geometryN[`geof:geometryN`],
 http://www.opengis.net/def/function/geosparql/dimension[`geof:dimension`], http://www.opengis.net/def/function/geosparql/difference[`geof:difference`], http://www.opengis.net/def/function/geosparql/symDifference[`geof:symDifference`], http://www.opengis.net/def/function/geosparql/envelope[`geof:envelope`], http://www.opengis.net/def/function/geosparql/boundary[`geof:boundary`] as SPARQL extension functions, consistent with the definitions of their corresponding functions (`distance`, `buffer`, `convexHull`, `intersection`, `isEmpty`, `isSimple`, `area`, `length`, `dimension`, `difference`, `symDifference`, `envelope` and `boundary` respectively) in Simple Features <<ISO19125-1>> and other attached definitions respectively.
-|`/req/geometry-extension/query-functions`
+|`georeq:geometry-extension/query-functions`
 |===
 
 An invocation of any of the following functions with invalid arguments produces an error. An invalid argument includes any of the following:
@@ -743,7 +743,7 @@ Returns the spatial reference system IRI for `geom`.
 |===
 | *Req 32* Implementations shall support http://www.opengis.net/def/function/geosparql/getSRID[`geof:getSRID`], http://www.opengis.net/def/function/geosparql/concaveHull[`geof:concaveHull`], http://www.opengis.net/def/function/geosparql/boundingCircle[`geof:boundingCircle`], http://www.opengis.net/def/function/geosparql/union2[`geof:union2`], http://www.opengis.net/def/function/geosparql/concatLines[`geof:concatLines`], http://www.opengis.net/def/function/geosparql/concatLines[`geof:centroid`], http://www.opengis.net/def/function/geosparql/minX[`geof:maxX`],
 http://www.opengis.net/def/function/geosparql/maxY[`geof:maxY`], http://www.opengis.net/def/function/geosparql/maxZ[`geof:maxZ`],  http://www.opengis.net/def/function/geosparql/minX[`geof:minX`], http://www.opengis.net/def/function/geosparql/minY[`geof:minY`] and http://www.opengis.net/def/function/geosparql/minZ[`geof:minZ`] as a SPARQL extension functions.
-|`/req/geometry-extension/srid-function`
+|`georeq:geometry-extension/srid-function`
 |===
 
 ==== Function: geof:maxX

--- a/1.1/spec/12-Part-09.adoc
+++ b/1.1/spec/12-Part-09.adoc
@@ -1,7 +1,7 @@
 [#geometry_extension]
 == Geometry Topology Extension (relation_family, serialization, version)
 
-This clause establishes the _Geometry Topology Extension (relation_family, serialization, version)_ parameterized requirements class, with IRI `/req/geometry-topology-extension`, which defines a collection of topological query functions that operate on geometry literals. This class is parameterized to give implementations flexibility in the topological relation families and geometry serializations that they choose to support. This requirements class has a single corresponding conformance class _Geometry Topology Extension (relation_family, serialization, version)_, with IRI `/conf/geometry-topology-extension`.
+This clause establishes the _Geometry Topology Extension (relation_family, serialization, version)_ parameterized requirements class, with IRI `georeq:geometry-topology-extension`, which defines a collection of topological query functions that operate on geometry literals. This class is parameterized to give implementations flexibility in the topological relation families and geometry serializations that they choose to support. This requirements class has a single corresponding conformance class _Geometry Topology Extension (relation_family, serialization, version)_, with IRI `geoconf:geometry-topology-extension`.
 
 The Dimensionally Extended Nine Intersection Model (DE-9IM) <<DE-9IM>> has been used to define the relation tested by the query functions introduced in this section. Each query function is associated with a defining DE-9IM intersection pattern. Possible pattern values are:
 
@@ -22,7 +22,7 @@ In the following descriptions, the notation `X/Y` is used denote applying a spat
 
 |===
 | *Req 34* Implementations shall support http://www.opengis.net/def/function/geosparql/relate[`geof:relate`] as a SPARQL extension function, consistent with the relate operator defined in Simple Features <<ISO19125-1>>.
-|`/req/geometry-topology-extension/relate-query-function`
+|`georeq:geometry-topology-extension/relate-query-function`
 |===
 
 ```
@@ -39,7 +39,7 @@ This clause establishes requirements for the _Simple Features_ relation family.
 
 |===
 | *Req 35* Implementations shall support http://www.opengis.net/def/function/geosparql/sfEquals[`geof:sfEquals`], http://www.opengis.net/def/function/geosparql/sfDisjoint[`geof:sfDisjoint`], http://www.opengis.net/def/function/geosparql/sfIntersects[`geof:sfIntersects`], http://www.opengis.net/def/function/geosparql/sfTouches[`geof:sfTouches`], http://www.opengis.net/def/function/geosparql/sfCrosses[`geof:sfCrosses`], http://www.opengis.net/def/function/geosparql/sfWithin[`geof:sfWithin`], http://www.opengis.net/def/function/geosparql/sfContains[`geof:sfContains`], http://www.opengis.net/def/function/geosparql/sfOverlaps[`geof:sfOverlaps`] as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <<ISO19125-1>>.
-|`/req/geometry-topology-extension/sf-query-functions`
+|`georeq:geometry-topology-extension/sf-query-functions`
 |===
 
 Boolean query functions defined for the Simple Features relation family, along with their associated DE-9IM intersection patterns, are shown in <<simple_features_query_functions>> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (`geom1` and `geom2`) of the geometry literal _serialization_ type _specified_ by serialization and version. Each function returns an http://www.w3.org/2001/XMLSchema#boolean[`xsd:boolean`] value of `true` if the specified relation exists between `geom1` and `geom2` and returns false otherwise. In each case, the spatial reference system of `geom1` is used for spatial calculations.
@@ -73,7 +73,7 @@ This clause establishes requirements for the _Egenhofer_ relation family. Consul
 
 |===
 | *Req 36* Implementations shall support http://www.opengis.net/def/function/geosparql/ehEquals[`geof:ehEquals`], http://www.opengis.net/def/function/geosparql/ehDisjoint[`geof:ehDisjoint`], http://www.opengis.net/def/function/geosparql/ehMeet[`geof:ehMeet`], http://www.opengis.net/def/function/geosparql/ehOverlap[`geof:ehOverlap`], http://www.opengis.net/def/function/geosparql/ehCovers[`geof:ehCovers`], http://www.opengis.net/def/function/geosparql/ehCoveredBy[`geof:ehCoveredBy`], http://www.opengis.net/def/function/geosparql/ehInside[`geof:ehInside`], http://www.opengis.net/def/function/geosparql/ehContains[`geof:ehContains`] as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <<ISO19125-1>>.
-|`/req/geometry-topology-extension/eh-query-functions`
+|`georeq:geometry-topology-extension/eh-query-functions`
 |===
 
 Boolean query functions defined for the _Egenhofer_ relation family, along with their associated DE-9IM intersection patterns, are shown in <<egenhofer_query_functions>> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (`geom1` and `geom2`) of the geometry literal serialization type specified by _serialization_ and _version_. Each function returns an http://www.w3.org/2001/XMLSchema#boolean[`xsd:boolean`] value of `true` if the specified relation exists between `geom1` and `geom2` and returns `false` otherwise. In each case, the spatial reference system of geom1 is used for spatial calculations.
@@ -107,7 +107,7 @@ This clause establishes requirements for the _RCC8_ relation family. Consult ref
 
 |===
 | *Req 37* Implementations shall support http://www.opengis.net/def/function/geosparql/rcc8eq[`geof:rcc8eq`], http://www.opengis.net/def/function/geosparql/rcc8dc[`geof:rcc8dc`], http://www.opengis.net/def/function/geosparql/rcc8ec[`geof:rcc8ec`], http://www.opengis.net/def/function/geosparql/rcc8po[`geof:rcc8po`], http://www.opengis.net/def/function/geosparql/rcc8tppi[`geof:rcc8tppi]`, http://www.opengis.net/def/function/geosparql/rcc8tpp[`geof:rcc8tpp`], http://www.opengis.net/def/function/geosparql/rcc8ntpp[`geof:rcc8ntpp`], http://www.opengis.net/def/function/geosparql/rcc8ntppi[`geof:rcc8ntppi`] as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <<ISO19125-1>>.
-|`/req/geometry-topology-extension/rcc8-query-functions`
+|`georeq:geometry-topology-extension/rcc8-query-functions`
 |===
 
 Boolean query functions defined for the _RCC8_ relation family, along with their associated DE-9IM intersection patterns, are shown in <<rcc8_query_functions>> below. Each function accepts two arguments (`geom1` and `geom2`) of the geometry literal serialization type specified by _serialization_ and _version_. Each function returns an http://www.w3.org/2001/XMLSchema#boolean[`xsd:boolean`] value of `true` if the specified relation exists between `geom1` and `geom2` and returns `false` otherwise. In each case, the spatial reference system of geom1 is used for spatial calculations.

--- a/1.1/spec/13-Part-10.adoc
+++ b/1.1/spec/13-Part-10.adoc
@@ -1,6 +1,6 @@
 == RDFS Entailment Extension (relation_family, serialization, version)
 
-This clause establishes the _RDFS Entailment Extension (relation_family, serialization, version)_ parameterized requirements class, with IRI `/req/rdfs-entailment-extension`, which defines a mechanism for matching implicitly-derived RDF triples in GeoSPARQL queries. This class is parameterized to give implementations flexibility in the topological relation families and geometry types that they choose to support. This requirements class has a single corresponding conformance class _RDFS Entailment Extension (relation_family, serialization, version)_, `with IRI /conf/rdfs-entailment-extension`.
+This clause establishes the _RDFS Entailment Extension (relation_family, serialization, version)_ parameterized requirements class, with IRI `georeq:rdfs-entailment-extension`, which defines a mechanism for matching implicitly-derived RDF triples in GeoSPARQL queries. This class is parameterized to give implementations flexibility in the topological relation families and geometry types that they choose to support. This requirements class has a single corresponding conformance class _RDFS Entailment Extension (relation_family, serialization, version)_, with IRI `geoconf:rdfs-entailment-extension`.
 
 === Parameters
 
@@ -14,7 +14,7 @@ The basic mechanism for supporting RDFS entailment has been defined by the W3C S
 
 |===
 | *Req 38* Basic graph pattern matching shall use the semantics defined by the RDFS Entailment Regime <<SPARQLENT>>.
-|`/req/rdfs-entailment-extension/bgp-rdfs-ent`
+|`georeq:rdfs-entailment-extension/bgp-rdfs-ent`
 |===
 
 === WKT Serialization (serialization=WKT)
@@ -38,7 +38,7 @@ sf:Polygon a rdfs:Class, owl:Class ;
 
 |===
 | *Req 39* Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of Simple Features <<ISO19125-1>>.
-|`/req/rdfs-entailment-extension/wkt-geometry-types`
+|`georeq:rdfs-entailment-extension/wkt-geometry-types`
 |===
 
 === GML Serialization (serialization=GML)
@@ -62,5 +62,5 @@ gml:Polygon a rdfs:Class, owl:Class ;
 
 |===
 | *Req 40* Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the GML schema that implements `GM_Object` using the specified _version_ of GML <<OGC07-036>>.
-|`/req/rdfs-entailment-extension/gml-geometry-types`
+|`georeq:rdfs-entailment-extension/gml-geometry-types`
 |===

--- a/1.1/spec/14-Part-11.adoc
+++ b/1.1/spec/14-Part-11.adoc
@@ -1,6 +1,6 @@
 == Query Rewrite Extension (relation_family, serialization, version)
 
-This clause establishes the _Query Rewrite Extension (relation_family, serialization, version)_ parameterized requirements class, with IRI `/req/query-rewrite-extension`, which has a single corresponding conformance class _Query Rewrite Extension (relation_family, serialization, version)_, with IRI `/conf/query-rewrite-extension`. This requirements class defines a set of RIF rules <<RIF>> that use topological extension functions defined in Clause 9 to establish the existence of direct topological predicates defined in Clause 7. One possible implementation strategy is to transform a given query by expanding a triple pattern involving a direct spatial predicate into a series of triple patterns and an invocation of the corresponding extension function as specified in the RIF rule.
+This clause establishes the _Query Rewrite Extension (relation_family, serialization, version)_ parameterized requirements class, with IRI `georeq:query-rewrite-extension`, which has a single corresponding conformance class _Query Rewrite Extension (relation_family, serialization, version)_, with IRI `geoconf:query-rewrite-extension`. This requirements class defines a set of RIF rules <<RIF>> that use topological extension functions defined in Clause 9 to establish the existence of direct topological predicates defined in Clause 7. One possible implementation strategy is to transform a given query by expanding a triple pattern involving a direct spatial predicate into a series of triple patterns and an invocation of the corresponding extension function as specified in the RIF rule.
 
 The following rule specified using the RIF Core Dialect <<RIFCORE>> is used as a template to describe rules in the remainder of this clause. http://www.opengis.net/def/relation[`ogc:relation`] is used as a placeholder for the spatial relation IRIs defined in Clause 7, and http://www.opengis.net/def/function[`ogc:function`] is used as a placeholder for the spatial functions defined in <<geometry_extension>>.
 
@@ -50,7 +50,7 @@ This clause defines requirements for the _Simple Features_ relation family. <<sf
 
 |===
 | *Req 41* Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <<SPARQLENT>> for the RIF rules <<RIFCORE>> http://www.opengis.net/def/rule/geosparql/sfEquals[`geor:sfEquals`], http://www.opengis.net/def/rule/geosparql/sfDisjoint[`geor:sfDisjoint`], http://www.opengis.net/def/rule/geosparql/sfIntersects[`geor:sfIntersects`], http://www.opengis.net/def/rule/geosparql/sfTouches[`geor:sfTouches`], http://www.opengis.net/def/rule/geosparql/sfCrosses[`geor:sfCrosses`], http://www.opengis.net/def/rule/geosparql/sfWithin[`geor:sfWithin`], http://www.opengis.net/def/rule/geosparql/sfContains[`geor:sfContains`], http://www.opengis.net/def/rule/geosparql/sfOverlaps[`geor:sfOverlaps`].
-|`/req/query-rewrite-extension/sf-query-rewrite`
+|`georeq:query-rewrite-extension/sf-query-rewrite`
 |===
 
 [#sf_query_transformation_rules]
@@ -75,7 +75,7 @@ This clause defines requirements for the _Egenhofer_ relation family. <<eh_query
 |===
 | *Req 42* Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <<SPARQLENT>> for the RIF rules <<RIFCORE>> http://www.opengis.net/def/rule/geosparql/ehEquals[`geor:ehEquals`], http://www.opengis.net/def/rule/geosparql/ehDisjoint[`geor:ehDisjoint`], http://www.opengis.net/def/rule/geosparql/ehMeet[`geor:ehMeet`], http://www.opengis.net/def/rule/geosparql/ehOverlap[`geor:ehOverlap`],
 http://www.opengis.net/def/rule/geosparql/ehCovers[`geor:ehCovers`], http://www.opengis.net/def/rule/geosparql/ehCoveredBy[`geor:ehCoveredBy`], http://www.opengis.net/def/rule/geosparql/ehInside[`geor:ehInside`], http://www.opengis.net/def/rule/geosparql/ehContains[`geor:ehContains`].
-|`/req/query-rewrite-extension/eh-query-rewrite`
+|`georeq:query-rewrite-extension/eh-query-rewrite`
 |===
 
 [#eh_query_transformation_rules]
@@ -99,7 +99,7 @@ This clause defines requirements for the _RCC8_ relation family. <<rcc8_query_tr
 
 |===
 | *Req 43* Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <<SPARQLENT>> for the RIF rules <<RIFCORE>> http://www.opengis.net/def/rule/geosparql/rcc8eq[`geor:rcc8eq`], http://www.opengis.net/def/rule/geosparql/rcc8dc[`geor:rcc8dc`], http://www.opengis.net/def/rule/geosparql/rcc8ec[`geor:rcc8ec`], http://www.opengis.net/def/rule/geosparql/rcc8po[`geor:rcc8po`], http://www.opengis.net/def/rule/geosparql/rcc8tppi[`geor:rcc8tppi`], http://www.opengis.net/def/rule/geosparql/rcc8tpp[`geor:rcc8tpp`], http://www.opengis.net/def/rule/geosparql/rcc8ntpp[`geor:rcc8ntpp`], http://www.opengis.net/def/rule/geosparql/rcc8ntppi[`geor:rcc8ntppi`].
-|`/req/query-rewrite-extension/rcc8-query-rewrite`
+|`georeq:query-rewrite-extension/rcc8-query-rewrite`
 |===
 
 [#rcc8_query_transformation_rules]

--- a/1.1/spec/16-Annex-A.adoc
+++ b/1.1/spec/16-Annex-A.adoc
@@ -2,11 +2,11 @@
 
 == A.1 Conformance Class: _Core_
 
-*Conformance Class IRI*: `/conf/core` 
+*Conformance Class IRI*: `geoconf:core` 
 
-=== A.1.1 `/conf/core/sparql-protocol`
+=== A.1.1 `geoconf:core/sparql-protocol`
 
-*Requirement*: `/req/core/sparql-protocol`
+*Requirement*: `georeq:core/sparql-protocol`
 
 Implementations shall support the SPARQL Query Language for RDF <<SPARQL>>, the SPARQL Protocol for RDF <<SPARQLPROT>> and the SPARQL Query Results XML Format <<SPARQLRESX>>.
 
@@ -16,9 +16,9 @@ Implementations shall support the SPARQL Query Language for RDF <<SPARQL>>, the 
 .. *Reference*: <<_sparql_2>>
 .. *Test Type*: Capabilities
 
-=== A.1.2 `/conf/core/spatial-object-class`
+=== A.1.2 `geoconf:core/spatial-object-class`
 
-*Requirement*: `/req/core/spatial-object-class`
+*Requirement*: `georeq:core/spatial-object-class`
 
 Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#SpatialObject[geo:SpatialObject] to be used in SPARQL graph 
 patterns.
@@ -28,9 +28,9 @@ patterns.
 .. *Reference*: <<_class_geospatialobject>>
 .. *Test Type*: Capabilities
 
-=== A.1.3 `/conf/core/spatial-measure-class`
+=== A.1.3 `geoconf:core/spatial-measure-class`
 
-*Requirement*: `/req/core/spatial-measure-class`
+*Requirement*: `georeq:core/spatial-measure-class`
 Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#SpatialMeasure[geo:SpatialMeasure] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -38,9 +38,9 @@ Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#
 .. *Reference*: <<_class_geospatialmeasure>>
 .. *Test Type*: Capabilities
 
-=== A.1.3 `/conf/core/feature-class`
+=== A.1.3 `geoconf:core/feature-class`
 
-*Requirement*: `/req/core/feature-class`
+*Requirement*: `georeq:core/feature-class`
 Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#Feature[geo:Feature] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -50,11 +50,11 @@ Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#
 
 == A.2 Conformance Class: Topology Vocabulary Extension (relation_family) 
 
-*Conformance Class IRI*: `/conf/topology-vocab-extension`
+*Conformance Class IRI*: `geoconf:topology-vocab-extension`
 
 === A.2.1 relation_family = Simple Features
-==== A.2.1.1 `/conf/topology-vocab-extension/sf-spatial-relations`
-*Requirement*: `/req/topology-vocab-extension/sf-spatial-relations`
+==== A.2.1.1 `geoconf:topology-vocab-extension/sf-spatial-relations`
+*Requirement*: `georeq:topology-vocab-extension/sf-spatial-relations`
 Implementations shall allow the properties http://www.opengis.net/ont/geosparql#sfEquals[`geo:sfEquals`], http://www.opengis.net/ont/geosparql#sfDisjoint[`geo:sfDisjoint`], http://www.opengis.net/ont/geosparql#sfIntersects[`geo:sfIntersects`], http://www.opengis.net/ont/geosparql#sfTouches[`geo:sfTouches`], http://www.opengis.net/ont/geosparql#sfCrosses[`geo:sfCrosses`], http://www.opengis.net/ont/geosparql#sfWithin[`geo:sfWithin`], http://www.opengis.net/ont/geosparql#sfContains[`geo:sfContains`], http://www.opengis.net/ont/geosparql#sfOverlaps[`geo:sfOverlaps`] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -63,8 +63,8 @@ Implementations shall allow the properties http://www.opengis.net/ont/geosparql#
 .. *Test Type*: Capabilities
 
 === A.2.2 relation_family = Egenhofer
-==== A.2.2.1 `/conf/topology-vocab-extension/eh-spatial-relations`
-*Requirement*: `/req/topology-vocab-extension/eh-spatial-relations`
+==== A.2.2.1 `geoconf:topology-vocab-extension/eh-spatial-relations`
+*Requirement*: `georeq:topology-vocab-extension/eh-spatial-relations`
 Implementations shall allow the properties http://www.opengis.net/ont/geosparql#ehEquals[`geo:ehEquals`], http://www.opengis.net/ont/geosparql#ehDisjoint[`geo:ehDisjoint`], http://www.opengis.net/ont/geosparql#ehMeet[`geo:ehMeet`], http://www.opengis.net/ont/geosparql#ehOverlap[`geo:ehOverlap`], http://www.opengis.net/ont/geosparql#ehCovers[`geo:ehCovers`], http://www.opengis.net/ont/geosparql#ehCoveredBy[`geo:ehCoveredBy`], http://www.opengis.net/ont/geosparql#ehInside[ `geo:ehInside`], http://www.opengis.net/ont/geosparql#ehContains[`geo:ehContains`] to be used in SPARQL graph patterns. 
 
 .. *Test purpose*: Check conformance with this requirement
@@ -73,8 +73,8 @@ Implementations shall allow the properties http://www.opengis.net/ont/geosparql#
 .. *Test Type*: Capabilities
 
 === A.2.3 relation_family = RCC8
-==== A.2.3.1 `/conf/topology-vocab-extension/rcc8-spatial-relations`
-*Requirement*: `/req/topology-vocab-extension/rcc8-spatial-relations`
+==== A.2.3.1 `geoconf:topology-vocab-extension/rcc8-spatial-relations`
+*Requirement*: `georeq:topology-vocab-extension/rcc8-spatial-relations`
 Implementations shall allow the properties http://www.opengis.net/ont/geosparql#rcc8eq[`geo:rcc8eq`], http://www.opengis.net/ont/geosparql#rcc8dc[`geo:rcc8dc`], http://www.opengis.net/ont/geosparql#rcc8ec[`geo:rcc8ec`], http://www.opengis.net/ont/geosparql#rcc8po[`geo:rcc8po`], http://www.opengis.net/ont/geosparql#rcc8tppi[`geo:rcc8tppi`], http://www.opengis.net/ont/geosparql#rcc8tpp[`geo:rcc8tpp`], http://www.opengis.net/ont/geosparql#rcc8tpp[`geo:rcc8ntpp`], http://www.opengis.net/ont/geosparql#rcc8tppi[`geo:rcc8ntppi`] to be used in SPARQL graph patterns
 
 .. *Test purpose*: Check conformance with this requirement
@@ -84,11 +84,11 @@ Implementations shall allow the properties http://www.opengis.net/ont/geosparql#
 
 == A.3 Conformance Class: Geometry Extension (serialization, version) 
 
-*Conformance Class IRI*: `/conf/geometry-extension`
+*Conformance Class IRI*: `geoconf:geometry-extension`
 
 === A.3.1 Tests for all Serializations
-==== A.3.1.1 `/conf/geometry-extension/geometry-class`
-*Requirement*: `/req/geometry-extension/geometry-class`
+==== A.3.1.1 `geoconf:geometry-extension/geometry-class`
+*Requirement*: `georeq:geometry-extension/geometry-class`
 Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -96,8 +96,8 @@ Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#
 .. *Reference*: <<_class_geogeometry>>
 .. *Test Type*: Capabilities
 
-==== A.3.1.2 `/conf/geometry-extension/feature-properties`
-*Requirement*: `/req/geometry-extension/feature-properties`
+==== A.3.1.2 `geoconf:geometry-extension/feature-properties`
+*Requirement*: `georeq:geometry-extension/feature-properties`
 Implementations shall allow the properties http://www.opengis.net/ont/geosparql#hasGeometry[`geo:hasGeometry`] and http://www.opengis.net/ont/geosparql#hasDefaultGeometry[`geo:hasDefaultGeometry`], 
 http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`],
 http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`],
@@ -110,8 +110,8 @@ http://www.opengis.net/ont/geosparql#hasCentroid[`geo:hasCentroid`] to be used i
 .. *Reference*: <<_standard_properties_for_geofeature>>
 .. *Test Type*: Capabilities
 
-==== A.3.1.3 `/conf/geometry-extension/geometry-properties`
-*Requirement*: `/req/geometry-extension/geometry-properties`
+==== A.3.1.3 `geoconf:geometry-extension/geometry-properties`
+*Requirement*: `georeq:geometry-extension/geometry-properties`
 Implementations shall allow the properties http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`], http://www.opengis.net/ont/geosparql#coordinateDimension[`geo:coordinateDimension`], http://www.opengis.net/ont/geosparql#spatialDimension[`geo:spatialDimension`],  http://www.opengis.net/ont/geosparql#isEmpty[`geo:isEmpty`],  http://www.opengis.net/ont/geosparql#isSimple[`geo:isSimple`],  http://www.opengis.net/ont/geosparql#hasSerialization[`geo:hasSerialization`] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -119,8 +119,8 @@ Implementations shall allow the properties http://www.opengis.net/ont/geosparql#
 .. *Reference*: <<_standard_properties_for_geogeometry>>
 .. *Test Type*: Capabilities
 
-==== A.3.1.4 `/conf/geometry-extension/query-functions`
-*Requirement*: `/req/geometry-extension/query-functions`  
+==== A.3.1.4 `geoconf:geometry-extension/query-functions`
+*Requirement*: `georeq:geometry-extension/query-functions`  
 Implementations shall support http://www.opengis.net/def/function/geosparql/distance[`geof:distance`], http://www.opengis.net/def/function/geosparql/buffer[`geof:buffer`], http://www.opengis.net/def/function/geosparql/convexHull[`geof:convexHull`], http://www.opengis.net/def/function/geosparql/intersection[`geof:intersection`], http://www.opengis.net/def/function/geosparql/union[`geof:union`], http://www.opengis.net/def/function/geosparql/difference[`geof:difference`], http://www.opengis.net/def/function/geosparql/symDifference[`geof:symDifference`], http://www.opengis.net/def/function/geosparql/envelope[`geof:envelope`] and http://www.opengis.net/def/function/geosparql/boundary[`geof:boundary`] as SPARQL extension functions, consistent with the definitions of the corresponding functions (distance, buffer, convexHull, intersection, difference, symDifference, envelope and boundary respectively) in Simple Features <<ISO19125-1>>.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -128,8 +128,8 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/dist
 .. *Reference*: <<_non_topological_query_functions>>
 .. *Test Type*: Capabilities
 
-==== A.3.1.5 `/conf/geometry-extension/srid-function`
-*Requirement*: `/req/geometry-extension/srid-function`
+==== A.3.1.5 `geoconf:geometry-extension/srid-function`
+*Requirement*: `georeq:geometry-extension/srid-function`
 Implementations shall support http://www.opengis.net/def/function/geosparql/getSRID[`geof:getSRID`] as a SPARQL extension function.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -139,8 +139,8 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/getS
 
 === A.3.2 serialization = WKT
 
-==== A.3.2.1 `/conf/geometry-extension/wkt-literal`
-*Requirement*: `/req/geometry-extension/wkt-literal`
+==== A.3.2.1 `geoconf:geometry-extension/wkt-literal`
+*Requirement*: `georeq:geometry-extension/wkt-literal`
 All http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] instances shall consist of an optional IRI identifying the Spatial Reference System (SRS) followed by Simple Features Well Known Text (WKT) describing a geometric value. Valid http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] instances are formed by concatenating a valid, absolute IRI as defined in <<IETF3987>>, one or more spaces (Unicode U+0020 character) as a separator, and a WKT string as defined in Simple Features <<ISO19125-1>>.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -148,8 +148,8 @@ All http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] instances 
 .. *Reference*: <<_rdfs_datatype_geowktliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.2.2 `/conf/geometry-extension/wkt-literal-default-srs`
-*Requirement*: `/req/geometry-extension/wkt-literal-default-srs`
+==== A.3.2.2 `geoconf:geometry-extension/wkt-literal-default-srs`
+*Requirement*: `georeq:geometry-extension/wkt-literal-default-srs`
 The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def/crs/OGC/1.3/CRS84>] shall be assumed as the SRS for  http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiterals`] that do not specify an explicit SRS IRI.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -157,8 +157,8 @@ The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def
 .. *Reference*: <<_rdfs_datatype_geowktliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.2.3 `/conf/geometry-extension/wkt-axis-order`
-*Requirement*: `/req/geometry-extension/wkt-axis-order`
+==== A.3.2.3 `geoconf:geometry-extension/wkt-axis-order`
+*Requirement*: `georeq:geometry-extension/wkt-axis-order`
 Coordinate tuples within http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiterals`] shall be interpreted using the axis order defined in the SRS used.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -166,8 +166,8 @@ Coordinate tuples within http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wk
 .. *Reference*: <<_rdfs_datatype_geowktliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.2.4 `/conf/geometry-extension/wkt-literal-empty`
-*Requirement*: `/req/geometry-extension/wkt-literal-empty`
+==== A.3.2.4 `geoconf:geometry-extension/wkt-literal-empty`
+*Requirement*: `georeq:geometry-extension/wkt-literal-empty`
 An empty RDFS Literal of type http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] shall be interpreted as an empty geometry.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -175,8 +175,8 @@ An empty RDFS Literal of type http://www.opengis.net/ont/geosparql#wktLiteral[`g
 .. *Reference*: <<_rdfs_datatype_geowktliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.2.5 `/conf/geometry-extension/geometry-as-wkt-literal`
-*Requirement*: `/req/geometry-extension/geometry-as-wkt-literal`
+==== A.3.2.5 `geoconf:geometry-extension/geometry-as-wkt-literal`
+*Requirement*: `georeq:geometry-extension/geometry-as-wkt-literal`
 Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asWKT[`geo:asWKT`] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -184,8 +184,8 @@ Implementations shall allow the RDF property http://www.opengis.net/ont/geosparq
 .. *Reference*: <<_property_geoaswkt>>
 .. *Test Type*: Capabilities
 
-==== A.3.2.6 `/req/geometry-extension/asWKT-function`
-*Requirement*: `/req/geometry-extension/asWKT-function` 
+==== A.3.2.6 `georeq:geometry-extension/asWKT-function`
+*Requirement*: `georeq:geometry-extension/asWKT-function` 
 Implementations shall support http://www.opengis.net/def/function/geosparql/asWKT[`geof:asWKT`], as a SPARQL extension function
 
 .. *Test purpose*: Check conformance with this requirement
@@ -194,8 +194,8 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/asWK
 .. *Test Type*: Capabilities
 
 === A.3.3 serialization = GML
-==== A.3.3.1 `/conf/geometry-extension/gml-literal`
-*Requirement*: `/req/geometry-extension/gml-literal`
+==== A.3.3.1 `geoconf:geometry-extension/gml-literal`
+*Requirement*: `georeq:geometry-extension/gml-literal`
 All http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] instances shall consist of a valid element from the GML schema that implements a subtype of GM_Object as defined in [OGC 07-036].
 
 .. *Test purpose*: Check conformance with this requirement
@@ -203,8 +203,8 @@ All http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] instances 
 .. *Reference*: <<_rdfs_datatype_geogmlliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.3.2 `/conf/geometry-extension/gml-literal-empty`
-*Requirement*: `/req/geometry-extension/gml-literal-empty`
+==== A.3.3.2 `geoconf:geometry-extension/gml-literal-empty`
+*Requirement*: `georeq:geometry-extension/gml-literal-empty`
 An empty http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] shall be interpreted as an empty geometry.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -212,8 +212,8 @@ An empty http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] shall
 .. *Reference*: <<_rdfs_datatype_geogmlliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.3.3 `/conf/geometry-extension/gml-profile`
-*Requirement*: `/req/geometry-extension/gml-profile`
+==== A.3.3.3 `geoconf:geometry-extension/gml-profile`
+*Requirement*: `georeq:geometry-extension/gml-profile`
 Implementations shall document supported GML profiles.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -221,8 +221,8 @@ Implementations shall document supported GML profiles.
 .. *Reference*: <<_rdfs_datatype_geogmlliteral>>
 .. *Test Type*: Documentation
 
-==== A.3.3.4 `/conf/geometry-extension/geometry-as-gml-literal`
-*Requirement*: `/req/geometry-extension/geometry-as-gml-literal` 
+==== A.3.3.4 `geoconf:geometry-extension/geometry-as-gml-literal`
+*Requirement*: `georeq:geometry-extension/geometry-as-gml-literal` 
 Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asGML[`geo:asGML`] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -230,8 +230,8 @@ Implementations shall allow the RDF property http://www.opengis.net/ont/geosparq
 .. *Reference*: <<_property_geoasgml>>
 .. *Test Type*: Capabilities
 
-==== A.3.3.5 `/req/geometry-extension/asGML-function`
-*Requirement*: `/req/geometry-extension/asGML-function` 
+==== A.3.3.5 `georeq:geometry-extension/asGML-function`
+*Requirement*: `georeq:geometry-extension/asGML-function` 
 Implementations shall support http://www.opengis.net/def/function/geosparql/asGML[`geof:asGML`], as a SPARQL extension function
 
 .. *Test purpose*: Check conformance with this requirement
@@ -240,8 +240,8 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/asGM
 .. *Test Type*: Capabilities
 
 === A.3.4 serialization = GEOJSON
-==== A.3.4.1 `/req/geometry-extension/geojson-literal`
-*Requirement*: `/req/geometry-extension/geojson-literal`
+==== A.3.4.1 `georeq:geometry-extension/geojson-literal`
+*Requirement*: `georeq:geometry-extension/geojson-literal`
 All http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral`] instances shall consist of valid JSON that conforms to the GeoJSON specification <<GEOJSON>>
 
 .. *Test purpose*: Check conformance with this requirement
@@ -249,8 +249,8 @@ All http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral`] in
 .. *Reference*: <<_property_geoasgml>>
 .. *Test Type*: Capabilities
 
-==== A.3.4.2 `/req/geometry-extension/geojson-literal-srs`
-*Requirement*: `/req/geometry-extension/geojson-literal-default-srs`
+==== A.3.4.2 `georeq:geometry-extension/geojson-literal-srs`
+*Requirement*: `georeq:geometry-extension/geojson-literal-default-srs`
 The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def/crs/OGC/1.3/CRS84>] shall be assumed as the SRS for http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral`] instances that do not specify an explicit SRS IRI.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -258,8 +258,8 @@ The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def
 .. *Reference*: <<_rdfs_datatype_geogeojsonliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.4.3 `/req/geometry-extension/geojson-literal-empty`
-*Requirement*: `/req/geometry-extension/geojson-literal-empty`
+==== A.3.4.3 `georeq:geometry-extension/geojson-literal-empty`
+*Requirement*: `georeq:geometry-extension/geojson-literal-empty`
 An empty http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral`] shall be interpreted as an empty geometry.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -267,8 +267,8 @@ An empty http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLiteral
 .. *Reference*: <<_rdfs_datatype_geogeojsonliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.4.4 `/req/geometry-extension/geometry-as-geojson-literal`
-*Requirement*: `/req/geometry-extension/geometry-as-geojson-literal` 
+==== A.3.4.4 `georeq:geometry-extension/geometry-as-geojson-literal`
+*Requirement*: `georeq:geometry-extension/geometry-as-geojson-literal` 
 Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -276,8 +276,8 @@ Implementations shall allow the RDF property http://www.opengis.net/ont/geosparq
 .. *Reference*: <<_property_geoasgeojson>>
 .. *Test Type*: Capabilities
 
-==== A.3.4.5 `/req/geometry-extension/asGeoJSON-function`
-*Requirement*: `/req/geometry-extension/asGeoJSON-function` 
+==== A.3.4.5 `georeq:geometry-extension/asGeoJSON-function`
+*Requirement*: `georeq:geometry-extension/asGeoJSON-function` 
 Implementations shall support http://www.opengis.net/def/function/geosparql/asGeoJSON[`geof:asGeoJSON`], as a SPARQL extension function
 
 .. *Test purpose*: Check conformance with this requirement
@@ -286,8 +286,8 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/asGe
 .. *Test Type*: Capabilities
 
 === A.3.5 serialization = KML
-==== A.3.5.1 `/req/geometry-extension/kml-literal`
-*Requirement*: `/req/geometry-extension/kml-literal`
+==== A.3.5.1 `georeq:geometry-extension/kml-literal`
+*Requirement*: `georeq:geometry-extension/kml-literal`
 All http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] instances shall consist of a valid element from the KML schema that implements a `kml:AbstractObjectGroup` as defined in <<OGCKML>>.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -295,8 +295,8 @@ All http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] instances 
 .. *Reference*: <<_rdfs_datatype_geomklliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.5.2 `/req/geometry-extension/kml-literal-srs`
-*Requirement*: `/req/geometry-extension/kml-literal-default-srs`
+==== A.3.5.2 `georeq:geometry-extension/kml-literal-srs`
+*Requirement*: `georeq:geometry-extension/kml-literal-default-srs`
 The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def/crs/OGC/1.3/CRS84>] shall be assumed as the SRS for http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiterals`] that do not specify an explicit SRS IRI.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -304,8 +304,8 @@ The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def
 .. *Reference*: <<_rdfs_datatype_geomklliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.5.3 `/req/geometry-extension/kml-literal-empty`
-*Requirement*: `/req/geometry-extension/kml-literal-empty`
+==== A.3.5.3 `georeq:geometry-extension/kml-literal-empty`
+*Requirement*: `georeq:geometry-extension/kml-literal-empty`
 An empty http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] shall be interpreted as an empty geometry.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -313,8 +313,8 @@ An empty http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] shall
 .. *Reference*: <<_rdfs_datatype_geomklliteral>>
 .. *Test Type*: Capabilities
 
-==== A.3.5.4 `/req/geometry-extension/geometry-as-kml-literal`
-*Requirement*: `/req/geometry-extension/geometry-as-kml-literal` 
+==== A.3.5.4 `georeq:geometry-extension/geometry-as-kml-literal`
+*Requirement*: `georeq:geometry-extension/geometry-as-kml-literal` 
 Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asKML[`geo:asKML`] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -322,8 +322,8 @@ Implementations shall allow the RDF property http://www.opengis.net/ont/geosparq
 .. *Reference*: <<_property_geoaskml>>
 .. *Test Type*: Capabilities
 
-==== A.3.5.5 `/req/geometry-extension/asKML-function`
-*Requirement*: `/req/geometry-extension/asKML-function` 
+==== A.3.5.5 `georeq:geometry-extension/asKML-function`
+*Requirement*: `georeq:geometry-extension/asKML-function` 
 Implementations shall support http://www.opengis.net/def/function/geosparql/asKML[`geof:asKML`], as a SPARQL extension function
 
 .. *Test purpose*: Check conformance with this requirement
@@ -332,8 +332,8 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/asKM
 .. *Test Type*: Capabilities
 
 === A.3.6 serialization = DGGS
-==== A.3.6.1 `/req/geometry-extension/dggs-literal`
-*Requirement*: `/req/geometry-extension/dggs-literal`
+==== A.3.6.1 `georeq:geometry-extension/dggs-literal`
+*Requirement*: `georeq:geometry-extension/dggs-literal`
 All RDFS Literals of type http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`] shall consist of a DGGS geometry serialization formulated according to a specific DGGS literal type identified by a datatype specializing this generic datatype.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -341,8 +341,8 @@ All RDFS Literals of type http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:
 .. *Reference*: <<_dggs_serialization_serializationdggs>>
 .. *Test Type*: Capabilities
 
-==== A.3.6.2 `/req/geometry-extension/dggs-literal-empty`
-*Requirement*: `/req/geometry-extension/dggs-literal-empty`
+==== A.3.6.2 `georeq:geometry-extension/dggs-literal-empty`
+*Requirement*: `georeq:geometry-extension/dggs-literal-empty`
 An empty http://www.opengis.net/ont/geosparql#asDGGS[`geo:dggsLiteral`] shall be interpreted as an empty geometry.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -350,8 +350,8 @@ An empty http://www.opengis.net/ont/geosparql#asDGGS[`geo:dggsLiteral`] shall be
 .. *Reference*: <<_dggs_serialization_serializationdggs>>
 .. *Test Type*: Capabilities
 
-==== A.3.6.3 `/req/geometry-extension/geometry-as-dggs-literal`
-*Requirement*: `/req/geometry-extension/geometry-as-dggs-literal` 
+==== A.3.6.3 `georeq:geometry-extension/geometry-as-dggs-literal`
+*Requirement*: `georeq:geometry-extension/geometry-as-dggs-literal` 
 Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asDGGS[`geo:asDGGS`] to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -359,8 +359,8 @@ Implementations shall allow the RDF property http://www.opengis.net/ont/geosparq
 .. *Reference*: <<_property_geoasdggs>>
 .. *Test Type*: Capabilities
 
-==== A.3.6.4 `/req/geometry-extension/asDGGS-function`
-*Requirement*: `/req/geometry-extension/asDGGS-function` 
+==== A.3.6.4 `georeq:geometry-extension/asDGGS-function`
+*Requirement*: `georeq:geometry-extension/asDGGS-function` 
 Implementations shall support http://www.opengis.net/def/function/geosparql/asDGGS[`geof:asDGGS`], as a SPARQL extension function
 
 .. *Test purpose*: Check conformance with this requirement
@@ -370,11 +370,11 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/asDG
 
 == A.4 Conformance Class: Geometry Topology Extension (relation_family, serialization, version)
 
-*Conformance Class IRI*: `/conf/geometry-topology-extension`
+*Conformance Class IRI*: `geoconf:geometry-topology-extension`
 
 === A.4.1 Tests for all relation families
-==== A.4.1.1 `/conf/geometry-topology-extension/relate-query-function`
-*Requirement*: `/req/geometry-topology-extension/relate-query-function`
+==== A.4.1.1 `geoconf:geometry-topology-extension/relate-query-function`
+*Requirement*: `georeq:geometry-topology-extension/relate-query-function`
 Implementations shall support http://www.opengis.net/def/function/geosparql/relate[`geof:relate`] as a SPARQL extension function, consistent with the relate operator defined in Simple Features <<ISO19125-1>>.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -383,8 +383,8 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/rela
 .. *Test Type*: Capabilities
 
 === A.4.2 relation_family = Simple Features
-==== A.4.2.1 `/conf/geometry-topology-extension/sf-query-functions`
-*Requirement*: `/req/geometry-topology-extension/sf-query-functions`
+==== A.4.2.1 `geoconf:geometry-topology-extension/sf-query-functions`
+*Requirement*: `georeq:geometry-topology-extension/sf-query-functions`
 Implementations shall support http://www.opengis.net/def/function/geosparql/sfEquals[`geof:sfEquals`], http://www.opengis.net/def/function/geosparql/sfDisjoint[`geof:sfDisjoint`], http://www.opengis.net/def/function/geosparql/efIntersects[`geof:sfIntersects`], http://www.opengis.net/def/function/geosparql/sfTouches[`geof:sfTouches`], http://www.opengis.net/def/function/geosparql/sfCrosses[`geof:sfCrosses`], http://www.opengis.net/def/function/geosparql/sfWithin[`geof:sfWithin`], http://www.opengis.net/def/function/geosparql/sfContains[`geof:sfContains`], http://www.opengis.net/def/function/geosparql/sfOverlaps[`geof:sfOverlaps`] as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <<ISO19125-1>>.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -393,8 +393,8 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/sfEq
 .. *Test Type*: Capabilities
 
 === A.4.3 relation_family = Egenhofer
-==== A.4.3.1 `/conf/geometry-topology-extension/eh-query-functions`
-*Requirement*: `/req/geometry-topology-extension/eh-query-functions`
+==== A.4.3.1 `geoconf:geometry-topology-extension/eh-query-functions`
+*Requirement*: `georeq:geometry-topology-extension/eh-query-functions`
 Implementations shall support http://www.opengis.net/def/function/geosparql/ehEquals[`geof:ehEquals`], http://www.opengis.net/def/function/geosparql/ehDisjoint[`geof:ehDisjoint`], http://www.opengis.net/def/function/geosparql/ehMeet[`geof:ehMeet`], http://www.opengis.net/def/function/geosparql/ehOverlap[`geof:ehOverlap`], http://www.opengis.net/def/function/geosparql/ehCovers[`geof:ehCovers`], http://www.opengis.net/def/function/geosparql/ehCoveredBy[`geof:ehCoveredBy`], http://www.opengis.net/def/function/geosparql/ehInside[`geof:ehInside`], http://www.opengis.net/def/function/geosparql/ehContains[`geof:ehContains`] as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features [ISO 19125- 1].
 
 .. *Test purpose*: Check conformance with this requirement
@@ -403,8 +403,8 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/ehEq
 .. *Test Type*: Capabilities
 
 === A.4.4 relation_family = RCC8
-==== A.4.4.1 `/conf/geometry-topology-extension/rcc8-query-functions`
-*Requirement*: `/req/geometry-topology-extension/rcc8-query-functions`
+==== A.4.4.1 `geoconf:geometry-topology-extension/rcc8-query-functions`
+*Requirement*: `georeq:geometry-topology-extension/rcc8-query-functions`
 Implementations shall support http://www.opengis.net/def/function/geosparql/rcc8eq[`geof:rcc8eq`], http://www.opengis.net/def/function/geosparql/rcc8dc[`geof:rcc8dc`], http://www.opengis.net/def/function/geosparql/rcc8ec[`geof:rcc8ec`], http://www.opengis.net/def/function/geosparql/rcc8po[`geof:rcc8po`], http://www.opengis.net/def/function/geosparql/rcc8tppi[`geof:rcc8tppi`], http://www.opengis.net/def/function/geosparql/rcc8tpp[`geof:rcc8tpp`], http://www.opengis.net/def/function/geosparql/rcc8ntpp[`geof:rcc8ntpp`], http://www.opengis.net/def/function/geosparql/rcc8ntppi[`geof:rcc8ntppi`] as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <<ISO19125-1>>.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -414,11 +414,11 @@ Implementations shall support http://www.opengis.net/def/function/geosparql/rcc8
 
 == A.5 Conformance Class: RDFS Entailment Extension (relation_family, serialization, version)
 
-*Conformance Class IRI*: `/conf/rdfs-entailment-extension`
+*Conformance Class IRI*: `geoconf:rdfs-entailment-extension`
 
 === A.5.1 Tests for all implementations
-==== A.5.1.1 `/conf/rdfsentailmentextension/bgp-rdfs-ent`
-*Requirement*: `/req/rdfs-entailment-extension/bgp-rdfs-ent`
+==== A.5.1.1 `geoconf:rdfsentailmentextension/bgp-rdfs-ent`
+*Requirement*: `georeq:rdfs-entailment-extension/bgp-rdfs-ent`
 Basic graph pattern matching shall use the semantics defined by the RDFS Entailment Regime <<SPARQLENT>>.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -427,8 +427,8 @@ Basic graph pattern matching shall use the semantics defined by the RDFS Entailm
 .. *Test Type*: Capabilities
 
 === A.5.2 serialization=WKT
-==== A.5.2.1 `/conf/rdfs-entailment-extension/wkt-geometry-types`
-*Requirement*: `/req/rdfs-entailment-extension/wkt-geometry-types`
+==== A.5.2.1 `geoconf:rdfs-entailment-extension/wkt-geometry-types`
+*Requirement*: `georeq:rdfs-entailment-extension/wkt-geometry-types`
 Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of Simple Features <<ISO19125-1>>.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -437,8 +437,8 @@ Implementations shall support graph patterns involving terms from an RDFS/OWL cl
 .. *Test Type*: Capabilities
 
 === A.5.3 serialization=GML
-==== A.5.3.1 `/conf/rdfs-entailment-extension/gml-geometry-types`
-*Requirement*: `/req/rdfs-entailment-extension/gml-geometry-types` 
+==== A.5.3.1 `geoconf:rdfs-entailment-extension/gml-geometry-types`
+*Requirement*: `georeq:rdfs-entailment-extension/gml-geometry-types` 
 Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the GML schema that implements GM_Object using the specified version of GML <<OGC07-036>>.
 
 .. *Test purpose*: Check conformance with this requirement
@@ -448,11 +448,11 @@ Implementations shall support graph patterns involving terms from an RDFS/OWL cl
 
 == A.6 Conformance Class: Query Rewrite Extension (relation_family, serialization, version)
 
-*Conformance Class IRI*: `/conf/query-rewrite-extension`
+*Conformance Class IRI*: `geoconf:query-rewrite-extension`
 
 === A.6.1 relation_family = Simple Features
-==== A.6.1.1 `/conf/query-rewrite-extension/sf-query-rewrite`
-*Requirement*: `/req/query-rewrite-extension/sf-query-rewrite`
+==== A.6.1.1 `geoconf:query-rewrite-extension/sf-query-rewrite`
+*Requirement*: `georeq:query-rewrite-extension/sf-query-rewrite`
 Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <<SPARQLENT>> for the RIF rules <<RIFCORE>> http://www.opengis.net/def/rule/geosparql/sfEquals[`geor:sfEquals`], http://www.opengis.net/def/rule/geosparql/sfDisjoint[`geor:sfDisjoint`], http://www.opengis.net/def/rule/geosparql/sfIntersects[`geor:sfIntersects`], http://www.opengis.net/def/rule/geosparql/sfTouches[`geor:sfTouches`], http://www.opengis.net/def/rule/geosparql/sfCrosses[`geor:sfCrosses`], http://www.opengis.net/def/rule/geosparql/sfWithin[`geor:sfWithin`], http://www.opengis.net/def/rule/geosparql/sfContains[`geor:sfContains`] and http://www.opengis.net/def/rule/geosparql/sfOverlaps[`geor:sfOverlaps`]..
 
 .. *Test purpose*: Check conformance with this requirement
@@ -461,8 +461,8 @@ Basic graph pattern matching shall use the semantics defined by the RIF Core Ent
 .. *Test Type*: Capabilities
 
 === A.6.2 relation_family = Egenhofer
-==== A.6.2.1 `/conf/query-rewrite-extension/eh-query-rewrite`
-*Requirement*: `/req/query-rewrite-extension/eh-query-rewrite`
+==== A.6.2.1 `geoconf:query-rewrite-extension/eh-query-rewrite`
+*Requirement*: `georeq:query-rewrite-extension/eh-query-rewrite`
 Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <<SPARQLENT>> for the RIF rules <<RIFCORE>> http://www.opengis.net/def/rule/geosparql/ehEquals[`geor:ehEquals`], http://www.opengis.net/def/rule/geosparql/ehDisjoint[`geor:ehDisjoint`], http://www.opengis.net/def/rule/geosparql/ehMeet[`geor:ehMeet`], http://www.opengis.net/def/rule/geosparql/ehOverlap[`geor:ehOverlap`], http://www.opengis.net/def/rule/geosparql/ehCovers[`geor:ehCovers`], http://www.opengis.net/def/rule/geosparql/ehCoveredBy[`geor:ehCoveredBy`], http://www.opengis.net/def/rule/geosparql/ehInside[`geor:ehInside`], http://www.opengis.net/def/rule/geosparql/ehContains[`geor:ehContains`].
 
 .. *Test purpose*: Check conformance with this requirement
@@ -471,8 +471,8 @@ Basic graph pattern matching shall use the semantics defined by the RIF Core Ent
 .. *Test Type*: Capabilities
 
 === A.6.3 relation_family = RCC8
-==== A.6.3.1 `/conf/query-rewrite-extension/rcc8-query-rewrite`
-*Requirement*: `/req/query-rewrite-extension/rcc8-query-rewrite`
+==== A.6.3.1 `geoconf:query-rewrite-extension/rcc8-query-rewrite`
+*Requirement*: `georeq:query-rewrite-extension/rcc8-query-rewrite`
 Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <<SPARQLENT>> for the RIF rules <<RIFCORE>> http://www.opengis.net/def/rule/geosparql/rcc8eq[`geor:rcc8eq`], http://www.opengis.net/def/rule/geosparql/rcc8dc[`geor:rcc8dc`], http://www.opengis.net/def/rule/geosparql/rcc8ec[`geor:rcc8ec`], http://www.opengis.net/def/rule/geosparql/rcc8po[`geor:rcc8po`], http://www.opengis.net/def/rule/geosparql/rcc8tppi[`geor:rcc8tppi`], http://www.opengis.net/def/rule/geosparql/rcc8tpp[`geor:rcc8tpp`], http://www.opengis.net/def/rule/geosparql/rcc8ntpp[`geor:rcc8ntpp`], http://www.opengis.net/def/rule/geosparql/rcc8ntppi[`geor:rcc8ntppi`].
 
 .. *Test purpose*: Check conformance with this requirement


### PR DESCRIPTION
This PR updates the Clause 5 schedule of prefixes & namespaces and introduces them for Requirements Classes, `georeq`, & Conformance Classes `geoconf`.

Until now, the IRIs for Requirements Classes & Conformance Classes  had no scheme (e.g. `http`) or authority (e.g. `opengis.net`).