### PR TITLE
SpatialMeasure props to use SpatialObject not Feature for domain

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -273,7 +273,7 @@
 .
 
 :hasArea a owl:ObjectProperty ;
-	rdfs:domain :Feature ;
+	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialMeasure ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
 	skos:definition """The area of a Feature, expressed as a Spatial Measure."""@en ;
@@ -281,7 +281,7 @@
 .
 
 :hasLength a owl:ObjectProperty ;
-	rdfs:domain :Feature ;
+	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialMeasure ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
 	skos:definition """The length of a one-dimensional Feature or the perimeter length of a two-dimensional Feature, expressed as a Spatial Measure."""@en ;
@@ -305,7 +305,7 @@
 .
 
 :hasVolume a owl:ObjectProperty ;
-	rdfs:domain :Feature ;
+	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialMeasure ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
 	skos:definition """The volume of a three-dimensional Feature, expressed as a Spatial Measure."""@en ;
@@ -608,7 +608,7 @@
 
 :hasMetricLength
 	a owl:DatatypeProperty ;
-	rdfs:domain :Feature ;
+	rdfs:domain :SpatialObject ;
 	rdfs:range xsd:double ;
 	rdfs:isDefinedBy <> , geosparql-spec: ;
 	skos:definition """The length of a Feature in meters."""@en ;
@@ -617,7 +617,7 @@
 
 :hasMetricArea
 	a owl:DatatypeProperty ;
-	rdfs:domain :Feature ;
+	rdfs:domain :SpatialObject ;
 	rdfs:range xsd:double ;
 	rdfs:isDefinedBy <> , geosparql-spec: ;
 	skos:definition """The area of a Feature in square meters."""@en ;
@@ -626,7 +626,7 @@
 
 :hasMetricVolume
 	a owl:DatatypeProperty ;
-	rdfs:domain :Feature ;
+	rdfs:domain :SpatialObject ;
 	rdfs:range xsd:double ;
 	rdfs:isDefinedBy <> , geosparql-spec: ;
 	skos:definition """The volume of a Feature in cubic meters."""@en ;

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -258,7 +258,7 @@
 	rdfs:isDefinedBy <> , geosparql-spec: ;
 	skos:definition """The minimum or smallest bounding or enclosing box of a given feature."""@en ;
 	skos:prefLabel "has bounding box"@en ;
-	skos:scopeNote "The target is a geometry that defines a rectilinear region whose edges are aligned with the axes of the coordinate reference system, which exactly contains the geometry or feature e.g. sf:Envelope."@en ;
+	skos:scopeNote "The target is a geometry that defines a rectilinear region whose edges are aligned with the axes of the coordinate reference system, which exactly contains the Geometry or Feature e.g. sf:Envelope."@en ;
 .
 
 :hasCentroid
@@ -276,7 +276,7 @@
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialMeasure ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
-	skos:definition """The area of a Feature, expressed as a Spatial Measure."""@en ;
+	skos:definition """The area of a Spatial Object, expressed as a Spatial Measure."""@en ;
 	skos:prefLabel "has area"@en ;
 .
 
@@ -284,7 +284,7 @@
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialMeasure ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
-	skos:definition """The length of a one-dimensional Feature or the perimeter length of a two-dimensional Feature, expressed as a Spatial Measure."""@en ;
+	skos:definition """The length of a one-dimensional Spatial Object or the perimeter length of a two-dimensional Spatial Object, expressed as a Spatial Measure."""@en ;
 	skos:prefLabel "has length"@en ;
 .
 
@@ -308,7 +308,7 @@
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialMeasure ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
-	skos:definition """The volume of a three-dimensional Feature, expressed as a Spatial Measure."""@en ;
+	skos:definition """The volume of a three-dimensional Spatial Object, expressed as a Spatial Measure."""@en ;
 	skos:prefLabel "has volume"@en ;
 .	
 
@@ -611,7 +611,7 @@
 	rdfs:domain :SpatialObject ;
 	rdfs:range xsd:double ;
 	rdfs:isDefinedBy <> , geosparql-spec: ;
-	skos:definition """The length of a Feature in meters."""@en ;
+	skos:definition """The length of a Spatial Object in meters."""@en ;
 	skos:prefLabel "has length in meters"@en ;
 .
 
@@ -620,7 +620,7 @@
 	rdfs:domain :SpatialObject ;
 	rdfs:range xsd:double ;
 	rdfs:isDefinedBy <> , geosparql-spec: ;
-	skos:definition """The area of a Feature in square meters."""@en ;
+	skos:definition """The area of a Spatial Object in square meters."""@en ;
 	skos:prefLabel "has area in square meters"@en ;
 .
 
@@ -629,7 +629,7 @@
 	rdfs:domain :SpatialObject ;
 	rdfs:range xsd:double ;
 	rdfs:isDefinedBy <> , geosparql-spec: ;
-	skos:definition """The volume of a Feature in cubic meters."""@en ;
+	skos:definition """The volume of a Spatial Object in cubic meters."""@en ;
 	skos:prefLabel "has volume in cubic meters"@en ;
 .
 

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -223,7 +223,7 @@ The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] is 
 geo:hasLength a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has length"@en ;
-    skos:definition "The length of a Feature, expressed as a Spatial Measure."@en ; 
+    skos:definition "The length of a Spatial Object, expressed as a Spatial Measure."@en ; 
     rdfs:domain :SpatialObject ;
     rdfs:range geo:SpatialMeasure .
 ```
@@ -248,7 +248,7 @@ The property http://www.opengis.net/ont/geosparql#hasMetricLength[`geo:hasMetric
 geo:hasMetricLength a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has length in meters"@en ;
-    skos:definition "The length of a Feature in meters."@en ; 
+    skos:definition "The length of a Spatial Object in meters."@en ; 
     rdfs:domain :SpatialObject ;
     rdfs:range xsd:double .
 ```
@@ -261,7 +261,7 @@ The property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`] is used
 geo:hasArea a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has area"@en ;
-    skos:definition "The two-dimensional area of a Feature, expressed as a Spatial Measure."@en ; 
+    skos:definition "The two-dimensional area of a Spatial Object, expressed as a Spatial Measure."@en ; 
     rdfs:domain :SpatialObject ;
     rdfs:range geo:SpatialMeasure .
 ```
@@ -286,7 +286,7 @@ The property http://www.opengis.net/ont/geosparql#hasMetricArea[`geo:hasMetricAr
 geo:hasMetricArea a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has area in square meters"@en ;
-    skos:definition "The area of a Feature in square meters."@en ; 
+    skos:definition "The area of a Spatial Object in square meters."@en ; 
     rdfs:domain :SpatialObject ;
     rdfs:range xsd:double .
 ```
@@ -298,7 +298,7 @@ The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] is 
 geo:hasVolume a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has volume"@en ;
-    skos:definition "The volume of a Feature, expressed as a 
+    skos:definition "The volume of a Spatial Object, expressed as a 
                     Spatial Measure"@en ; 
     rdfs:domain :SpatialObject ;
     rdfs:range geo:SpatialMeasure .
@@ -324,7 +324,7 @@ The property http://www.opengis.net/ont/geosparql#hasMetricVolume[`geo:hasMetric
 geo:hasMetricVolume a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has volume in cubic meters"@en ;
-    skos:definition "The volume of a Feature in cubic meters."@en ; 
+    skos:definition "The volume of a Spatial Object in cubic meters."@en ; 
     rdfs:domain :SpatialObject ;
     rdfs:range xsd:double .
 ```

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -217,14 +217,14 @@ GeoSPARQL does not restrict the cardinality of the http://www.opengis.net/ont/ge
 
 ==== Property: geo:hasLength
 
-The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] is used to indicate the length of a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`]. In the case of a one-dimensional http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`], it is the simple length. In the case of a two-dimensional http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`], it is interpreted to mean the perimeter length. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the length value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.
+The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] is used to indicate the length of a http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] which could be either a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] or a http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`]. In the case of a one-dimensional http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`], it is the simple length. In the case of a two-dimensional http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`], it is interpreted to mean the perimeter length. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the length value expressed as a scalar quantity and also other properties as needed by the measurement system used, such as units of measure. Uncertainty and other properties may be included also.
 
 ```turtle
 geo:hasLength a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has length"@en ;
     skos:definition "The length of a Feature, expressed as a Spatial Measure."@en ; 
-    rdfs:domain geo:Feature ; 
+    rdfs:domain :SpatialObject ;
     rdfs:range geo:SpatialMeasure .
 ```
 
@@ -249,20 +249,20 @@ geo:hasMetricLength a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has length in meters"@en ;
     skos:definition "The length of a Feature in meters."@en ; 
-    rdfs:domain geo:Feature ; 
+    rdfs:domain :SpatialObject ;
     rdfs:range xsd:double .
 ```
 
 ==== Property: geo:hasArea
 
-The property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`] is used to indicate the area of a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`]. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the area value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.
+The property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`] is used to indicate the area of a http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] which could be either a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] or a http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`]. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the length value expressed as a scalar quantity and also other properties as needed by the measurement system used, such as units of measure. Uncertainty and other properties may be included also.
 
 ```turtle
 geo:hasArea a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has area"@en ;
     skos:definition "The two-dimensional area of a Feature, expressed as a Spatial Measure."@en ; 
-    rdfs:domain geo:Feature ; 
+    rdfs:domain :SpatialObject ;
     rdfs:range geo:SpatialMeasure .
 ```
 
@@ -287,21 +287,20 @@ geo:hasMetricArea a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has area in square meters"@en ;
     skos:definition "The area of a Feature in square meters."@en ; 
-    rdfs:domain geo:Feature ; 
+    rdfs:domain :SpatialObject ;
     rdfs:range xsd:double .
 ```
 
 ==== Property: geo:hasVolume
 
-The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] is used to indicate the volume of a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`]. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the volume value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.
-
+The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] is used to indicate the volume of a http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] which could be either a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] or a http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`]. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the length value expressed as a scalar quantity and also other properties as needed by the measurement system used, such as units of measure. Uncertainty and other properties may be included also.
 ```turtle
 geo:hasVolume a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has volume"@en ;
     skos:definition "The volume of a Feature, expressed as a 
                     Spatial Measure"@en ; 
-    rdfs:domain geo:Feature ; 
+    rdfs:domain :SpatialObject ;
     rdfs:range geo:SpatialMeasure .
 ```
 
@@ -326,7 +325,7 @@ geo:hasMetricVolume a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has volume in cubic meters"@en ;
     skos:definition "The volume of a Feature in cubic meters."@en ; 
-    rdfs:domain geo:Feature ; 
+    rdfs:domain :SpatialObject ;
     rdfs:range xsd:double .
 ```
 

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -223,7 +223,7 @@ The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] is 
 geo:hasLength a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has length"@en ;
-    skos:definition "The length of a Spatial Object, expressed as a Spatial Measure."@en ; 
+    skos:definition "The length of a one-dimensional Spatial Object or the perimeter length of a two-dimensional Spatial Object, expressed as a Spatial Measure."@en ; 
     rdfs:domain :SpatialObject ;
     rdfs:range geo:SpatialMeasure .
 ```
@@ -294,6 +294,7 @@ geo:hasMetricArea a rdf:Property, owl:DatatypeProperty ;
 ==== Property: geo:hasVolume
 
 The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] is used to indicate the volume of a http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] which could be either a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] or a http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`]. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the length value expressed as a scalar quantity and also other properties as needed by the measurement system used, such as units of measure. Uncertainty and other properties may be included also.
+
 ```turtle
 geo:hasVolume a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;

--- a/1.1/spec/17-Annex-B.adoc
+++ b/1.1/spec/17-Annex-B.adoc
@@ -17,36 +17,39 @@ _New Features checklist - to be removed when all examples are complete:_
 
 === B.1.1 Classes
 
-==== B 1.1.1 `SpatialObject`
+==== B.1.1.1 `SpatialObject`
 The `SpatialObject` class is defined in <<Class: geo:SpatialObject>>.
 
 Basic use (as per the example in the class definition)
 
 ```turtle
-eg:x a geo:SpatialObject ;
+eg:x 
+    a geo:SpatialObject ;
     skos:prefLabel "Object X";
 .
 ```
 
 NOTE: It is unlikely that users of GeoSPARQL will create many instances of http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] as its two more concrete subclasses, http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] & http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`], are more directly relatable to real-world phenomena and use.
 
-==== B 1.1.2 `Feature`
+==== B.1.1.2 `Feature`
 The `Feature` class is defined in <<Class: geo:Feature>>.
 
-===== B 1.1.2.1 Basic use
+===== B.1.1.2.1 Basic use
 
 ```turtle
-eg:x a geo:Feature ;
+eg:x 
+    a geo:Feature ;
     skos:prefLabel "Feature X";
 .
 ```
 
 Here a `Feature` is declared and given a preferred label.
 
-===== B 1.1.2.2 A `Feature` related to a `Geometry`
+===== B.1.1.2.2 A `Feature` related to a `Geometry`
 
 ```turtle
-eg:x a geo:Feature ;
+eg:x 
+    a geo:Feature ;
     skos:prefLabel "Feature X";
     geo:hasGeometry [
         geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
@@ -56,12 +59,13 @@ eg:x a geo:Feature ;
 
 Here a `Feature` is declared, given a preferred label and a geometry for that `Feature` is indicated with the use of http://www.opengis.net/ont/geosparql#hasGeometry[`geo:hasGeometry`]. The `Geometry` indicated is described using a _Well-Known Text_ literal value, indicated by the property http://www.opengis.net/ont/geosparql#asWKT[`geo:asWKT`] and the literal type `geo:wktLiteral`.
 
-===== B 1.1.2.3 `Feature` with both `Geometry` and `SpatialMeasure` instances indicated
+===== B.1.1.2.3 `Feature` with both `Geometry` and `SpatialMeasure` instances indicated
 
 ```turtle
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 
-eg:x a geo:Feature ;
+eg:x 
+    a geo:Feature ;
     skos:prefLabel "Feature X";
         geo:hasGeometry [
             geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
@@ -78,11 +82,11 @@ Here a `Feature` and a `Geometry` are described as per the previous example but 
 
 Note that in this example, the use of QUDT and its http://qudt.org/schema/qudt#numericValue[`qudt:numericValue`] & http://qudt.org/schema/qudt#numericValue[`qudt:unit`] is just one of many possible ways to convey a `SpatialMeasure` instance's value.
 
-===== B 1.1.2.4 `Feature` with metric area
-
+===== B.1.1.2.4 `Feature` with metric area
 
 ```turtle
-eg:x a geo:Feature ;
+eg:x 
+    a geo:Feature ;
     skos:prefLabel "Feature X";
         geo:hasGeometry [
             geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
@@ -92,12 +96,13 @@ eg:x a geo:Feature ;
 ```
 This example encodes the same data as the example above (B 1.1.2.3), but it uses the simpler metric expression of area.
 
-===== B 1.1.2.5 `Feature` with two different `Geometry` instances indicated
+===== B.1.1.2.5 `Feature` with two different `Geometry` instances indicated
 
 ```turtle
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 
-eg:x a geo:Feature ;
+eg:x 
+    a geo:Feature ;
     skos:prefLabel "Feature X";
     geo:hasGeometry [
         rdfs:label "Official boundary" ;
@@ -114,12 +119,13 @@ eg:x a geo:Feature ;
 
 In this example, `Feature X` has two different `Geometry` instances indicated with their different explained in annotation properties. No ontology properties are used to indicate a difference in these `Geometry` thus machine use of this `Feature` woud not be easily able to differentiate them.
 
-===== B 1.1.2.6 `Feature` with two different `Geometry` instances with different property values
+===== B.1.1.2.6 `Feature` with two different `Geometry` instances with different property values
 
 ```turtle
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 
-eg:x a geo:Feature ;
+eg:x 
+    a geo:Feature ;
     skos:prefLabel "Feature X";
     geo:hasGeometry [
         geo:hasSpatialResolution [
@@ -142,10 +148,11 @@ In this example, `Feature X` has two different `Geometry` instances indicated wi
 
 Machine use of this `Feature` would be able to differentiate the two `Geometry` instnaces based on this use of http://www.opengis.net/ont/geosparql#hasSpatialResolution[`geo:hasSpatialResolution`].
 
-===== B 1.1.2.7 `Feature` with two different `Geometry` instances using metric spatial resolution
+===== B.1.1.2.7 `Feature` with two different `Geometry` instances using metric spatial resolution
 
 ```turtle
-eg:x a geo:Feature ;
+eg:x 
+    a geo:Feature ;
     skos:prefLabel "Feature X";
     geo:hasGeometry [
         geo:hasMetricSpatialResolution "100"^^xsd:double ;
@@ -160,10 +167,11 @@ eg:x a geo:Feature ;
 
 This example encodes the same data as the example above (B 1.1.2.7), but uses the simpler metric property to indicate spatial resolution.
 
-===== B 1.1.2.8 `Feature` with two different types of `Geometry` instances
+===== B.1.1.2.8 `Feature` with two different types of `Geometry` instances
 
 ```turtle
-eg:x a geo:Feature ;
+eg:x 
+    a geo:Feature ;
     skos:prefLabel "Feature X";
     geo:hasGeometry [
         geo:asWKT "POLYGON ((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610))"^^geo:wktLiteral ;
@@ -179,7 +187,7 @@ Here a `Feature` instance has two geometries, one indicated with the general pro
 ==== B.1.1.3 `Geometry`
 The `Geometry` class is defined in <<Class: geo:Geometry>>.
 
-===== B1.1.3.1 Basic Use
+===== B.1.1.3.1 Basic Use
 
 ```turtle
 eg:y a geo:Geometry ;
@@ -201,7 +209,7 @@ From GeoSPARQL 1.0 use, the most commonly observed use of a `Geometry` is in rel
 
 Here the `Geometry` instance has data in WKT form and, since no CRS is declared, WGS84 is the assumed, default, CRS.
 
-===== B1.1.3.2 A `Geometry` with multiple serializations
+===== B.1.1.3.2 A `Geometry` with multiple serializations
 
 ```turtle
 eg:x
@@ -216,10 +224,29 @@ eg:x
 
 Here a single `Geometry`, linked to a `Feature` instance, is expressed using two different serializations: Well-known Text and the AusPIX DGGS.
 
-==== B 1.1.4 `SpatialMeasure`
+===== B.1.1.3.3 `Geometry` with Spatial Measure property
+
+```turtle
+eg:x 
+    a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry eg:x-geo ;    
+.
+
+eg:x-geo
+    a geo:Geometry ;
+    geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
+    geo:hasMetricArea "8.7E4"^^xsd:double;
+.
+```
+This example shows a Feature, `eg:x`, with a Geometry, `eg:x-geo`, which has both a serilization (WKT) and a scalar area. While it is entirely possible that scalar areas can be calculated from polygons, it may be efficient to store a scalar area in addition to the polygon. Perhaps it's a detailed polygon and a one-time calculation with results stored is efficient for repeated use.
+
+This use of a Spatial Measure property with a Geometry, here `geo:hasMetricArea`, is possible since the domain of such properties is `geo:SpatialObject`, the superclass of both `geo:Feature` and `geo:Geometry`.
+
+==== B.1.1.4 `SpatialMeasure`
 The `SpatialMeasure` class is defined in <<Class: geo:SpatialMeasure>>.
 
-===== B1.1.4.1 Basic Use
+===== B.1.1.4.1 Basic Use
 
 ```turtle
 @prefix qudt: <http://qudt.org/schema/qudt/> .
@@ -250,7 +277,7 @@ eg:x
 
 In this example, the `SpatialMeasure` instance has no label - only a numeric value and a unit of measure - but it is declared to be the area for "Feature X".
 
-===== B1.1.4.1 Multiple measures
+===== B.1.1.4.1 Multiple measures
 
 ```turtle
 @prefix qudt: <http://qudt.org/schema/qudt/> .
@@ -834,8 +861,6 @@ _New Features checklist - to be removed when all examples are complete:_
 |asGeoJSON function | <<Function: geof:asGeoJSON>>
 |asKML function | <<Function: geof:asKML>>
 |===
-
-==== B.1.2.2.1 `geof:asWKT`
 
 For the geometry literal values in <<B.1.2.3 Geometry Serializations>>:
 


### PR DESCRIPTION
This PR was motivated by the Issue raised in the last meeting about the domain of Spatial Measure properties.

Closes Issue #178 