### PR TITLE
Update geo.ttl to add a base uri statement

### DIFF
--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -1,3 +1,5 @@
+BASE <http://www.opengis.net/def/geosparql/funcsrules> # baseuri added as per issue 147 
+
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX funcs: <http://www.opengis.net/def/function/geosparql/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>

--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -1,15 +1,15 @@
-BASE <http://www.opengis.net/def/geosparql/funcsrules> # baseuri added as per issue 147 
+@base <http://www.opengis.net/def/geosparql/funcsrules> . # baseuri added as per issue 147 
 
-PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX funcs: <http://www.opengis.net/def/function/geosparql/>
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
-PREFIX policy: <http://www.opengis.net/def/metamodel/ogc-na/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX rules: <http://www.opengis.net/def/rule/geosparql/>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX status: <http://www.opengis.net/def/status/>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX geosparql-doc: <http://www.opengis.net/spec/geosparql/1.1/specification.html#> #To be changed once the definitive IRI of the HTML documentation is known.
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix funcs: <http://www.opengis.net/def/function/geosparql/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix policy: <http://www.opengis.net/def/metamodel/ogc-na/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rules: <http://www.opengis.net/def/rule/geosparql/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix status: <http://www.opengis.net/def/status/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix geosparql-doc: <http://www.opengis.net/spec/geosparql/1.1/specification.html#> . #To be changed once the definitive IRI of the HTML documentation is known.
 
 <http://www.opengis.net/def/geosparql/funcsrules> 
     a owl:Ontology , skos:ConceptScheme ;

--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -1,5 +1,4 @@
-@base <http://www.opengis.net/def/geosparql/funcsrules> . # baseuri added as per issue 147 
-
+@base <http://www.opengis.net/def/geosparql/funcsrules> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix funcs: <http://www.opengis.net/def/function/geosparql/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -9,7 +8,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix status: <http://www.opengis.net/def/status/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix geosparql-doc: <http://www.opengis.net/spec/geosparql/1.1/specification.html#> . #To be changed once the definitive IRI of the HTML documentation is known.
+@prefix geosparql-doc: <http://www.opengis.net/spec/geosparql/1.1/specification.html#> . # To be changed once the definitive IRI of the HTML documentation is known.
 
 <http://www.opengis.net/def/geosparql/funcsrules> 
     a owl:Ontology , skos:ConceptScheme ;

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -1,13 +1,13 @@
 # baseURI: http://www.opengis.net/ont/geosparql
 # prefix: geosparql
 
-@base <http://www.opengis.net/ont/geosparql> . # baseuri added as per issue 147 
+@base <http://www.opengis.net/ont/geosparql> .
 
 @prefix : <http://www.opengis.net/ont/geosparql#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix geosparql: <http://www.opengis.net/ont/geosparql> .
 @prefix geosparql-spec: <http://www.opengis.net/spec/geosparql/1.1> .
-@prefix geosparql-doc: <http://www.opengis.net/spec/geosparql/1.1/specification.html#> . #To be changed once the definitive IRI of the HTML documentation is known.
+@prefix geosparql-doc: <http://www.opengis.net/spec/geosparql/1.1/specification.html#> . # To be changed once the definitive IRI of the HTML documentation is known.
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -1,6 +1,8 @@
 # baseURI: http://www.opengis.net/ont/geosparql
 # prefix: geosparql
 
+@base <http://www.opengis.net/ont/geosparql> . # baseuri added as per issue 147 
+
 @prefix : <http://www.opengis.net/ont/geosparql#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix geosparql: <http://www.opengis.net/ont/geosparql> .

--- a/1.1/profile.ttl
+++ b/1.1/profile.ttl
@@ -1,6 +1,4 @@
-# This is a placeholder for a Profile Vocabulary description of GeoSPARQL
-
-@base <http://www.opengis.net/def/geosparql> . # baseuri added as per issue 147 
+@base <http://www.opengis.net/def/geosparql> . 
 
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/1.1/profile.ttl
+++ b/1.1/profile.ttl
@@ -1,4 +1,7 @@
 # This is a placeholder for a Profile Vocabulary description of GeoSPARQL
+
+@base <http://www.opengis.net/def/geosparql> . # baseuri added as per issue 147 
+
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix prof: <http://www.w3.org/ns/dx/prof/> .

--- a/1.1/sa_functions.ttl
+++ b/1.1/sa_functions.ttl
@@ -1,4 +1,4 @@
-@base <http://www.opengis.net/def/geosparql/safuncs> . # baseuri added as per issue 147
+@base <http://www.opengis.net/def/geosparql/safuncs> .
 
 @prefix safuncs: <http://www.opengis.net/def/function/geosparql/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .

--- a/1.1/sa_functions.ttl
+++ b/1.1/sa_functions.ttl
@@ -1,3 +1,5 @@
+@base <http://www.opengis.net/def/geosparql/safuncs> . # baseuri added as per issue 147
+
 @prefix safuncs: <http://www.opengis.net/def/function/geosparql/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/1.1/sf_geometries.ttl
+++ b/1.1/sf_geometries.ttl
@@ -1,3 +1,5 @@
+@base <http://www.opengis.net/ont/sf> . # baseuri added as per issue 147
+
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/1.1/sf_geometries.ttl
+++ b/1.1/sf_geometries.ttl
@@ -1,4 +1,4 @@
-@base <http://www.opengis.net/ont/sf> . # baseuri added as per issue 147
+@base <http://www.opengis.net/ont/sf> .
 
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .


### PR DESCRIPTION
Added @base statement to provide baseuri. Without trailing hash to align with the ontology definition statement. Closes #147 