### PR TITLE
RDFS members

### DIFF
--- a/1.1/spec/01-Preamble.adoc
+++ b/1.1/spec/01-Preamble.adoc
@@ -10,9 +10,9 @@ The GeoSPARQL standard defines:
 * a set of RIF rules, and
 * SHACL shapes for RDF data validation
 
-This document has the role of _specification_ and authoratitivly defines many of the standard's elements, including the ontology, SPRQL functions and function and rule vocabularies. Complete descriptions of the standard's parts and their roles are given in the Introduction in the section <<GeoSPARQL Standard structure>>.
+This document has the role of _specification_ and authoritatively defines many of the standard's elements, including the ontology classes and properties, SPARQL functions and function and rule vocabulary concepts. Complete descriptions of the standard's parts and their roles are given in the Introduction in the section <<GeoSPARQL Standard structure>>.
 
-== ii.   Submitting organizations
+== ii. Submitting organizations
 The following organizations submitted this Implementation Specification to the Open Geospatial Consortium Inc.:
 
 [loweralpha]
@@ -47,7 +47,7 @@ All questions regarding this submission should be directed to the editor or the 
 | Simon J.D. Cox | CSIRO
 |===
 
-== iv.  Revision history
+== iv. Revision history
 
 |===
 |Date | Release | Author | Paragraph modified | Description
@@ -132,7 +132,7 @@ These new ontology elements and new functions are normatively defined in this sp
 |Union | <<Function: geoaf:Union>>
 |===
 
-== v.   Changes to the OGC® Abstract Specification
+== v. Changes to the OGC® Abstract Specification
 The OGC® Abstract Specification does not require changes to accommodate this OGC® standard.
 
 == Foreword

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -11,16 +11,17 @@ This clause establishes the *core* requirements class, with IRI `/req/core`, whi
 
 === Classes
 
-Three main classes are defined: http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`], http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`], and http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`]. The class http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] is equivalent to the UML class `Feature` defined in <<ISO19109>>.
+Three main classes are defined: <<Class: geo:SpatialObject, Spatial Object>>, <<Class: geo:Feature, Feature>>, and <<Class: geo:SpatialMeasure, Spatial Measure>>. The class <<Class: geo:Feature, Feature>> is equivalent to the UML class `Feature` defined in <<ISO19109>>.
 
-Two container classes are defined: http://www.opengis.net/ont/geosparql#SpatialObjectCollection[`geo:SpatialObjectCollection`] and http://www.opengis.net/ont/geosparql#FeatureCollection[`geo:FeatureCollection`]. 
+Two container classes are defined: <<Class: geo:SpatialObjectCollection, Spatial Object Collection>> and <<Class: geo:FeatureCollection, Feature Collection>>. 
 
 ==== Class: geo:SpatialObject
 
-The class http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] is defined by the following:
+The class http://www.opengis.net/ont/geosparql#SpatialObject[geo:SpatialObject] is defined by the following:
 
 ```turtle
-geo:SpatialObject a rdfs:Class, owl:Class ;
+geo:SpatialObject 
+    a rdfs:Class, owl:Class ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "Spatial Object"@en ;
     skos:definition "The class Spatial Object represents everything that can 
@@ -29,24 +30,26 @@ geo:SpatialObject a rdfs:Class, owl:Class ;
 ```
 
 |===
-| *Req 2* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] to be used in SPARQL graph patterns.
+| *Req 2* Implementations shall allow the RDFS class <<Class: geo:SpatialObject, Spatial Object>> to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.0/req/core/spatial-object-class[`http://www.opengis.net/spec/geosparql/1.0/req/core/spatial-object-class`]
 |===
 
 *Example:*
 
 ```turtle
-eg:x a geo:SpatialObject ;
+eg:x 
+    a geo:SpatialObject ;
      skos:prefLabel "Object X";
 .
 ```
 
 ==== Class: geo:Feature
 
-The class http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] is equivalent to the class `GFI_Feature` <<ISO19156>> and is defined by the following:
+The class http://www.opengis.net/ont/geosparql#Feature[geo:Feature] is equivalent to the class `GFI_Feature` <<ISO19156>> and is defined by the following:
 
 ```turtle
-geo:Feature a rdfs:Class, owl:Class ;
+geo:Feature 
+    a rdfs:Class, owl:Class ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "Feature"@en ;
     rdfs:subClassOf geo:SpatialObject ;
@@ -57,16 +60,17 @@ geo:Feature a rdfs:Class, owl:Class ;
 ```
 
 |===
-| *Req 3* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] to be used in SPARQL graph patterns.
+| *Req 3* Implementations shall allow the RDFS class <<Class: geo:Feature, Feature>> to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.0/req/core/feature-class[`http://www.opengis.net/spec/geosparql/1.0/req/core/feature-class`]
 |===
 
 ==== Class: geo:SpatialMeasure
 
-The class http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`] is defined by the following:
+The class http://www.opengis.net/ont/geosparql#SpatialMeasure[geo:SpatialMeasure] is defined by the following:
 
 ```turtle
-geo:SpatialMeasure a rdfs:Class, owl:Class ;
+geo:SpatialMeasure 
+    a rdfs:Class, owl:Class ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "Spatial Measure"@en ;
     skos:definition "This class represents a measurement of some dimension 
@@ -76,55 +80,56 @@ geo:SpatialMeasure a rdfs:Class, owl:Class ;
 NOTE: Properties for Spatial Measure may need to indicate a use a unit of measure. When they do, OGC recommended units of measure vocabularies should be used. See the OGC Definitions Serverfootnote:[https://www.ogc.org/def-server].
 
 |===
-| *Req 4* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`] to be used in SPARQL graph patterns.
+| *Req 4* Implementations shall allow the RDFS class <<Class: geo:SpatialMeasure, Spatial Measure>> to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-measure-class[`http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-measure-class`]
 |===
 
 ==== Class: geo:SpatialObjectCollection
 
-The class http://www.opengis.net/ont/geosparql#SpatialObjectCollection[`geo:SpatialObjectCollection`] is defined by the following:
+The class http://www.opengis.net/ont/geosparql#SpatialObjectCollection[geo:SpatialObjectCollection] is defined by the following:
 
 ```turtle
 geo:SpatialObjectCollection
-  rdf:type owl:Class ;
+  a owl:Class ;
   rdfs:subClassOf rdfs:Container ;
   rdfs:subClassOf [
-      rdf:type owl:Restriction ;
+      a owl:Restriction ;
       owl:allValuesFrom geo:SpatialObject ;
       owl:onProperty rdfs:member ;
     ] ;
   skos:prefLabel "Collection of spatial objects" ;
-  skos:definition """The class Spatial Object Collection represents any collection of things that can 
-                    have a spatial representation. It is superclass of Feature Collection
-                    and Geometry Collection""" ;
+  skos:definition "The class Spatial Object Collection represents any collection of things that can 
+                  have a spatial representation. It is superclass of Feature Collection
+                  and Geometry Collection."@en ;
 .
 ```
 
 |===
-| *Req 5* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#SpatialObjectCollection[`geo:SpatialObjectCollection`] to be used in SPARQL graph patterns.
+| *Req 5* Implementations shall allow the RDFS class <<Class: geo:SpatialObjectCollection, Spatial Object Collection>> to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-object-collection-class[`http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-object-collection-class`]
 |===
 
 ==== Class: geo:FeatureCollection
 
-The class http://www.opengis.net/ont/geosparql#FeatureCollection[`geo:FeatureCollection`] is defined by the following:
+The class http://www.opengis.net/ont/geosparql#FeatureCollection[geo:FeatureCollection] is defined by the following:
 
 ```turtle
 geo:FeatureCollection
-  rdf:type owl:Class ;
+  a owl:Class ;
   rdfs:subClassOf geo:SpatialObjectCollection ;
   rdfs:subClassOf [
-      rdf:type owl:Restriction ;
+      a owl:Restriction ;
       owl:allValuesFrom :Feature ;
       owl:onProperty rdfs:member ;
     ] ;
   skos:prefLabel "Collection of geospatial features" ;
-  skos:definition "The class Feature Collection represents any collection of individual Features. " ;
+  skos:definition "The class Feature Collection represents 
+                  any collection of individual Features."@en ;
 .
 ```
 
 |===
-| *Req 6* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#FeatureCollection[`geo:FeatureCollection`] to be used in SPARQL graph patterns.
+| *Req 6* Implementations shall allow the RDFS class <<Class: geo:FeatureCollection, Feature Collection>> to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.1/req/core/feature-collection-class[`http://www.opengis.net/spec/geosparql/1.1/req/core/feature-collection-class`]
 |===
 
@@ -137,8 +142,8 @@ _To be defined_
 Properties are defined for associating geometries with features.
 
 |===
-| *Req 7* Implementations shall allow the properties http://www.opengis.net/ont/geosparql#hasGeometry[`geo:hasGeometry`], 
-http://www.opengis.net/ont/geosparql#hasDefaultGeometry[`geo:hasDefaultGeometry`], http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`], http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`], http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] http://www.opengis.net/ont/geosparql#hasCentroid[`geo:hasCentroid`], http://www.opengis.net/ont/geosparql#hasBoundingBox[`geo:hasBoundingBox`] and http://www.opengis.net/ont/geosparql#hasSpatialResolution[`geo:hasSpatialResolution`] to be used in SPARQL graph patterns.
+| *Req 7* Implementations shall allow the properties <<Property: geo:hasGeometry, has geometry>>, 
+<<Property: geo:hasDefaultGeometry, has default geometry>>, <<Property: geo:hasLength, has length>>, <<Property: geo:hasArea, has area>>, <<Property: geo:hasVolume, has volume>> <<Property: geo:hasCentroid, has centroid>>, <<Property: geo:hasBoundingBox, has bounding box>> and <<Property: geo:hasSpatialResolution, has spatial resolution>> to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties[`http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties`]
 |===
 
@@ -147,7 +152,8 @@ http://www.opengis.net/ont/geosparql#hasDefaultGeometry[`geo:hasDefaultGeometry`
 The property http://www.opengis.net/ont/geosparql#hasGeometry[`geo:hasGeometry`] is used to link a feature with a geometry that represents its spatial extent. A given feature may have many associated geometries.
 
 ```turtle
-geo:hasGeometry a rdf:Property, owl:ObjectProperty ;
+geo:hasGeometry 
+    a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has Geometry"@en ;
     skos:definition "A spatial representation for a given feature."@en ;     
@@ -160,17 +166,18 @@ geo:hasGeometry a rdf:Property, owl:ObjectProperty ;
 The property http://www.opengis.net/ont/geosparql#hasDefaultGeometry[`geo:hasDefaultGeometry`] is used to link a feature with its default geometry. The default geometry is the geometry that should be used for spatial calculations in the absence of a request for a specific geometry (e.g. in the case of query rewrite).
 
 ```turtle
-geo:hasDefaultGeometry a rdf:Property, owl:ObjectProperty ;
+geo:hasDefaultGeometry 
+    a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has Default Geometry"@en ;
     skos:definition "The default geometry to be used in spatial calculations, 
-                 usually the most detailed geometry."@en ; 
+                    usually the most detailed geometry."@en ; 
     rdfs:subPropertyOf geo:hasGeometry;
     rdfs:domain geo:Feature; 
     rdfs:range geo:Geometry .
 ```
 
-GeoSPARQL does not restrict the cardinality of the http://www.opengis.net/ont/geosparql#hasDefaultGeometry[`geo:hasDefaultGeometry`] property. It is thus possible for a feature to have more than one distinct default geometry or to have no default geometry. This situation does not result in a query processing error; SPARQL graph pattern matching simply proceeds as normal. Certain queries may, however, give logically inconsistent results. For example, if a feature `my:f1` has two asserted default geometries, and those two geometries are disjoint polygons, the query below could return a non-zero count on a system supporting the GeoSPARQL Query Rewrite Extension (rule http://www.opengis.net/def/rule/geosparql/sfDisjoint[`geor:sfDisjoint`]).
+GeoSPARQL does not restrict the cardinality of the <<Property: geo:hasDefaultGeometry, has default geometry>> property. It is thus possible for a feature to have more than one distinct default geometry or to have no default geometry. This situation does not result in a query processing error; SPARQL graph pattern matching simply proceeds as normal. Certain queries may, however, give logically inconsistent results. For example, if a feature `my:f1` has two asserted default geometries, and those two geometries are disjoint polygons, the query below could return a non-zero count on a system supporting the GeoSPARQL Query Rewrite Extension (rule http://www.opengis.net/def/rule/geosparql/sfDisjoint[`geor:sfDisjoint`]).
 
 ```sparql
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
@@ -179,48 +186,54 @@ SELECT (COUNT(*) AS ?cnt)
 WHERE { :f1 geo:sfDisjoint :f1 }
 ```
 
-Such cases are application-specific data modeling errors and are therefore outside of the scope of the GeoSPARQL specification., however it is recommended that multiple geometries indicated with http://www.opengis.net/ont/geosparql#hasDefaultGeometry[`geo:hasDefaultGeometry`] should be differentiated by `Geometry` class properties, perhaps relating to precision, SRS etc.
+Such cases are application-specific data modeling errors and are therefore outside of the scope of the GeoSPARQL specification., however it is recommended that multiple geometries indicated with <<Property: geo:hasDefaultGeometry, has default geometry>> should be differentiated by `Geometry` class properties, perhaps relating to precision, SRS etc.
 
 ==== Property: geo:hasBoundingBox
 
 The property http://www.opengis.net/ont/geosparql#hasBoundingBox[`geo:hasBoundingBox`] is used to link a feature with a simplified geometry-representation corresponding to the envelope of its geometry. Bounding-boxes are typically uses in indexing and discovery.
 
 ```turtle
-geo:hasBoundingBox a rdf:Property, owl:ObjectProperty ;
+geo:hasBoundingBox 
+    a rdf:Property, owl:ObjectProperty ;
     rdfs:subPropertyOf geo:hasGeometry;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has bounding box"@en ;
     skos:definition "The minimum or smallest bounding or enclosing box of a given feature."@en ; 
-    skos:scopeNote "The target is a geometry that defines a rectilinear region whose edges are aligned with the axes of the coordinate reference system, which exactly contains the geometry or feature e.g. sf:Envelope"@en ;
+    skos:scopeNote "The target is a geometry that defines a rectilinear region whose edges are 
+                    aligned with the axes of the coordinate reference system, which exactly 
+                    contains the geometry or feature e.g. sf:Envelope"@en ;
     rdfs:domain geo:Feature ;      
     rdfs:range geo:Geometry .
 ```
 
-GeoSPARQL does not restrict the cardinality of the http://www.opengis.net/ont/geosparql#hasBoundingBox[`geo:hasBoundingBox`] property. A feature may be associated with more than one bounding-box, for example in different coordinate reference systems.
+GeoSPARQL does not restrict the cardinality of the <<Property: geo:hasBoundingBox, has bounding box>> property. A feature may be associated with more than one bounding-box, for example in different coordinate reference systems.
 
 ==== Property: geo:hasCentroid
 
 The property http://www.opengis.net/ont/geosparql#hasCentroid[`geo:hasCentroid`] is used to link a feature with a point geometry corresponding with the centroid of its geometry. The centroid is typically used to show location on a low-resolution image, and for some indexing and discovery functions. 
 
 ```turtle
-geo:hasCentroid a rdf:Property, owl:ObjectProperty ;
+geo:hasCentroid 
+    a rdf:Property, owl:ObjectProperty ;
     rdfs:subPropertyOf geo:hasGeometry;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has centroid"@en ;
-    skos:definition "The arithmetic mean position of all the geometry points of a given feature."@en ; 
+    skos:definition "The arithmetic mean position of all the geometry points 
+                    of a given feature."@en ; 
     skos:scopeNote "The target geometry shall describe a point, e.g. sf:Point"@en ;
     rdfs:domain geo:Feature ;     
     rdfs:range geo:Geometry .
 ```
 
-GeoSPARQL does not restrict the cardinality of the http://www.opengis.net/ont/geosparql#hasCentroid[`geo:hasCentroid`] property. A feature may be associated with more than one centroid, for example computed using different rules or in different coordinate reference systems.
+GeoSPARQL does not restrict the cardinality of the <<Property: geo:hasCentroid, has centroid>> property. A feature may be associated with more than one centroid, for example computed using different rules or in different coordinate reference systems.
 
 ==== Property: geo:hasLength
 
-The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] is used to indicate the length of a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`]. In the case of a one-dimensional http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`], it is the simple length. In the case of a two-dimensional http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`], it is interpreted to mean the perimeter length. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the length value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.
+The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] is used to indicate the length of a <<Class: geo:Feature, Feature>>. In the case of a one-dimensional <<Class: geo:Feature, Feature>>, it is the simple length. In the case of a two-dimensional <<Class: geo:Feature, Feature>>, it is interpreted to mean the perimeter length. The range of the property is <<Class: geo:SpatialMeasure, Spatial Measure>>, which encodes the length value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.
 
 ```turtle
-geo:hasLength a rdf:Property, owl:ObjectProperty ;
+geo:hasLength 
+    a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has length"@en ;
     skos:definition "The length of a Feature, expressed as a Spatial Measure."@en ; 
@@ -228,7 +241,7 @@ geo:hasLength a rdf:Property, owl:ObjectProperty ;
     rdfs:range geo:SpatialMeasure .
 ```
 
-TIP: A consistency check can be applied to geometries indicating both this property and the http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`] property: if supplied, the http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`] property's range value must be the literal integer  1 or 2. The following SPARQL query will return `true` if applied to a graph where is not always the case for all geometries:
+TIP: A consistency check can be applied to geometries indicating both this property and the <<Property: geo:dimension, dimension>> property: if supplied, the <<Property: geo:dimension, dimension>> property's range value must be the literal integer  1 or 2. The following SPARQL query will return `true` if applied to a graph where is not always the case for all geometries:
 
 ```sparql
     PREFIX geo: <http://www.opengis.net/ont/geosparql#>
@@ -242,10 +255,11 @@ TIP: A consistency check can be applied to geometries indicating both this prope
 ```
 
 ==== Property: geo:hasMetricLength
-The property http://www.opengis.net/ont/geosparql#hasMetricLength[`geo:hasMetricLength`] is similar to http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`], but is easier to specify and use because the unit is always meter (the standard length unit of the International System of Units).
+The property http://www.opengis.net/ont/geosparql#hasMetricLength[`geo:hasMetricLength`] is similar to <<Property: geo:hasLength, has length>>, but is easier to specify and use because the unit is always meter (the standard length unit of the International System of Units).
 
 ```turtle
-geo:hasMetricLength a rdf:Property, owl:DatatypeProperty ;
+geo:hasMetricLength 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has length in meters"@en ;
     skos:definition "The length of a Feature in meters."@en ; 
@@ -255,10 +269,11 @@ geo:hasMetricLength a rdf:Property, owl:DatatypeProperty ;
 
 ==== Property: geo:hasArea
 
-The property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`] is used to indicate the area of a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`]. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the area value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.
+The property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`] is used to indicate the area of a <<Class: geo:Feature, Feature>>. The range of the property is <<Class: geo:SpatialMeasure, Spatial Measure>>, which encodes the area value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.
 
 ```turtle
-geo:hasArea a rdf:Property, owl:ObjectProperty;
+geo:hasArea 
+    a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has area"@en ;
     skos:definition "The two-dimensional area of a Feature, expressed as a Spatial Measure."@en ; 
@@ -266,7 +281,7 @@ geo:hasArea a rdf:Property, owl:ObjectProperty;
     rdfs:range geo:SpatialMeasure .
 ```
 
-TIP: A consistency check can be applied to geometries indicating both this property and the http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`] property: if supplied, the http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`] property's range value must be the literal integer 2. The following SPARQL query will return `true` if applied to a graph where is not always the case for all geometries:
+TIP: A consistency check can be applied to geometries indicating both this property and the <<Property: geo:dimension, dimension>> property: if supplied, the <<Property: geo:dimension, dimension>> property's range value must be the literal integer 2. The following SPARQL query will return `true` if applied to a graph where is not always the case for all geometries:
 
 ```sparql
     PREFIX geo: <http://www.opengis.net/ont/geosparql#>
@@ -280,10 +295,11 @@ TIP: A consistency check can be applied to geometries indicating both this prope
 ```
 
 ==== Property: geo:hasMetricArea
-The property http://www.opengis.net/ont/geosparql#hasMetricArea[`geo:hasMetricArea`] is similar to http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`], but is easier to specify and use because the unit is always square meter (the standard area unit of the International System of Units).
+The property http://www.opengis.net/ont/geosparql#hasMetricArea[`geo:hasMetricArea`] is similar to <<Property: geo:hasArea, has area>>, but is easier to specify and use because the unit is always square meter (the standard area unit of the International System of Units).
 
 ```turtle
-geo:hasMetricArea a rdf:Property, owl:DatatypeProperty ;
+geo:hasMetricArea 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has area in square meters"@en ;
     skos:definition "The area of a Feature in square meters."@en ; 
@@ -293,19 +309,20 @@ geo:hasMetricArea a rdf:Property, owl:DatatypeProperty ;
 
 ==== Property: geo:hasVolume
 
-The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] is used to indicate the volume of a http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`]. The range of the property is http://www.opengis.net/ont/geosparql#SpatialMeasure[`geo:SpatialMeasure`], which encodes the volume value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.
+The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] is used to indicate the volume of a <<Class: geo:Feature, Feature>>. The range of the property is <<Class: geo:SpatialMeasure, Spatial Measure>>, which encodes the volume value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.
 
 ```turtle
-geo:hasVolume a rdf:Property, owl:ObjectProperty;
+geo:hasVolume 
+    a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has volume"@en ;
-    skos:definition "The volume of a Feature, expressed as a 
-                    Spatial Measure"@en ; 
+    skos:definition "The volume of a Feature, expressed as a Spatial Measure"@en ; 
     rdfs:domain geo:Feature ; 
-    rdfs:range geo:SpatialMeasure .
+    rdfs:range geo:SpatialMeasure ;
+.
 ```
 
-TIP: A consistency check can be applied to geometries indicating both this property and the http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`] property: if supplied, the http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`] property's range value must be the literal integer 3. The following SPARQL query will return `true` if applied to a graph where is not always the case for all geometries:
+TIP: A consistency check can be applied to geometries indicating both this property and the <<Property: geo:dimension, dimension>> property: if supplied, the <<Property: geo:dimension, dimension>> property's range value must be the literal integer 3. The following SPARQL query will return `true` if applied to a graph where is not always the case for all geometries:
 
 ```sparql
     PREFIX geo: <http://www.opengis.net/ont/geosparql#>
@@ -319,10 +336,11 @@ TIP: A consistency check can be applied to geometries indicating both this prope
 ```
 
 ==== Property: geo:hasMetricVolume
-The property http://www.opengis.net/ont/geosparql#hasMetricVolume[`geo:hasMetricVolume`] is similar to http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`], but is easier to specify and use because the unit is always cubic meter (the standard volume unit of the International System of Units).
+The property http://www.opengis.net/ont/geosparql#hasMetricVolume[`geo:hasMetricVolume`] is similar to <<Property: geo:hasVolume, has volume>>, but is easier to specify and use because the unit is always cubic meter (the standard volume unit of the International System of Units).
 
 ```turtle
-geo:hasMetricVolume a rdf:Property, owl:DatatypeProperty ;
+geo:hasMetricVolume 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has volume in cubic meters"@en ;
     skos:definition "The volume of a Feature in cubic meters."@en ; 

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -91,16 +91,17 @@ The class http://www.opengis.net/ont/geosparql#SpatialObjectCollection[geo:Spati
 ```turtle
 geo:SpatialObjectCollection
   a owl:Class ;
+  rdfs:isDefinedBy geo: ;
+  skos:prefLabel "Collection of spatial objects" ;
+  skos:definition "The class Spatial Object Collection represents any collection of things that can 
+                  have a spatial representation. It is superclass of Feature Collection
+                  and Geometry Collection."@en ;  
   rdfs:subClassOf rdfs:Container ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:allValuesFrom geo:SpatialObject ;
       owl:onProperty rdfs:member ;
     ] ;
-  skos:prefLabel "Collection of spatial objects" ;
-  skos:definition "The class Spatial Object Collection represents any collection of things that can 
-                  have a spatial representation. It is superclass of Feature Collection
-                  and Geometry Collection."@en ;
 .
 ```
 
@@ -116,15 +117,16 @@ The class http://www.opengis.net/ont/geosparql#FeatureCollection[geo:FeatureColl
 ```turtle
 geo:FeatureCollection
   a owl:Class ;
+  rdfs:isDefinedBy geo: ;
+  skos:prefLabel "Collection of geospatial features" ;
+  skos:definition "The class Feature Collection represents 
+                  any collection of individual Features."@en ;  
   rdfs:subClassOf geo:SpatialObjectCollection ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:allValuesFrom :Feature ;
       owl:onProperty rdfs:member ;
     ] ;
-  skos:prefLabel "Collection of geospatial features" ;
-  skos:definition "The class Feature Collection represents 
-                  any collection of individual Features."@en ;
 .
 ```
 

--- a/1.1/spec/10-Part-07.adoc
+++ b/1.1/spec/10-Part-07.adoc
@@ -26,14 +26,14 @@ Topological relations in the _Simple Features_ family are summarized in <<sf_rel
 |===
 |Relation Name | Relation IRI | Domain/Range | Applies To Geometry Types | DE-9IM Intersection Pattern
 
-|equals | http://www.opengis.net/ont/geosparql#sfEquals[`geo:sfEquals`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All` | `(TFFFTFFFT)`
-|disjoint | http://www.opengis.net/ont/geosparql#sfDisjoint[`geo:sfDisjoint`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All` | `+(FF**FF****)+`
-|intersects | http://www.opengis.net/ont/geosparql#sfIntersects[`geo:sfIntersects`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All` | `+(T******** *T******* ***T***** ****T****)+`
-|touches | http://www.opengis.net/ont/geosparql#sfTouches[`geo:sfTouches`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All except P/P` | `+(FT******* F**T***** F***T****)+`
-|within | http://www.opengis.net/ont/geosparql#sfWithin[`geo:sfWithin`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All` | `+(T*F**F***)+`
-|contains | http://www.opengis.net/ont/geosparql#sfContains[`geo:sfContains`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All` | `+(T*****FF*)+`
-|overlaps | http://www.opengis.net/ont/geosparql#sfOverlaps[`geo:sfOverlaps`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `A/A, P/P, L/L` | `+(T*T***T**) for A/A, P/P+`; `+(1*T***T**) for L/L+`
-|crosses | http://www.opengis.net/ont/geosparql#sfCrosses[`geo:sfCrosses`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `P/L, P/A, L/A, L/L` | `+(T*T***T**) for P/L, P/A,
+|equals | http://www.opengis.net/ont/geosparql#sfEquals[`geo:sfEquals`] | <<Class: geo:SpatialObject, Spatial Object>> | `All` | `(TFFFTFFFT)`
+|disjoint | http://www.opengis.net/ont/geosparql#sfDisjoint[`geo:sfDisjoint`] | <<Class: geo:SpatialObject, Spatial Object>> | `All` | `+(FF**FF****)+`
+|intersects | http://www.opengis.net/ont/geosparql#sfIntersects[`geo:sfIntersects`] | <<Class: geo:SpatialObject, Spatial Object>> | `All` | `+(T******** *T******* ***T***** ****T****)+`
+|touches | http://www.opengis.net/ont/geosparql#sfTouches[`geo:sfTouches`] | <<Class: geo:SpatialObject, Spatial Object>> | `All except P/P` | `+(FT******* F**T***** F***T****)+`
+|within | http://www.opengis.net/ont/geosparql#sfWithin[`geo:sfWithin`] | <<Class: geo:SpatialObject, Spatial Object>> | `All` | `+(T*F**F***)+`
+|contains | http://www.opengis.net/ont/geosparql#sfContains[`geo:sfContains`] | <<Class: geo:SpatialObject, Spatial Object>> | `All` | `+(T*****FF*)+`
+|overlaps | http://www.opengis.net/ont/geosparql#sfOverlaps[`geo:sfOverlaps`] | <<Class: geo:SpatialObject, Spatial Object>> | `A/A, P/P, L/L` | `+(T*T***T**) for A/A, P/P+`; `+(1*T***T**) for L/L+`
+|crosses | http://www.opengis.net/ont/geosparql#sfCrosses[`geo:sfCrosses`] | <<Class: geo:SpatialObject, Spatial Object>> | `P/L, P/A, L/A, L/L` | `+(T*T***T**) for P/L, P/A,
 L/A+`; `+(0********) for L/L+`
 |===
 
@@ -53,14 +53,14 @@ Topological relations in the _Egenhofer_ family are summarized in <<genhofer_rel
 |===
 |Relation Name | Relation IRI | Domain/Range | Applies To Geometry Types | DE-9IM Intersection Pattern
 
-|equals | http://www.opengis.net/ont/geosparql#ehEquals[`geo:ehEquals`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All` | `(TFFFTFFFT)`
-|disjoint | http://www.opengis.net/ont/geosparql#ehDisjoint[`geo:ehDisjoint`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All` | `+(FF*FF****)+`
-|meet | http://www.opengis.net/ont/geosparql#ehMeet[`geo:ehMeet`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All except P/P` | `+(FT******* F**T***** F***T****)+`
-|overlap | http://www.opengis.net/ont/geosparql#ehOverlap[`geo:ehOverlap`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `All` | `+(T*T***T**)+`
-|covers | http://www.opengis.net/ont/geosparql#ehCovers[`geo:ehCovers`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `A/A, A/L, L/L` | `+(T*TFT*FF*)+`
-|covered by | http://www.opengis.net/ont/geosparql#ehCoveredBy[`geo:ehCoveredBy`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | `A/A, L/A, L/L` | `+(TFF*TFT**)+`
-|inside | http://www.opengis.net/ont/geosparql#ehInside[`geo:ehInside`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | All | `+(TFF*FFT**)+`
-|contains | http://www.opengis.net/ont/geosparql#ehContains[`geo:ehContains`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] | All | `+(T*TFF*FF*)+`
+|equals | http://www.opengis.net/ont/geosparql#ehEquals[`geo:ehEquals`] | <<Class: geo:SpatialObject, Spatial Object>> | `All` | `(TFFFTFFFT)`
+|disjoint | http://www.opengis.net/ont/geosparql#ehDisjoint[`geo:ehDisjoint`] | <<Class: geo:SpatialObject, Spatial Object>> | `All` | `+(FF*FF****)+`
+|meet | http://www.opengis.net/ont/geosparql#ehMeet[`geo:ehMeet`] | <<Class: geo:SpatialObject, Spatial Object>> | `All except P/P` | `+(FT******* F**T***** F***T****)+`
+|overlap | http://www.opengis.net/ont/geosparql#ehOverlap[`geo:ehOverlap`] | <<Class: geo:SpatialObject, Spatial Object>> | `All` | `+(T*T***T**)+`
+|covers | http://www.opengis.net/ont/geosparql#ehCovers[`geo:ehCovers`] | <<Class: geo:SpatialObject, Spatial Object>> | `A/A, A/L, L/L` | `+(T*TFT*FF*)+`
+|covered by | http://www.opengis.net/ont/geosparql#ehCoveredBy[`geo:ehCoveredBy`] | <<Class: geo:SpatialObject, Spatial Object>> | `A/A, L/A, L/L` | `+(TFF*TFT**)+`
+|inside | http://www.opengis.net/ont/geosparql#ehInside[`geo:ehInside`] | <<Class: geo:SpatialObject, Spatial Object>> | All | `+(TFF*FFT**)+`
+|contains | http://www.opengis.net/ont/geosparql#ehContains[`geo:ehContains`] | <<Class: geo:SpatialObject, Spatial Object>> | All | `+(T*TFF*FF*)+`
 |===
 
 === RCC8 Relation Family (relation_family=RCC8)
@@ -79,14 +79,14 @@ Topological relations in the _RCC8_ family are summarized in <<rcc8_relations>>.
 |===
 |Relation Name | Relation IRI | Domain/Range | Applies To Geometry Types | DE-9IM Intersection Pattern
 
-|equals | http://www.opengis.net/ont/geosparql#rcc8eq[`geo:rcc8eq`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`]  | `A/A` | `(TFFFTFFFT)`
-|disconnected | http://www.opengis.net/ont/geosparql#rcc8dc[`geo:rcc8dc`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`]  | `A/A` | `(FFTFFTTTT)`
-|externally connected | http://www.opengis.net/ont/geosparql#rcc8ec[`geo:rcc8ec`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`]  | `A/A` | `(FFTFTTTTT)`
-|partially overlapping | http://www.opengis.net/ont/geosparql#rcc8po[`geo:rcc8po`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`]  | `A/A` | `(TTTTTTTTT)`
-|tangential proper part inverse | http://www.opengis.net/ont/geosparql#rcc8tppi[`geo:rcc8tppi`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`]  | `A/A`  | `(TTTFTTFFT)`
-|tangential proper part | http://www.opengis.net/ont/geosparql#rcc8tpp[`geo:rcc8tpp`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`]  | `A/A` | `(TFFTTFTTT)`
-|non-tangential proper part | http://www.opengis.net/ont/geosparql#rcc8ntpp[`geo:rcc8ntpp`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`]  | `A/A` | `(TFFTFFTTT)`
-|non-tangential proper part inverse | http://www.opengis.net/ont/geosparql#rcc8ntppi[`geo:rcc8ntppi`] | http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`]  | `A/A` | `(TTTFFTFFT)`
+|equals | http://www.opengis.net/ont/geosparql#rcc8eq[`geo:rcc8eq`] | <<Class: geo:SpatialObject, Spatial Object>>  | `A/A` | `(TFFFTFFFT)`
+|disconnected | http://www.opengis.net/ont/geosparql#rcc8dc[`geo:rcc8dc`] | <<Class: geo:SpatialObject, Spatial Object>>  | `A/A` | `(FFTFFTTTT)`
+|externally connected | http://www.opengis.net/ont/geosparql#rcc8ec[`geo:rcc8ec`] | <<Class: geo:SpatialObject, Spatial Object>>  | `A/A` | `(FFTFTTTTT)`
+|partially overlapping | http://www.opengis.net/ont/geosparql#rcc8po[`geo:rcc8po`] | <<Class: geo:SpatialObject, Spatial Object>>  | `A/A` | `(TTTTTTTTT)`
+|tangential proper part inverse | http://www.opengis.net/ont/geosparql#rcc8tppi[`geo:rcc8tppi`] | <<Class: geo:SpatialObject, Spatial Object>>  | `A/A`  | `(TTTFTTFFT)`
+|tangential proper part | http://www.opengis.net/ont/geosparql#rcc8tpp[`geo:rcc8tpp`] | <<Class: geo:SpatialObject, Spatial Object>>  | `A/A` | `(TFFTTFTTT)`
+|non-tangential proper part | http://www.opengis.net/ont/geosparql#rcc8ntpp[`geo:rcc8ntpp`] | <<Class: geo:SpatialObject, Spatial Object>>  | `A/A` | `(TFFTFFTTT)`
+|non-tangential proper part inverse | http://www.opengis.net/ont/geosparql#rcc8ntppi[`geo:rcc8ntppi`] | <<Class: geo:SpatialObject, Spatial Object>>  | `A/A` | `(TTTFFTFFT)`
 |===
 
 

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -4,13 +4,13 @@ This clause establishes the _Geometry Extension (serialization, version)_ parame
 
 As part of the vocabulary, an RDFS datatype is defined for encoding detailed geometry information as a literal value. A literal representation of a geometry is needed so that geometric values may be treated as a single unit. Such a representation allows geometries to be passed to external functions for computations and to be returned from a query.
 
-Other schemes for encoding simple geometry data in RDF have been implemented. The W3C Basic Geo vocabularyfootnote:[http://www.w3.org/2003/01/geo/] was an early (2003) RDF vocabulary for "representing lat(itude), long(itude) and other information about spatially-located things, using WGS84 as a reference datum" and many widely used Semantic Web vocabularies contain some spatial data support. For example, _Dublin Core Terms_ provides a _Location_ classfootnote:[http://purl.org/dc/terms/Location] for "A spatial region or named place." and _schema.org_ provides a number of spatial object and geometry classes, such as `GeoCoordinates`footnote:[https://schema.org/GeoCoordinates] and `GeoShape`footnote:[https://schema.org/GeoShape]. 
+Other schemes for encoding simple geometry data in RDF have been implemented. The W3C Basic Geo vocabularyfootnote:[http://www.w3.org/2003/01/geo/] was an early (2003) RDF vocabulary for "representing lat(itude), long(itude) and other information about spatially-located things, using WGS84 as a reference datum" and many widely used Semantic Web vocabularies contain some spatial data support. For example, _Dublin Core Terms_ provides a _Location_ classfootnote:[http://purl.org/dc/terms/Location] for "A spatial region or named place." and _schema.org_ provides a number of spatial object and geometry classes, such as `GeoCoordinates` footnote:[https://schema.org/GeoCoordinates] and `GeoShape` footnote:[https://schema.org/GeoShape]. 
 
 Many vocabularies, such as these two, provide little specific support for detailed geometries and only support the WGS84 Coordinate Reference System (CSR).
 
-Since 2012 and the first version of GeoSPARQL, many ontologies have imported GeoSPARQL, for example, the _ISA Programme Location Core Vocabulary_footnote:[https://www.w3.org/ns/locn] whose usage notes provide examples containing GeoSPARQL literals and the use of GeoSPARQL's "geometry class". The W3C's more recent DCAT2 standardfootnote:[https://www.w3.org/TR/vocab-dcat/#spatial-properties] similarly contains usage notes for `geometry`, `bbox` and other properties that suggest the use of GeoSPARQL literals.
+Since 2012 and the first version of GeoSPARQL, many ontologies have imported GeoSPARQL, for example, the _ISA Programme Location Core Vocabulary_ footnote:[https://www.w3.org/ns/locn] whose usage notes provide examples containing GeoSPARQL literals and the use of GeoSPARQL's "geometry class". The W3C's more recent _Data Catalog Vocabulary, Version 2_ (DCAT2) standardfootnote:[https://www.w3.org/TR/vocab-dcat/#spatial-properties] similarly contains usage notes for `geometry`, `bbox` and other properties that suggest the use of GeoSPARQL literals.
 
-Some of the properties defined in these vocabularies, such as `hasSpatialResolution` which are introduced in this version of GeoSPARQL, were motivated by similar properties introduced in external vocabularies such as DCAT2, which provided some of the motivation for their inclusion here. The GeoSPARQL 1.1 Standards Working Group charter <<CHARTER>> contains references to a number of vocabularies/ontologies that were influential in the generation of this verison of GeoSPARQL.
+Some of the properties defined in these vocabularies, such as DCAT2's `spatialResolution` have motivated the inclusion of new properties in this version of GeoSPARQL. In this case the equivalent property is <<Property: geo:hasSpatialResolution, has spatial resolution>>. The GeoSPARQL 1.1 Standards Working Group charter <<CHARTER>> contains references to a number of vocabularies/ontologies that were influential in the generation of this verison of GeoSPARQL.
 
 === Parameters
 
@@ -18,56 +18,59 @@ The following parameters are defined for the _Geometry Extension_ requirements c
 
 serialization:: Specifies the serialization standard to use when generating geometry literals and also the supported geometry types.
 
-Note that the serialization chosen strongly affects the geometry conceptualization. The WKT serialization aligns the geometry types with _ISO 19125 Simple Features_ <<ISO19125-1>>, and the GML serialization aligns the geometry types with _ISO 19107 Spatial Schema_ <<ISO19107>>.
+NOTE: a serialization strongly affects the geometry conceptualization. The WKT serialization aligns the geometry types with _ISO 19125 Simple Features_ <<ISO19125-1>>, and the GML serialization aligns the geometry types with _ISO 19107 Spatial Schema_ <<ISO19107>>.
 
 version:: Specifies the version of the serialization format used.
 
 === Geometry Class
 
-A single root geometry class is defined: http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`]. The class http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`] is equivalent to the UML class `GM_Object` defined in <<ISO19107>>. In addition, properties are defined for describing geometry data and for associating geometries with features.
+A single root geometry class is defined: <<Class: geo:Geometry, Geometry>>. In addition, properties are defined for describing geometry data and for associating geometries with features.
 
-One container class is defined: http://www.opengis.net/ont/geosparql#GeometryCollection[`geo:GeometryCollection`]. 
+One container class is defined: <<Class: geo:GeometryCollection, Geometry Collection>>. 
 
 ==== Class: geo:Geometry
 
 The class http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`] is equivalent to `GM_Object` <<ISO19107>> and is defined by the following:
 
 ```turtle
-geo:Geometry a rdfs:Class, owl:Class ;
+geo:Geometry 
+    a rdfs:Class, owl:Class ;
     rdfs:isDefinedBy geo: ; 
     skos:prefLabel "Geometry"@en ;
     rdfs:subClassOf geo:SpatialObject ;
     owl:disjointWith geo:Feature;
     skos:definition "The class represents the top-level geometry type. This class 
                     is equivalent to the UML class GM_Object defined in ISO 19107, 
-                    and it is superclass of all geometry types."@en .
+                    and it is superclass of all geometry types."@en ;
+.
 ```
 
 |===
-| *Req 11* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`] to be used in SPARQL graph patterns.
+| *Req 11* Implementations shall allow the RDFS class <<Class: geo:Geometry, Geometry>> to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-class[`http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-class`]
 |===
 
 ==== Class: geo:GeometryCollection
 
-The class http://www.opengis.net/ont/geosparql#GeometryCollection[`geo:GeometryCollection`] is defined by the following:
+The class <<Class: geo:GeometryCollection, Geometry Collection>> is defined by the following:
 
 ```turtle
 geo:GeometryCollection
-  rdf:type owl:Class ;
+  a owl:Class ;
+  rdfs:isDefinedBy geo: ;
+  skos:prefLabel "Collection of geometry entities"@en ;
+  skos:definition "The class Geometry Collection represents any collection of Geometry entities."@en ;
   rdfs:subClassOf geo:SpatialObjectCollection ;
   rdfs:subClassOf [
-      rdf:type owl:Restriction ;
+      a owl:Restriction ;
       owl:allValuesFrom geo:Geometry ;
       owl:onProperty rdfs:member ;
     ] ;
-  skos:definition "The class Geometry Collection represents any collection of Geometry entities. " ;
-  skos:prefLabel "Collection of geometry entities" ;
 .
 ```
 
 |===
-| *Req 12* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#GeometryCollection[`geo:GeometryCollection`] to be used in SPARQL graph patterns.
+| *Req 12* Implementations shall allow the RDFS class <<Class: geo:GeometryCollection, Geometry Collection>> to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.1/req/core/geometry-collection-class[`http://www.opengis.net/spec/geosparql/1.1/req/core/geometry-collection-class`]
 |===
 
@@ -76,16 +79,17 @@ geo:GeometryCollection
 Properties are defined for describing geometry metadata.
 
 |===
-| *Req 13* Implementations shall allow the properties http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`], http://www.opengis.net/ont/geosparql#coordinateDimension[`geo:coordinateDimension`], http://www.opengis.net/ont/geosparql#spatialDimension[`geo:spatialDimension`], http://www.opengis.net/ont/geosparql#isEmpty[`geo:isEmpty`], http://www.opengis.net/ont/geosparql#isSimple[`geo:isSimple`], http://www.opengis.net/ont/geosparql#hasSerialization[`geo:hasSerialization`] to be used in SPARQL graph patterns.
+| *Req 13* Implementations shall allow the properties <<Property: geo:dimension, dimension>>, <<Property: geo:coordinateDimension, coordinate dimension>>, <<Property: geo:spatialDimension, spatial dimension>>, <<Property: geo:isEmpty, is empty>>, <<Property: geo:isSimple, is simple>>, <<Property: geo:hasSerialization, has serialization>> to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-properties[`http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-properties`]
 |===
 
 ==== Property: geo:dimension
 
-The dimension is the topological dimension of this geometric object, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this will return the largest topological dimension of the contained objects.
+The property http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`] is used to link the a geometry object to its topological dimension, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this will return the largest topological dimension of the contained objects.
 
 ```turtle
-geo:dimension a rdf:Property, owl:DatatypeProperty ;
+geo:dimension 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "dimension"@en ;
     skos:definition "The topological dimension of this geometric object, which
@@ -93,63 +97,72 @@ geo:dimension a rdf:Property, owl:DatatypeProperty ;
                     non-homogeneous collections, this is the largest 
                     topological dimension of the contained objects."@en ;
     rdfs:domain geo:Geometry ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+.
 ```
 
 ==== Property: geo:coordinateDimension
 
-The coordinate dimension is the dimension of direct positions (coordinate tuples) used in the definition of this geometric object.
+The property http://www.opengis.net/ont/geosparql#coordinateDimension[`geo:coordinateDimension`] is defined to link a geometry object to the dimension of direct positions (coordinate tuples) used in the geometry's definition.
 
 ```turtle
-geo:coordinateDimension a rdf:Property, owl:DatatypeProperty;
+geo:coordinateDimension 
+    a rdf:Property, owl:DatatypeProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "coordinate dimension"@en ;
     skos:definition "The number of measurements or axes needed to describe the
                     position of this geometry in a coordinate system."@en ;
     rdfs:domain geo:Geometry ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+.
 ```
 
 ==== Property: geo:spatialDimension
 
-The spatial dimension is the dimension of the spatial portion of the direct positions (coordinate tuples) used in the definition of this geometric object. If the direct positions do not carry a measure coordinate, this will be equal to the coordinate dimension.
+The property http://www.opengis.net/ont/geosparql#spatialDimension[`geo:spatialDimension`] is defined to link a geometry object to the dimension of the spatial portion of the direct positions (coordinate tuples) used in its serializations. If the direct positions do not carry a measure coordinate, this will be equal to the coordinate dimension.
 
 ```turtle
-geo:spatialDimension a rdf:Property, owl:DatatypeProperty;
+geo:spatialDimension 
+    a rdf:Property, owl:DatatypeProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "spatial dimension"@en ;
     skos:definition "The number of measurements or axes needed to describe the
                     spatial position of this geometry in a coordinate system."@en ;
     rdfs:domain geo:Geometry ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+.
 ```
 
 ==== Property: geo:hasSpatialResolution
 
-The property http://www.opengis.net/ont/geosparql#hasSpatialResolution[`geo:hasSpatialResolution`] is used to indicate spatial resolution of the elements within a Geometry. Spatial resolution specifies the level of detail of a Geometry. It the smallest dinstinghuishable distance between adjacent coordinate sets. Therefore this property is not applicable to a point Geometry, because it consists of a single coordinate set.
+The property http://www.opengis.net/ont/geosparql#hasSpatialResolution[`geo:hasSpatialResolution`] is defined to indicate spatial resolution of the elements within a Geometry. Spatial resolution specifies the level of detail of a Geometry. It the smallest dinstinghuishable distance between adjacent coordinate sets. Therefore this property is not applicable to a point Geometry, because it consists of a single coordinate set.
 
-Since this property is defined for a http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`], all literal representations of that Geometry instance must have the same spatial resolution.
+Since this property is defined for a <<Class: geo:Geometry, Geometry>>, all literal representations of that Geometry instance must have the same spatial resolution.
 
 ```turtle
-geo:hasSpatialResolution a rdf:Property, owl:ObjectProperty;
+geo:hasSpatialResolution 
+    a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has spatial resolution"@en ;
     skos:definition "The spatial resolution of a Geometry"@en ; 
-    rdfs:domain geo:Geometry .
+    rdfs:domain geo:Geometry ;
+.
 ```
 
 
 ==== Property: geo:hasMetricSpatialResolution
 
-The property http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution[`geo:hasMetricSpatialResolution`] is similar to http://www.opengis.net/ont/geosparql#hasSpatialResolution[`geo:hasSpatialResolution`], but it is easier to specify and use because the unit of resolution distance is always meter (the standard distance unit of the International System of Units). 
+The property http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution[`geo:hasMetricSpatialResolution`] is similar to <<Property: geo:hasSpatialResolution, has spatial resolution>>, specifies that the unit of resolution distance is always meter (the standard distance unit of the International System of Units). 
 
 ```turtle
-geo:hasMetricSpatialResolution a rdf:Property, owl:ObjectProperty;
+geo:hasMetricSpatialResolution 
+    a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has spatial resolution in meters"@en ;
     skos:definition "The spatial resolution of a Geometry in meters."@en ; 
     rdfs:domain geo:Geometry ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+.
 ```
 
 
@@ -158,66 +171,76 @@ geo:hasMetricSpatialResolution a rdf:Property, owl:ObjectProperty;
 The property http://www.opengis.net/ont/geosparql#hasSpatialAccuracy[`geo:hasSpatialAccuracy`] is applicable when a Geometry is used to represent a Feature. It is expressed as a distance that indicates the truthfullness of the positions (coordinates) that define the Geometry. In this case accuracy defines a zone surrounding each coordinate within wich the real positions are known to be. The accuracy value defines this zone as a distance from the coordinate(s) in all directions (e.g. a line, a circle or a sphere, depending on spatial dimension).
 
 ```turtle
-geo:hasSpatialAccuracy a rdf:Property, owl:ObjectProperty;
+geo:hasSpatialAccuracy 
+    a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has spatial accuracy"@en ;
     skos:definition "The positional accuracy of the coordinates of a Geometry."@en ; 
-    rdfs:domain geo:Geometry .
+    rdfs:domain geo:Geometry ;
+.
 ```
 
 ==== Property: geo:hasMetricSpatialAccuracy
 
-The property http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy[`geo:hasMetricSpatialAccuracy`] is similar to http://www.opengis.net/ont/geosparql#hasSpatialAccuracy[`geo:hasSpatialaccuracy`], but it is easier to specify and use because the unit of distance is always meter (the standard distance unit of the International System of Units). 
+The property http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy[`geo:hasMetricSpatialAccuracy`] is similar to <<Property: geo:hasSpatialAccuracy, has spatial accuracy>>, but it is easier to specify and use because the unit of distance is always meter (the standard distance unit of the International System of Units). 
 
 ```turtle
-geo:hasMetricSpatialAccuracy a rdf:Property, owl:ObjectProperty;
+geo:hasMetricSpatialAccuracy 
+    a rdf:Property, owl:ObjectProperty;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "has spatial accuracy in meters"@en ;
     skos:definition "The positional accuracy of the coordinates of a Geometry in meters."@en ; 
     rdfs:domain geo:Geometry ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+.
 ```
 
 ==== Property: geo:isEmpty
 
-The http://www.opengis.net/ont/geosparql#isEmpty[`geo:isEmpty`] Boolean will be set to `true` only if the geometry contains no information.
+The property http://www.opengis.net/ont/geosparql#isEmpty[`geo:isEmpty`] will indicate a Boolean object set to `true` if and only if the geometry contains no information.
 
 ```turtle
-geo:isEmpty a rdf:Property, owl:DatatypeProperty ;
+geo:isEmpty 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "is empty"@en ;
     skos:definition "(true) if this geometric object is the empty Geometry. If
                     true, then this geometric object represents the empty point
                     set for the coordinate space."@en ; 
     rdfs:domain geo:Geometry ;
-    rdfs:range xsd:boolean .
+    rdfs:range xsd:boolean ;
+.
 ```
 
 ==== Property: geo:isSimple
 
-The http://www.opengis.net/ont/geosparql#isSimple[`geo:isSimple`] Boolean will be set to `true`, only if the geometry contains no self-intersections, with the possible exception of its boundary.
+The proeprty http://www.opengis.net/ont/geosparql#isSimple[`geo:isSimple`] will indicate a Boolean object set to `true`, only if the geometry contains no self-intersections, with the possible exception of its boundary.
 
 ```turtle
-geo:isSimple a rdf:Property, owl:DatatypeProperty ;
+geo:isSimple 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "is simple"@en ;
     skos:definition "(true) if this geometric object has no anomalous geometric
                     points, such as self intersection or self tangency."@en ; 
     rdfs:domain geo:Geometry ;
-    rdfs:range xsd:boolean .    
+    rdfs:range xsd:boolean ;
+.    
 ```
 
 ==== Property: geo:hasSerialization
 
-The http://www.opengis.net/ont/geosparql#hasSerialization[`geo:hasSerialization`] property is used to connect a geometry with its text-based serialization (e.g., its WKT serialization).
+The property http://www.opengis.net/ont/geosparql#hasSerialization[`geo:hasSerialization`] is defined to connect a geometry with its text-based serialization (e.g., its WKT serialization).
 
 ```turtle
-geo:hasSerialization a rdf:Property, owl:DatatypeProperty ;
+geo:hasSerialization 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:isDefinedBy geo: ; 
     skos:prefLabel "has serialization"@en ;
     skos:definition "Connects a geometry object with its text-based serialization."@en ;
     rdfs:domain geo:Geometry ; 
-    rdfs:range rdfs:Literal .
+    rdfs:range rdfs:Literal ;
+.
 ```
 
 NOTE: this property is the generic property used to connect a geometry with its serialization. GeoSPARQL also contains a number of sub properties of this one for connecting serializations of common types with geometries, for example http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] which can be used for GeoJSON <<GEOJSON>> literals.
@@ -227,15 +250,19 @@ This section establishes the requirements for representing geometry data in RDF 
 
 ==== Well-Known Text (serialization=WKT)
 
-This section establishes the requirements for representing geometry data in RDF based on Well-Known Text (WKT) as defined by Simple Features <<ISO19125-1>>. It defines one RDFS Datatype: http://www.opengis.net/ont/geosparql#wktLiteral[`+http://www.opengis.net/ont/geosparql#wktLiteral+`] and one property, http://www.opengis.net/ont/geosparql#asWKT[`+http://www.opengis.net/ont/geosparql#asWKT+`].
+This section establishes the requirements for representing geometry data in RDF based on Well-Known Text (WKT) as defined by Simple Features <<ISO19125-1>>. It defines one RDFS Datatype: http://www.opengis.net/ont/geosparql#wktLiteral[`+http://www.opengis.net/ont/geosparql#wktLiteral+`] and one property, <<Function: geof:asWKT, as WKT>>.
 
 ===== RDFS Datatype: geo:wktLiteral
 
+The datatype http://www.opengis.net/ont/geosparql#wktLiteral[`geo:wktLiteral`] is used to contain the Well-Known Text (WKT) serialization of a geometry.
+
 ```turtle
-geo:wktLiteral a rdfs:Datatype ;
+geo:wktLiteral 
+    a rdfs:Datatype ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "Well-known Text literal"@en ;
-    skos:definition "A Well-known Text serialization of a geometry object."@en .
+    skos:definition "A Well-known Text serialization of a geometry object."@en ;
+.
 ```
 
 |===
@@ -286,7 +313,7 @@ A second example below encodes the same point as encoded in the example above bu
 
 ===== Property: geo:asWKT
 
-The `geo:asWKT` property is defined to link a geometry with its WKT serialization.
+The property http://www.opengis.net/ont/geosparql#asWKT[`geo:asWKT`] is defined to link a geometry with its WKT serialization.
 
 |===
 | *Req 18* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asWKT[`geo:asWKT`] to be used in SPARQL graph patterns.
@@ -296,13 +323,15 @@ The `geo:asWKT` property is defined to link a geometry with its WKT serializatio
 The property http://www.opengis.net/ont/geosparql#asWKT[`geo:asWKT`] is used to link a geometric element with its WKT serialization.
 
 ```turtle
-geo:asWKT a rdf:Property, owl:DatatypeProperty ;
+geo:asWKT 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:subPropertyOf geo:hasSerialization ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "as WKT"@en ;
     skos:definition "The WKT serialization of a geometry."@en ;
     rdfs:domain geo:Geometry ;
-    rdfs:range geo:wktLiteral .
+    rdfs:range geo:wktLiteral ;
+.
 ```
 
 ===== Function: geof:asWKT
@@ -321,15 +350,19 @@ The function http://www.opengis.net/def/function/geosparql/asWKT[`geof:asWKT`] c
 ==== Geography Markup Language (serialization=GML)
 
 This section establishes requirements for representing geometry data in RDF based on GML as defined by Geography Markup Language Encoding Standard <<OGC07-036>>. It defines one RDFS Datatype:
-http://www.opengis.net/ont/geosparql#gmlLiteral[`+http://www.opengis.net/ont/geosparql#gmlLiteral+`] and one property, http://www.opengis.net/ont/geosparql#asGML[`+http://www.opengis.net/ont/geosparql#asGML+`].
+http://www.opengis.net/ont/geosparql#gmlLiteral[`+http://www.opengis.net/ont/geosparql#gmlLiteral+`] and one property, <<Function: geof:asGML, as GML>>.
 
 ===== RDFS Datatype: geo:gmlLiteral
 
+The datatype http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] is used to contain the Geography Markup Language (GML) serialization of a geometry.
+
 ```turtle
-geo:gmlLiteral a rdfs:Datatype ;
+geo:gmlLiteral 
+    a rdfs:Datatype ;
     rdfs:isDefinedBy geo: ; 
     skos:prefLabel "GML literal"@en ;
-    skos:definition "The datatype of GML literal values"@en .
+    skos:definition "The datatype of GML literal values"@en ;
+.
 ```
 
 Valid http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] instances are formed by encoding geometry information as a valid element from the GML schema that implements a subtype of `GM_Object`. For example, in GML 3.2.1 this is every element directly or indirectly in the substitution group of the element `{http://www.opengis.net/ont/gml/3.2}AbstractGeometry`. In GML 3.1.1 and GML 2.1.2 this is every element directly or indirectly in the substitution group of the element `{http://www.opengis.net/ont/gml}_Geometry`.
@@ -363,7 +396,7 @@ The example http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:gmlLiteral`] be
 
 ===== Property: geo:asGML
 
-This document defines the http://www.opengis.net/ont/geosparql#asGML[`geo:asGML`] property to link a geometry with its serialization.
+The property http://www.opengis.net/ont/geosparql#asGML[`geo:asGML`] is defined to link a geometry with its GML serialization.
 
 |===
 | *Req 23* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asGML[`geo:asGML`] to be used in SPARQL graph patterns.
@@ -374,13 +407,15 @@ This document defines the http://www.opengis.net/ont/geosparql#asGML[`geo:asGML`
 The property http://www.opengis.net/ont/geosparql#asGML[`geo:asGML`] is used to link a geometric element with its GML serialization.
 
 ```turtle
-geo:asGML a rdf:Property ; 
+geo:asGML 
+    a rdf:Property ; 
     rdfs:subPropertyOf geo:hasSerialization ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "as GML"@en ;
     skos:definition "The GML serialization of a geometry."@en ; 
     rdfs:domain geo:Geometry ;
-    rdfs:range geo:gmlLiteral .
+    rdfs:range geo:gmlLiteral ;
+.
 ```
 
 ===== Function: geof:asGML
@@ -399,9 +434,11 @@ The function http://www.opengis.net/def/function/geosparql/asGML[`geof:asGML`] c
 ==== GeoJSON (serialization=GEOJSON)
 
 This section establishes requirements for representing geometry data in RDF based on GeoJSON as defined by <<GeoJSON>>. It defines one RDFS Datatype:
-http://www.opengis.net/ont/geosparql#geoJSONLiteral[`+http://www.opengis.net/ont/geosparql#geoJSONLiteral+`] and one property, http://www.opengis.net/ont/geosparql#asGeoJSON[`+http://www.opengis.net/ont/geosparql#asGeoJSON+`].
+http://www.opengis.net/ont/geosparql#geoJSONLiteral[`+http://www.opengis.net/ont/geosparql#geoJSONLiteral+`] and one property, <<Function: geof:asGeoJSON, as GeoJSON>>.
 
 ===== RDFS Datatype: geo:geoJSONLiteral
+
+The datatype http://www.opengis.net/ont/geosparql#gmlLiteral[`geo:geoJSONLiteral`] is used to contain the Geo JavaScript Object Notation (GeoJSON) serialization of a geometry.
 
 ```turtle
 geo:geoJSONLiteral a rdfs:Datatype ;
@@ -437,7 +474,7 @@ The example http://www.opengis.net/ont/geosparql#geoJSONLiteral[`geo:geoJSONLite
 
 ===== Property: geo:asGeoJSON
 
-The http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] property is defined to link a geometry with its GeoJSON serialization.
+The property http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] is defined to link a geometry with its GeoJSON serialization.
 
 |===
 | *Req 28* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] to be used in SPARQL graph patterns.
@@ -447,13 +484,15 @@ The http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] property is 
 The property http://www.opengis.net/ont/geosparql#asGeoJSON[`geo:asGeoJSON`] is used to link a geometric element with its GeoJSON serialization.
 
 ```turtle
-geo:asGeoJSON a rdf:Property, owl:DatatypeProperty ;
+geo:asGeoJSON 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:subPropertyOf geo:hasSerialization ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "as GeoJSON"@en ;
     skos:definition "The GeoJSON serialization of a geometry."@en ;
     rdfs:domain geo:Geometry ;
-    rdfs:range geo:geoJSONLiteral .
+    rdfs:range geo:geoJSONLiteral ;
+.
 ```
 
 ===== Function: geof:asGeoJSON
@@ -472,15 +511,19 @@ The function http://www.opengis.net/def/function/geosparql/asGeoJSON[`geof:asGeo
 ==== Keyhole Markup Language (serialization=KML)
 
 This section establishes requirements for representing geometry data in RDF based on KML as defined by <<OGCKML>>. It defines one RDFS Datatype:
-http://www.opengis.net/ont/geosparql#kmlLiteral[`+http://www.opengis.net/ont/geosparql#kmlLiteral+`] and one property, http://www.opengis.net/ont/geosparql#asKML[`+http://www.opengis.net/ont/geosparql#asKML+`].
+http://www.opengis.net/ont/geosparql#kmlLiteral[`+http://www.opengis.net/ont/geosparql#kmlLiteral+`] and one property, <<Function: geof:asKML, as KML>>.
 
 ===== RDFS Datatype: geo:kmlLiteral
 
+The datatype http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] is used to contain the Keyhole Markup Language (KML) serialization of a geometry.
+
 ```turtle
-geo:kmlLiteral a rdfs:Datatype ;
+geo:kmlLiteral 
+    a rdfs:Datatype ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "KML Literal"@en ;
-    skos:definition "A KML serialization of a geometry object."@en .
+    skos:definition "A KML serialization of a geometry object."@en ;
+.
 ```
 
 Valid http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] instances are formed by encoding geometry information as a Geometry object as defined in the KML specification <<OGCKML>>.
@@ -512,7 +555,7 @@ The example http://www.opengis.net/ont/geosparql#kmlLiteral[`geo:kmlLiteral`] be
 
 ===== Property: geo:asKML
 
-The http://www.opengis.net/ont/geosparql#asKML[`geo:asKML`] property is defined to link a geometry with its KML serialization.
+The property http://www.opengis.net/ont/geosparql#asKML[`geo:asKML`] is defined to link a geometry with its KML serialization.
 
 |===
 | *Req 33* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asKML[`geo:asKML`] to be used in SPARQL graph patterns.
@@ -522,13 +565,15 @@ The http://www.opengis.net/ont/geosparql#asKML[`geo:asKML`] property is defined 
 The property http://www.opengis.net/ont/geosparql#asKML[`geo:asKML`] is used to link a geometric element with its KML serialization.
 
 ```turtle
-geo:asKML a rdf:Property, owl:DatatypeProperty;
+geo:asKML 
+    a rdf:Property, owl:DatatypeProperty;
     rdfs:subPropertyOf geo:hasSerialization ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "as KML"@en ;
     skos:definition "The KML serialization of a geometry."@en ;
     rdfs:domain geo:Geometry ;
-    rdfs:range geo:kmlLiteral .
+    rdfs:range geo:kmlLiteral ;
+.
 ```
 
 ===== Function: geof:asKML
@@ -549,17 +594,21 @@ The function http://www.opengis.net/def/function/geosparql/asKML[`geof:asKML`] c
 This section establishes the requirements for representing Discrete Global Grid System (DGGS) geometry data as RDF literals. The form of representation is specific to individual DGGS implementations: known DGGSes are not compatible or even very similar. 
 
 Here are defined two RDFS Datatypes:
-http://www.opengis.net/ont/geosparql#dggsLiteral[`+http://www.opengis.net/ont/geosparql#dggsLiteral+`] & http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`+http://www.opengis.net/ont/geosparql#auspixDggsLiteral+`] and one property, http://www.opengis.net/ont/geosparql#asDGGS[`+http://www.opengis.net/ont/geosparql#asDGGS+`]. 
+http://www.opengis.net/ont/geosparql#dggsLiteral[`+http://www.opengis.net/ont/geosparql#dggsLiteral+`] & http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`+http://www.opengis.net/ont/geosparql#auspixDggsLiteral+`] and one property, <<Function: geof:asDGGS, as DGGS>>. 
 
 NOTE: The two datatypes defined here are for an abstract DGGS implementation (http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`]) and a specific one, AusPIX <<AUSPIX>> (http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`]). The purposes of including both of these are to indicate the conceptual position of DGGS literals in this specification - the abstract form acts as a parent of all other potential, specific, DGGS datatypes - and to exemplify a specific system implementation which allows for real examples of use.
 
 ===== RDFS Datatype: geo:dggsLiteral
 
+The datatype http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`] is used to contain the Discrete Global Grid System (DGGS) serialization of a geometry.
+
 ```turtle
-geo:dggsLiteral a rdfs:Datatype ;
+geo:dggsLiteral 
+    a rdfs:Datatype ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "DGGS Literal"@en ;
-    skos:definition "A textual serialization of a Discrete Global Grid System (DGGS) geometry object."@en .
+    skos:definition "A textual serialization of a Discrete Global Grid System (DGGS) geometry object."@en 
+.
 ```
 
 Valid http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`] instances are formed by encoding geometry information according to specific DGGS implementation. The specific implementation should be indicated by use of a subclass of the `geo:dggsLiteral` datatype. 
@@ -576,12 +625,15 @@ Valid http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`] instan
 
 ===== RDFS Datatype: geo:auspixDggsLiteral
 
+The datatype http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`] is used to contain the AusPIX Discrete Global Grid System (DGGS) serialization of a geometry.
+
 ```turtle
 geo:auspixDggsLiteral 
     a rdfs:Datatype ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "AusPIX DGGS Literal"@en ;
-    skos:definition "A textual serialization of an AusPIX Discrete Global Grid System (DGGS) geometry object."@en .
+    skos:definition "A textual serialization of an AusPIX Discrete Global Grid System (DGGS) geometry object."@en ;
+.
 ```
 
 Valid http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`] instances are formed by encoding geometry information according to the AusPIX DGGS implementation <<AUSPIX>>.
@@ -601,7 +653,7 @@ NOTE: What `R3234` means is not handled by GeoSPARQL but by the AusPIX DGGS spec
 
 ===== Property: geo:asDGGS
 
-The http://www.opengis.net/ont/geosparql#asDGGS[`geo:asDGGS`] property is defined to link a geometry with its DGGS serialization.
+The property http://www.opengis.net/ont/geosparql#asDGGS[`geo:asDGGS`] is defined to link a geometry with its DGGS serialization.
 
 |===
 | *Req 38* Implementations shall allow the RDF property http://www.opengis.net/ont/geosparql#asDGGS[`geo:asDGGS`] to be used in SPARQL graph patterns.
@@ -611,13 +663,15 @@ The http://www.opengis.net/ont/geosparql#asDGGS[`geo:asDGGS`] property is define
 The property http://www.opengis.net/ont/geosparql#asDGGS[`geo:asDGGS`] is used to link a Geometry instance with its serialization.
 
 ```turtle
-geo:asDGGS a rdf:Property, owl:DatatypeProperty ;
+geo:asDGGS 
+    a rdf:Property, owl:DatatypeProperty ;
     rdfs:subPropertyOf geo:hasSerialization ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "as DGGS"@en ;
     skos:definition "A DGGS Well-Known Text serialization of a geometry."@en ;
     rdfs:domain geo:Geometry ;
-    rdfs:range geo:dggsLiteral .
+    rdfs:range geo:dggsLiteral ;
+.
 ```
 
 NOTE: It is expected that this property will be used to indicate specific DGGS data types, such as http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`], descibed above, as opposed to the generic http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`].
@@ -640,12 +694,12 @@ The function http://www.opengis.net/def/function/geosparql/asDGGS[`geof:asDGGS`]
 This clause defines SPARQL functions for performing non-topological spatial operations.
 
 |===
-| *Req 40* Implementations shall support http://www.opengis.net/def/function/geosparql/distance[`geof:distance`], http://www.opengis.net/def/function/geosparql/buffer[`geof:buffer`], http://www.opengis.net/def/function/geosparql/convexHull[`geof:convexHull`], http://www.opengis.net/def/function/geosparql/intersection[`geof:intersection`], http://www.opengis.net/def/function/geosparql/union[`geof:union`], 
-http://www.opengis.net/def/function/geosparql/isEmpty[`geof:isEmpty`], http://www.opengis.net/def/function/geosparql/isSimple[`geof:isSimple`], 
-http://www.opengis.net/def/function/geosparql/area[`geof:area`], http://www.opengis.net/def/function/geosparql/length[`geof:length`],
-http://www.opengis.net/def/function/geosparql/numGeometries[`geof:numGeometries`],
-http://www.opengis.net/def/function/geosparql/geometryN[`geof:geometryN`], http://www.opengis.net/def/function/geosparql/transform[`geof:transform`],
-http://www.opengis.net/def/function/geosparql/dimension[`geof:dimension`], http://www.opengis.net/def/function/geosparql/difference[`geof:difference`], http://www.opengis.net/def/function/geosparql/symDifference[`geof:symDifference`], http://www.opengis.net/def/function/geosparql/envelope[`geof:envelope`], http://www.opengis.net/def/function/geosparql/boundary[`geof:boundary`] as SPARQL extension functions, consistent with the definitions of their corresponding functions (`distance`, `buffer`, `convexHull`, `intersection`, `isEmpty`, `isSimple`, `area`, `length`, `dimension`, `difference`, `symDifference`, `envelope` and `boundary` respectively) in Simple Features <<ISO19125-1>> and other attached definitions respectively.
+| *Req 40* Implementations shall support <<Function: geof:distance, distance>>, <<Function: geof:buffer, buffer>>, <<Function: geof:convexHull, convex hull>>, <<Function: geof:intersection, intersection>>, <<Function: geof:union, union>>, 
+<<Function: geof:isEmpty, is empty>>, <<Function: geof:isSimple, is simple>>, 
+<<Function: geof:area, area>>, <<Function: geof:length, length>>,
+<<Function: geof:numGeometries, num geometries>>,
+<<Function: geof:geometryN, geometry n>>, <<Function: geof:transform, transform>>,
+<<Function: geof:dimension, dimension>>, <<Function: geof:difference, difference>>, <<Function: geof:symDifference, sym difference>>, <<Function: geof:envelope, envelope>>, <<Function: geof:boundary, boundary>> as SPARQL extension functions, consistent with the definitions of their corresponding functions in Simple Features <<ISO19125-1>> (`distance`, `buffer`, `convexHull`, `intersection`, `union`, `isEmpty`, `isSimple`, `area`, `length`, `numGeometries`, `geometryN`, `transform`, `dimension`, `difference`, `symDifference`, `envelope` and `boundary` respectively) and other attached definitions.
 |http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions[`http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions`]
 |===
 
@@ -702,6 +756,7 @@ Returns a geometric object that represents all Points in the convex hull of `geo
 ```
 geof:isEmpty (geom1: ogc:geomLiteral): xsd:boolean
 ```
+
 Returns true if `geom1` is an empty geometry, i.e. contains no coordinates.
 
 ==== Function: geof:isSimple
@@ -709,6 +764,7 @@ Returns true if `geom1` is an empty geometry, i.e. contains no coordinates.
 ```
 geof:isSimple (geom1: ogc:geomLiteral): xsd:boolean
 ```
+
 Returns true if `geom1` is a simple geometry, i.e. has no anomalous geometric points, such as self intersection or self tangency.
 
 ==== Function: geof:area
@@ -716,6 +772,7 @@ Returns true if `geom1` is a simple geometry, i.e. has no anomalous geometric po
 ```
 geof:area (geom1: ogc:geomLiteral): xsd:double
 ```
+
 Returns the area of `geom1` in squaremeters.
 
 ==== Function: geof:length
@@ -723,6 +780,7 @@ Returns the area of `geom1` in squaremeters.
 ```
 geof:length (geom1: ogc:geomLiteral): xsd:double
 ```
+
 Returns the length of `geom1` in meters.
 
 ==== Function: geof:dimension
@@ -730,6 +788,7 @@ Returns the length of `geom1` in meters.
 ```
 geof:dimension (geom1: ogc:geomLiteral): xsd:integer
 ```
+
 Returns the dimension of `geom1`.
 
 ==== Function: geof:numGeometries
@@ -737,6 +796,7 @@ Returns the dimension of `geom1`.
 ```
 geof:numGeometries (geom1: ogc:geomLiteral): xsd:integer
 ```
+
 Returns the number of geometries of `geom1`.
 
 ==== Function: geof:geometryN
@@ -744,6 +804,7 @@ Returns the number of geometries of `geom1`.
 ```
 geof:geometryN (geom1: ogc:geomLiteral): xsd:integer
 ```
+
 Returns the nth geometry of `geom1` if it is a GeometryCollection .
 
 ==== Function: geof:transform
@@ -881,6 +942,7 @@ The function http://www.opengis.net/def/function/geosparql/minZ[`geof:minZ`] ret
 ```
 geof:boundingCircle (geom: ogc:geomLiteral): ogc:geomLiteral
 ```
+
 The function http://www.opengis.net/def/function/geosparql/boundingCircle[`geof:boundingCircle`] calculates a minimum bounding circle of the set of given geometries.
 
 ==== Function: geof:centroid
@@ -888,6 +950,7 @@ The function http://www.opengis.net/def/function/geosparql/boundingCircle[`geof:
 ```
 geof:centroid (geom: ogc:geomLiteral): ogc:geomLiteral
 ```
+
 The function http://www.opengis.net/def/function/geosparql/centroid[`geof:centroid`] valculates the centroid of the set of given geometries.
 
 ==== Function: geof:concatLines
@@ -895,6 +958,7 @@ The function http://www.opengis.net/def/function/geosparql/centroid[`geof:centro
 ```
 geof:concatLines (geom: ogc:geomLiteral): ogc:geomLiteral
 ```
+
 The function http://www.opengis.net/def/function/geosparql/concatLines[`geof:concatLines`]  Concatenates a set of LineStrings.
 
 ==== Function: geof:concaveHull
@@ -902,6 +966,7 @@ The function http://www.opengis.net/def/function/geosparql/concatLines[`geof:con
 ```
 geof:concaveHull (geom: ogc:geomLiteral, targetPercent: xsd:double): ogc:geomLiteral
 ```
+
 The function http://www.opengis.net/def/function/geosparql/concaveHull[`geof:concaveHull`] calculates the concave hull of the set of given geometries.
 
 ==== Function: geof:union2
@@ -909,5 +974,6 @@ The function http://www.opengis.net/def/function/geosparql/concaveHull[`geof:con
 ```
 geof:union2 (geom: ogc:geomLiteral): ogc:geomLiteral
 ```
+
 The function http://www.opengis.net/def/function/geosparql/union2[`geof:union2`] calculates the union of the set of given geometries.
 

--- a/1.1/spec/16-Annex-A.adoc
+++ b/1.1/spec/16-Annex-A.adoc
@@ -113,30 +113,30 @@ Implementations shall allow the properties http://www.opengis.net/ont/geosparql#
 === A.3.1 Tests for all Serializations
 ==== A.3.1.1 `/conf/geometry-extension/geometry-class`
 *Requirement*: `/req/geometry-extension/geometry-class`
-Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`] to be used in SPARQL graph patterns.
+Implementations shall allow the RDFS class <<Class: geo:Geometry, Geometry>> to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
-.. *Test method*: Verify that queries involving http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`] return the correct result on a test dataset
+.. *Test method*: Verify that queries involving <<Class: geo:Geometry, Geometry>> return the correct result on a test dataset
 .. *Reference*: <<_class_geogeometry>>
 .. *Test Type*: Capabilities
 
 ==== A.3.1.6 `/conf/geometry-extension/geometry-collection-class`
 *Requirement*: `/req/geometry-extension/geometry-collection-class`
-Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#GeometryCollection[`geo:GeometryCollection`] to be used in SPARQL graph patterns.
+Implementations shall allow the RDFS class <<Class: geo:GeometryCollection, Geometry Collection>> to be used in SPARQL graph patterns.
 
 .. *Test purpose*: check conformance with this requirement
-.. *Test method*: verify that queries involving http://www.opengis.net/ont/geosparql#GeometryCollection[`geo:GeometryCollection`] return the correct result on a test dataset
+.. *Test method*: verify that queries involving <<Class: geo:GeometryCollection, Geometry Collection>> return the correct result on a test dataset
 .. *Reference*: <<_class_geogeometrycollection>>
 .. *Test Type*: Capabilities
 
 ==== A.3.1.2 `/conf/geometry-extension/feature-properties`
 *Requirement*: `/req/geometry-extension/feature-properties`
-Implementations shall allow the properties http://www.opengis.net/ont/geosparql#hasGeometry[`geo:hasGeometry`] and http://www.opengis.net/ont/geosparql#hasDefaultGeometry[`geo:hasDefaultGeometry`], 
-http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`],
-http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`],
+Implementations shall allow the properties <<Property: geo:hasGeometry, has geometry>> and <<Property: geo:hasDefaultGeometry, has default geometry>>, 
+<<Property: geo:hasLength, has length>>,
+<<Property: geo:hasArea, has area>>,
 http://www.opengis.net/ont/geosparql#hasCentroid[`geo:hasVolume`]
-http://www.opengis.net/ont/geosparql#hasBoundingBox[`geo:hasBoundingBox`]
-http://www.opengis.net/ont/geosparql#hasCentroid[`geo:hasCentroid`] to be used in SPARQL graph patterns.
+<<Property: geo:hasBoundingBox, has bounding box>>
+<<Property: geo:hasCentroid, has centroid>> to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
 .. *Test method*: Verify that queries involving these properties return the correct result for a test dataset.
@@ -145,7 +145,7 @@ http://www.opengis.net/ont/geosparql#hasCentroid[`geo:hasCentroid`] to be used i
 
 ==== A.3.1.3 `/conf/geometry-extension/geometry-properties`
 *Requirement*: `/req/geometry-extension/geometry-properties`
-Implementations shall allow the properties http://www.opengis.net/ont/geosparql#dimension[`geo:dimension`], http://www.opengis.net/ont/geosparql#coordinateDimension[`geo:coordinateDimension`], http://www.opengis.net/ont/geosparql#spatialDimension[`geo:spatialDimension`],  http://www.opengis.net/ont/geosparql#isEmpty[`geo:isEmpty`],  http://www.opengis.net/ont/geosparql#isSimple[`geo:isSimple`],  http://www.opengis.net/ont/geosparql#hasSerialization[`geo:hasSerialization`] to be used in SPARQL graph patterns.
+Implementations shall allow the properties <<Property: geo:dimension, dimension>>, <<Property: geo:coordinateDimension, coordinate dimension>>, <<Property: geo:spatialDimension, spatial dimension>>,  <<Property: geo:isEmpty, is empty>>,  <<Property: geo:isSimple, is simple>>,  <<Property: geo:hasSerialization, has serialization>> to be used in SPARQL graph patterns.
 
 .. *Test purpose*: Check conformance with this requirement
 .. *Test method*: Verify that queries involving these properties return the correct result for a test dataset.
@@ -154,10 +154,10 @@ Implementations shall allow the properties http://www.opengis.net/ont/geosparql#
 
 ==== A.3.1.4 `/conf/geometry-extension/query-functions`
 *Requirement*: `/req/geometry-extension/query-functions`  
-Implementations shall support http://www.opengis.net/def/function/geosparql/distance[`geof:distance`], http://www.opengis.net/def/function/geosparql/buffer[`geof:buffer`], http://www.opengis.net/def/function/geosparql/convexHull[`geof:convexHull`], http://www.opengis.net/def/function/geosparql/intersection[`geof:intersection`], http://www.opengis.net/def/function/geosparql/union[`geof:union`], http://www.opengis.net/def/function/geosparql/difference[`geof:difference`], http://www.opengis.net/def/function/geosparql/symDifference[`geof:symDifference`], http://www.opengis.net/def/function/geosparql/envelope[`geof:envelope`] and http://www.opengis.net/def/function/geosparql/boundary[`geof:boundary`] as SPARQL extension functions, consistent with the definitions of the corresponding functions (distance, buffer, convexHull, intersection, difference, symDifference, envelope and boundary respectively) in Simple Features <<ISO19125-1>>.
+Implementations shall support <<Function: geof:distance, distance>>, <<Function: geof:buffer, buffer>>, <<Function: geof:convexHull, convex hull>>, <<Function: geof:intersection, intersection>>, <<Function: geof:union, union>>, <<Function: geof:difference, difference>>, <<Function: geof:symDifference, sym difference>>, <<Function: geof:envelope, envelope>> and <<Function: geof:boundary, boundary>> as SPARQL extension functions, consistent with the definitions of the corresponding functions (distance, buffer, convexHull, intersection, difference, symDifference, envelope and boundary respectively) in Simple Features <<ISO19125-1>>.
 
 .. *Test purpose*: Check conformance with this requirement
-.. *Test method*: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: http://www.opengis.net/def/function/geosparql/distance[`geof:distance`], http://www.opengis.net/def/function/geosparql/buffer[`geof:buffer`], http://www.opengis.net/def/function/geosparql/convexHull[`geof:convexHull`], http://www.opengis.net/def/function/geosparql/intersection[`geof:intersection`], http://www.opengis.net/def/function/geosparql/union[`geof:union`], http://www.opengis.net/def/function/geosparql/difference[`geof:difference`], http://www.opengis.net/def/function/geosparql/symDifference[`geof:symDifference`], http://www.opengis.net/def/function/geosparql/envelope[`geof:envelope`] and http://www.opengis.net/def/function/geosparql/boundary[`geof:boundary`]. 
+.. *Test method*: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: <<Function: geof:distance, distance>>, <<Function: geof:buffer, buffer>>, <<Function: geof:convexHull, convex hull>>, <<Function: geof:intersection, intersection>>, <<Function: geof:union, union>>, <<Function: geof:difference, difference>>, <<Function: geof:symDifference, sym difference>>, <<Function: geof:envelope, envelope>> and <<Function: geof:boundary, boundary>>. 
 .. *Reference*: <<_non_topological_query_functions>>
 .. *Test Type*: Capabilities
 

--- a/1.1/spec/17-Annex-B.adoc
+++ b/1.1/spec/17-Annex-B.adoc
@@ -18,7 +18,7 @@ _New Features checklist - to be removed when all examples are complete:_
 === B.1.1 Classes
 
 ==== B 1.1.1 `SpatialObject`
-The `SpatialObject` class is defined in <<Class: geo:SpatialObject>>.
+The `SpatialObject` class is defined in <<Class: geo:SpatialObject, Spatial Object>>.
 
 Basic use (as per the example in the class definition)
 
@@ -28,7 +28,7 @@ eg:x a geo:SpatialObject ;
 .
 ```
 
-NOTE: It is unlikely that users of GeoSPARQL will create many instances of http://www.opengis.net/ont/geosparql#SpatialObject[`geo:SpatialObject`] as its two more concrete subclasses, http://www.opengis.net/ont/geosparql#Feature[`geo:Feature`] & http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`], are more directly relatable to real-world phenomena and use.
+NOTE: It is unlikely that users of GeoSPARQL will create many instances of <<Class: geo:SpatialObject, Spatial Object>> as its two more concrete subclasses, <<Class: geo:Feature, Feature>> & <<Class: geo:Geometry, Geometry>>, are more directly relatable to real-world phenomena and use.
 
 ==== B 1.1.2 `Feature`
 The `Feature` class is defined in <<Class: geo:Feature>>.
@@ -54,7 +54,7 @@ eg:x a geo:Feature ;
 .
 ```
 
-Here a `Feature` is declared, given a preferred label and a geometry for that `Feature` is indicated with the use of http://www.opengis.net/ont/geosparql#hasGeometry[`geo:hasGeometry`]. The `Geometry` indicated is described using a _Well-Known Text_ literal value, indicated by the property http://www.opengis.net/ont/geosparql#asWKT[`geo:asWKT`] and the literal type `geo:wktLiteral`.
+Here a `Feature` is declared, given a preferred label and a geometry for that `Feature` is indicated with the use of <<Property: geo:hasGeometry, has geometry>>. The `Geometry` indicated is described using a _Well-Known Text_ literal value, indicated by the property http://www.opengis.net/ont/geosparql#asWKT[`geo:asWKT`] and the literal type `geo:wktLiteral`.
 
 ===== B 1.1.2.3 `Feature` with both `Geometry` and `SpatialMeasure` instances indicated
 
@@ -74,7 +74,7 @@ eg:x a geo:Feature ;
 .
 ```
 
-Here a `Feature` and a `Geometry` are described as per the previous example but an additional `SpatialMeasure` for the `Feature` is indicated with the use of the property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`]. This property indicates a `SpatialMeasure` instance which conveys its value using the _Quantities, Units, Dimensions and Types (QUDT)_ ontologyfootnote:[http://www.qudt.org]
+Here a `Feature` and a `Geometry` are described as per the previous example but an additional `SpatialMeasure` for the `Feature` is indicated with the use of the property <<Property: geo:hasArea, has area>>. This property indicates a `SpatialMeasure` instance which conveys its value using the _Quantities, Units, Dimensions and Types (QUDT)_ ontologyfootnote:[http://www.qudt.org]
 
 Note that in this example, the use of QUDT and its http://qudt.org/schema/qudt#numericValue[`qudt:numericValue`] & http://qudt.org/schema/qudt#numericValue[`qudt:unit`] is just one of many possible ways to convey a `SpatialMeasure` instance's value.
 
@@ -138,9 +138,9 @@ eg:x a geo:Feature ;
 .
 ```
 
-In this example, `Feature X` has two different `Geometry` instances indicated with different spatial resolutions. This use of the http://www.opengis.net/ont/geosparql#hasSpatialResolution[`geo:hasSpatialResolution`] property follows Example <<B 1.1.2.3 `Feature` with both `Geometry` and `SpatialMeasure` instances indicated>> with its use of QUDT for unit & value. 
+In this example, `Feature X` has two different `Geometry` instances indicated with different spatial resolutions. This use of the <<Property: geo:hasSpatialResolution, has spatial resolution>> property follows Example <<B 1.1.2.3 `Feature` with both `Geometry` and `SpatialMeasure` instances indicated>> with its use of QUDT for unit & value. 
 
-Machine use of this `Feature` would be able to differentiate the two `Geometry` instnaces based on this use of http://www.opengis.net/ont/geosparql#hasSpatialResolution[`geo:hasSpatialResolution`].
+Machine use of this `Feature` would be able to differentiate the two `Geometry` instnaces based on this use of <<Property: geo:hasSpatialResolution, has spatial resolution>>.
 
 ===== B 1.1.2.7 `Feature` with two different `Geometry` instances using metric spatial resolution
 
@@ -359,7 +359,7 @@ eg:x
 . 
 ```
 
-In this example, each of the standards properties defined for a `Geometry` instance has realistic values, for example, the http://www.opengis.net/ont/geosparql#isempty[`geo:isEmpty`] is set to `false` since the `Geometry` contains information.
+In this example, each of the standards properties defined for a `Geometry` instance has realistic values, for example, the <<Property: geo:isEmpty, is empty>> is set to `false` since the `Geometry` contains information.
 
 ==== B.1.2.3 Geometry Serializations
 

--- a/spec-iris.html
+++ b/spec-iris.html
@@ -1,0 +1,8064 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.10">
+<title>OGC GeoSPARQL - A Geographic Query Language for RDF Data</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+:not(pre)>code.nobreak{word-wrap:normal}
+:not(pre)>code.nowrap{white-space:nowrap}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="book">
+<div id="header">
+<h1>GeoSPARQL</h1>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<style>
+  .imageblock > .title {
+    text-align: inherit;
+  }
+</style>
+<div style="page-break-after: always;"></div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong class="big">Open Geospatial Consortium</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Submission Date: &lt;yyyy-mm-dd&gt;</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Approval Date: &lt;yyyy-mm-dd&gt;</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Publication Date: &lt;yyyy-mm-dd&gt;</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">External identifier of this OGC&#174; document: <a href="http://www.opengis.net/doc/IS/geosparql/1.1" class="bare">http://www.opengis.net/doc/IS/geosparql/1.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Internal reference number of this OGC&#174; document: YY-DOC</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Version: 1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Category: OGC&#174; Implementation Specification</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Editors: Matthew Perry, John Herring, Nicholas J. Car, Timo Homburg, Joseph Abhayaratna &amp; Simon J.D. Cox</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-none grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong class="big">OGC GeoSPARQL - A Geographic Query Language for RDF Data</strong></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Copyright notice</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Copyright &#169; 2021 Open Geospatial Consortium</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock">To obtain additional rights of use, visit <a href="http://www.opengeospatial.org/legal/" class="bare">http://www.opengeospatial.org/legal/</a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-none grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Warning</strong></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>This document is an OGC Member approved international standard. This document is available on a royalty free, non-discriminatory basis. Recipients of this document are invited to submit, with their comments, notification of any relevant patent rights of which they are aware and to provide supporting documentation.</p>
+</div>
+<table class="tableblock frame-all grid-none stripes-odd" style="width: 50%;">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Document type: OGC&#174; Standard</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Document subtype: Encoding</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Document stage: Approved for Public Release</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Document language: English</p></td>
+</tr>
+</tbody>
+</table>
+<div style="page-break-after: always;"></div>
+<div class="paragraph">
+<p>License Agreement</p>
+</div>
+<div class="paragraph">
+<p><span class="small">Permission is hereby granted by the Open Geospatial Consortium, ("Licensor"), free of charge and subject to the terms set forth below, to any person obtaining a copy of this Intellectual Property and any associated documentation, to deal in the Intellectual Property without restriction (except as set forth below), including without limitation the rights to implement, use, copy, modify, merge, publish, distribute, and/or sublicense copies of the Intellectual Property, and to permit persons to whom the Intellectual Property is furnished to do so, provided that all copyright notices on the intellectual property are retained intact and that each person to whom the Intellectual Property is furnished agrees to the terms of this Agreement.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">If you modify the Intellectual Property, all copies of the modified Intellectual Property must include, in addition to the above copyright notice, a notice that the Intellectual Property includes modifications that have not been approved or adopted by LICENSOR.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">THIS LICENSE IS A COPYRIGHT LICENSE ONLY, AND DOES NOT CONVEY ANY RIGHTS UNDER ANY PATENTS THAT MAY BE IN FORCE ANYWHERE IN THE WORLD.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">THE INTELLECTUAL PROPERTY IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE DO NOT WARRANT THAT THE FUNCTIONS CONTAINED IN THE INTELLECTUAL PROPERTY WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION OF THE INTELLECTUAL PROPERTY WILL BE UNINTERRUPTED OR ERROR FREE. ANY USE OF THE INTELLECTUAL PROPERTY SHALL BE MADE ENTIRELY AT THE USER’S OWN RISK. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ANY CONTRIBUTOR OF INTELLECTUAL PROPERTY RIGHTS TO THE INTELLECTUAL PROPERTY BE LIABLE FOR ANY CLAIM, OR ANY DIRECT, SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM ANY ALLEGED INFRINGEMENT OR ANY LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR UNDER ANY OTHER LEGAL THEORY, ARISING OUT OF OR IN CONNECTION WITH THE IMPLEMENTATION, USE, COMMERCIALIZATION OR PERFORMANCE OF THIS INTELLECTUAL PROPERTY.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">This license is effective until terminated. You may terminate it at any time by destroying the Intellectual Property together with all copies in any form. The license will also terminate if you fail to comply with any term or condition of this Agreement. Except as provided in the following sentence, no such termination of this license shall require the termination of any third party end-user sublicense to the Intellectual Property which is in force as of the date of notice of such termination. In addition, should the Intellectual Property, or the operation of the Intellectual Property, infringe, or in LICENSOR&#8217;s sole opinion be likely to infringe, any patent, copyright, trademark or other right of a third party, you agree that LICENSOR, in its sole discretion, may terminate this license without any compensation or liability to you, your licensees or any other party. You agree upon termination of any kind to destroy or cause to be destroyed the Intellectual Property together with all copies in any form, whether held by you or by any third party.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">Except as contained in this notice, the name of LICENSOR or of any other holder of a copyright in all or part of the Intellectual Property shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Intellectual Property without prior written authorization of LICENSOR or such copyright holder. LICENSOR is and shall at all times be the sole entity that may authorize you or any third party to use certification marks, trademarks or other special designations to indicate compliance with any LICENSOR standards or specifications.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">This Agreement is governed by the laws of the Commonwealth of Massachusetts. The application to this Agreement of the United Nations Convention on Contracts for the International Sale of Goods is hereby expressly excluded. In the event any provision of this Agreement shall be deemed unenforceable, void or invalid, such provision shall be modified so as to make it valid and enforceable, and as so modified the entire Agreement shall remain in full force and effect. No decision, action or inaction by LICENSOR shall be construed to be a waiver of any rights or remedies available to it.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">None of the Intellectual Property or underlying information or technology may be downloaded or otherwise exported or reexported in violation of U.S. export laws and regulations. In addition, you are responsible for complying with any local laws in your jurisdiction which may impact your right to import, export or use the Intellectual Property, and you represent that you have complied with any regulations or registration procedures required by applicable law to make this license enforceable.</span></p>
+</div>
+<div style="page-break-after: always;"></div>
+<div id="toc" class="toc">
+<div id="toctitle" class="title">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_i_preface">i.    Preface</a></li>
+<li><a href="#_ii_submitting_organizations">ii. Submitting organizations</a>
+<ul class="sectlevel2">
+<li><a href="#_iii_submission_contact_points">iii. Submission contact points</a></li>
+</ul>
+</li>
+<li><a href="#_iv_revision_history">iv. Revision history</a>
+<ul class="sectlevel2">
+<li><a href="#_major_changes_between_versions_1_0_and_1_1">Major changes between versions 1.0 and 1.1</a></li>
+</ul>
+</li>
+<li><a href="#_v_changes_to_the_ogc_abstract_specification">v. Changes to the OGC® Abstract Specification</a></li>
+<li><a href="#_foreword">Foreword</a></li>
+<li><a href="#_introduction">Introduction</a>
+<ul class="sectlevel2">
+<li><a href="#_rdf">RDF</a></li>
+<li><a href="#_sparql">SPARQL</a></li>
+<li><a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a></li>
+</ul>
+</li>
+<li><a href="#_ogc_geosparql_a_geographic_query_language_for_rdf_data">OGC GeoSPARQL – A Geographic Query Language for RDF Data</a>
+<ul class="sectlevel1">
+<li><a href="#_scope">1. Scope</a></li>
+<li><a href="#_conformance">2. Conformance</a></li>
+<li><a href="#_normative_references">3. Normative references</a></li>
+<li><a href="#_terms_and_definitions">4. Terms and definitions</a></li>
+<li><a href="#_conventions">5. Conventions</a>
+<ul class="sectlevel2">
+<li><a href="#_symbols_and_abbreviated_terms">5.1. Symbols and abbreviated terms</a></li>
+<li><a href="#_namespaces">5.2. Namespaces</a></li>
+<li><a href="#_placeholder_iris">5.3. Placeholder IRIs</a></li>
+<li><a href="#_rdf_serializations">5.4. RDF Serializations</a></li>
+</ul>
+</li>
+<li><a href="#_core">6. Core</a>
+<ul class="sectlevel2">
+<li><a href="#_sparql_2">6.1. SPARQL</a></li>
+<li><a href="#_classes">6.2. Classes</a></li>
+<li><a href="#_standard_properties_for_geospatialobject">6.3. Standard Properties for geo:SpatialObject</a></li>
+<li><a href="#_standard_properties_for_geofeature">6.4. Standard Properties for geo:Feature</a></li>
+<li><a href="#_standard_properties_for_geospatialmeasure">6.5. Standard Properties for geo:SpatialMeasure</a></li>
+</ul>
+</li>
+<li><a href="#_topology_vocabulary_extension_relation_family">7. Topology Vocabulary Extension (relation_family)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters">7.1. Parameters</a></li>
+<li><a href="#_simple_features_relation_family_relation_familysimple_features">7.2. Simple Features Relation Family (relation_family=Simple Features)</a></li>
+<li><a href="#_egenhofer_relation_family_relation_familyegenhofer">7.3. Egenhofer Relation Family (relation_family=Egenhofer)</a></li>
+<li><a href="#_rcc8_relation_family_relation_familyrcc8">7.4. RCC8 Relation Family (relation_family=RCC8)</a></li>
+<li><a href="#_equivalent_rcc8_egenhofer_and_simple_features_topological_relations">7.5. Equivalent RCC8, Egenhofer and Simple Features Topological Relations</a></li>
+</ul>
+</li>
+<li><a href="#_geometry_extension_serialization_version">8. Geometry Extension (serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters_2">8.1. Parameters</a></li>
+<li><a href="#_geometry_class">8.2. Geometry Class</a></li>
+<li><a href="#_standard_properties_for_geogeometry">8.3. Standard Properties for geo:Geometry</a></li>
+<li><a href="#_geometry_serializations">8.4. Geometry Serializations</a></li>
+<li><a href="#_non_topological_query_functions">8.5. Non-topological Query Functions</a></li>
+</ul>
+</li>
+<li><a href="#geometry_extension">9. Geometry Topology Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters_3">9.1. Parameters</a></li>
+<li><a href="#_common_query_functions">9.2. Common Query Functions</a></li>
+<li><a href="#_simple_features_relation_family_relation_familysimple_features_2">9.3. Simple Features Relation Family (relation_family=Simple Features)</a></li>
+<li><a href="#_egenhofer_relation_family_relation_familyegenhofer_2">9.4. Egenhofer Relation Family (relation_family=Egenhofer)</a></li>
+<li><a href="#_requirements_for_rcc8_relation_family_relation_familyrcc8">9.5. Requirements for RCC8 Relation Family (relation_family=RCC8)</a></li>
+</ul>
+</li>
+<li><a href="#_rdfs_entailment_extension_relation_family_serialization_version">10. RDFS Entailment Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters_4">10.1. Parameters</a></li>
+<li><a href="#_common_requirements">10.2. Common Requirements</a></li>
+<li><a href="#_wkt_serialization_serializationwkt">10.3. WKT Serialization (serialization=WKT)</a></li>
+<li><a href="#_gml_serialization_serializationgml">10.4. GML Serialization (serialization=GML)</a></li>
+</ul>
+</li>
+<li><a href="#_query_rewrite_extension_relation_family_serialization_version">11. Query Rewrite Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters_5">11.1. Parameters</a></li>
+<li><a href="#_simple_features_relation_family_relation_familysimple_features_3">11.2. Simple Features Relation Family (relation_family=Simple Features)</a></li>
+<li><a href="#_egenhofer_relation_family_relation_familyegenhofer_3">11.3. Egenhofer Relation Family (relation_family=Egenhofer)</a></li>
+<li><a href="#_rcc8_relation_family_relation_familyrcc8_2">11.4. RCC8 Relation Family (relation_family=RCC8)</a></li>
+<li><a href="#_special_considerations">11.5. Special Considerations</a></li>
+</ul>
+</li>
+<li><a href="#_future_work">12. Future Work</a></li>
+</ul>
+</li>
+<li><a href="#_annex_a_normative_abstract_test_suite">Annex A (normative) Abstract Test Suite</a>
+<ul class="sectlevel1">
+<li><a href="#_a_1_conformance_class_core">A.1 Conformance Class: <em>Core</em></a>
+<ul class="sectlevel2">
+<li><a href="#_a_1_1_confcoresparql_protocol">A.1.1 <code>/conf/core/sparql-protocol</code></a></li>
+<li><a href="#_a_1_2_confcorespatial_object_class">A.1.2 <code>/conf/core/spatial-object-class</code></a></li>
+<li><a href="#_a_1_3_confcorefeature_class">A.1.3 <code>/conf/core/feature-class</code></a></li>
+<li><a href="#_a_1_4_confcorespatial_measure_class">A.1.4 <code>/conf/core/spatial-measure-class</code></a></li>
+<li><a href="#_a_1_5_confcorespatial_object_collection_class">A.1.5 <code>/conf/core/spatial-object-collection-class</code></a></li>
+<li><a href="#_a_1_6_confcorefeature_collection_class">A.1.6 <code>/conf/core/feature-collection-class</code></a></li>
+</ul>
+</li>
+<li><a href="#_a_2_conformance_class_topology_vocabulary_extension_relation_family">A.2 Conformance Class: Topology Vocabulary Extension (relation_family)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_2_1_relation_family_simple_features">A.2.1 relation_family = Simple Features</a></li>
+<li><a href="#_a_2_2_relation_family_egenhofer">A.2.2 relation_family = Egenhofer</a></li>
+<li><a href="#_a_2_3_relation_family_rcc8">A.2.3 relation_family = RCC8</a></li>
+</ul>
+</li>
+<li><a href="#_a_3_conformance_class_geometry_extension_serialization_version">A.3 Conformance Class: Geometry Extension (serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_3_1_tests_for_all_serializations">A.3.1 Tests for all Serializations</a></li>
+<li><a href="#_a_3_2_serialization_wkt">A.3.2 serialization = WKT</a></li>
+<li><a href="#_a_3_3_serialization_gml">A.3.3 serialization = GML</a></li>
+<li><a href="#_a_3_4_serialization_geojson">A.3.4 serialization = GEOJSON</a></li>
+<li><a href="#_a_3_5_serialization_kml">A.3.5 serialization = KML</a></li>
+<li><a href="#_a_3_6_serialization_dggs">A.3.6 serialization = DGGS</a></li>
+</ul>
+</li>
+<li><a href="#_a_4_conformance_class_geometry_topology_extension_relation_family_serialization_version">A.4 Conformance Class: Geometry Topology Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_4_1_tests_for_all_relation_families">A.4.1 Tests for all relation families</a></li>
+<li><a href="#_a_4_2_relation_family_simple_features">A.4.2 relation_family = Simple Features</a></li>
+<li><a href="#_a_4_3_relation_family_egenhofer">A.4.3 relation_family = Egenhofer</a></li>
+<li><a href="#_a_4_4_relation_family_rcc8">A.4.4 relation_family = RCC8</a></li>
+</ul>
+</li>
+<li><a href="#_a_5_conformance_class_rdfs_entailment_extension_relation_family_serialization_version">A.5 Conformance Class: RDFS Entailment Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_5_1_tests_for_all_implementations">A.5.1 Tests for all implementations</a></li>
+<li><a href="#_a_5_2_serializationwkt">A.5.2 serialization=WKT</a></li>
+<li><a href="#_a_5_3_serializationgml">A.5.3 serialization=GML</a></li>
+</ul>
+</li>
+<li><a href="#_a_6_conformance_class_query_rewrite_extension_relation_family_serialization_version">A.6 Conformance Class: Query Rewrite Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_6_1_relation_family_simple_features">A.6.1 relation_family = Simple Features</a></li>
+<li><a href="#_a_6_2_relation_family_egenhofer">A.6.2 relation_family = Egenhofer</a></li>
+<li><a href="#_a_6_3_relation_family_rcc8">A.6.3 relation_family = RCC8</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#_annex_b_informative_geosparql_examples">Annex B (informative) GeoSPARQL Examples</a>
+<ul class="sectlevel1">
+<li><a href="#_b_1_rdf_examples">B.1 RDF Examples</a>
+<ul class="sectlevel2">
+<li><a href="#_b_1_1_classes">B.1.1 Classes</a></li>
+<li><a href="#_b_1_2_properties">B.1.2 Properties</a></li>
+</ul>
+</li>
+<li><a href="#_b_2_example_sparql_queries_rules">B.2 Example SPARQL Queries &amp; Rules</a>
+<ul class="sectlevel2">
+<li><a href="#_b_2_1_example_data">B.2.1 Example Data</a></li>
+<li><a href="#_b_2_2_example_queries">B.2.2 Example Queries</a></li>
+<li><a href="#_b_2_3_example_rule_application">B.2.3 Example Rule Application</a></li>
+<li><a href="#_b_2_4_example_geometry_serialization_conversion_functions">B.2.4 Example Geometry Serialization Conversion Functions</a></li>
+<li><a href="#_annex_c">Annex C</a></li>
+<li><a href="#_informative">(informative)</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#_bibliography">Bibliography</a></li>
+</ul>
+</div>
+<div style="page-break-after: always;"></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_i_preface"><a class="anchor" href="#_i_preface"></a>i.    Preface</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The GeoSPARQL standard defines:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>a formal <em>profile</em></p>
+</li>
+<li>
+<p><strong>this specification document</strong></p>
+<div class="ulist">
+<ul>
+<li>
+<p>a core RDF/OWL ontology for geographic information representation</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a set of SPARQL extension functions</p>
+</li>
+<li>
+<p>a Functions &amp; Rules vocabulary, derived from the ontology</p>
+</li>
+<li>
+<p>a Simple Features feature types vocabulary</p>
+</li>
+<li>
+<p>a set of RIF rules, and</p>
+</li>
+<li>
+<p>SHACL shapes for RDF data validation</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>This document has the role of <em>specification</em> and authoritatively defines many of the standard&#8217;s elements, including the ontology classes and properties, SPARQL functions and function and rule vocabulary concepts. Complete descriptions of the standard&#8217;s parts and their roles are given in the Introduction in the section <a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a>.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_ii_submitting_organizations"><a class="anchor" href="#_ii_submitting_organizations"></a>ii. Submitting organizations</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The following organizations submitted this Implementation Specification to the Open Geospatial Consortium Inc.:</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>Australian Bureau of Meteorology</p>
+</li>
+<li>
+<p>Bentley Systems, Inc.</p>
+</li>
+<li>
+<p>CSIRO</p>
+</li>
+<li>
+<p>Defence Geospatial Information Working Group (DGIWG)</p>
+</li>
+<li>
+<p>GeoConnections - Natural Resources Canada</p>
+</li>
+<li>
+<p>Interactive Instruments GmbH</p>
+</li>
+<li>
+<p>GeoScape Australia</p>
+</li>
+<li>
+<p>Mainz University Of Applied Sciences</p>
+</li>
+<li>
+<p>Oracle America</p>
+</li>
+<li>
+<p>Ordnance Survey</p>
+</li>
+<li>
+<p>Raytheon Company</p>
+</li>
+<li>
+<p>SURROUND Australia Pty Ltd.</p>
+</li>
+<li>
+<p>Traverse Technologies, Inc.</p>
+</li>
+<li>
+<p>US Geological Survey (USGS)</p>
+</li>
+</ol>
+</div>
+<div class="sect2">
+<h3 id="_iii_submission_contact_points"><a class="anchor" href="#_iii_submission_contact_points"></a>iii. Submission contact points</h3>
+<div class="paragraph">
+<p>All questions regarding this submission should be directed to the editor or the submitters:</p>
+</div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Contact</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Company</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Oracle America</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">John Herring</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Oracle America</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Nicholas J. Car</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SURROUND Australia Pty Ltd.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Timo Homburg</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Mainz University Of Applied Sciences</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Joseph Abhayaratna</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoScape Australia</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Simon J.D. Cox</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">CSIRO</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_iv_revision_history"><a class="anchor" href="#_iv_revision_history"></a>iv. Revision history</h2>
+<div class="sectionbody">
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Date</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Release</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Author</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Paragraph modified</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">27 Oct. 2009</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Clause 6</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Technical Draft</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">11 Nov. 2009</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">John R. Herring</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Creation</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">06 Jan. 2010</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">John R. Herring</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Comment responses</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">30 March 2010</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Comment responses</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">26 Oct. 2010</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision based on working group discussion</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">28 Jan. 2011</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision based on working group discussion</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">18 April 2011</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Restructure with multiple conformance classes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">02 May 2011</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Clause 6 and Clause 8</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Move Geometry Class from core to geometryExtension</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">05 May 2011</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Update URIs</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">13 Jan. 2012</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision based on Public RFC</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">16 April 2012</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision based on adoption vote comments</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">19 July 2012</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision of URIs based on OGC Naming Authority recommendations</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">09 Oct. 2020</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1 Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Joseph Abhayaratna</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Establishment of the 1.1 Specification</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">10 Oct. 2020</p>
+<p class="tableblock">to</p>
+<p class="tableblock">15 March 2021</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1 Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoSPARQL 1.1 SWG</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Addition of GeoSPARQL 1.1 elements</p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect2">
+<h3 id="_major_changes_between_versions_1_0_and_1_1"><a class="anchor" href="#_major_changes_between_versions_1_0_and_1_1"></a>Major changes between versions 1.0 and 1.1</h3>
+<div class="paragraph">
+<p>Version 1.1 of GeoSPARQL was released approximately 9 years after version 1.0. It contains no breaking changes to 1.0, but does contain additions: whole new profile resources, new ontology elements and new functions. The major changes are given in the tables below.</p>
+</div>
+<div class="paragraph">
+<p>These new profile resources are resources - documents - that are separate from this specification. The new <em>profile defintion</em> lists all the GeoSPARQL 1.1 resources.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New resource</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Location</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Profile definition</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/geosparql" class="bare">http://www.opengis.net/def/geosparql</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoSPARQL Rules in RIF</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/geosparql-rifrules" class="bare">http://www.opengis.net/def/geosparql-rifrules</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDF validation file</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/geosparql-shapes" class="bare">http://www.opengis.net/def/geosparql-shapes</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>These new ontology elements and new functions are normatively defined in this specification document.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Classes</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Spatial Measure class</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialmeasure">Section 6.2.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Spatial Object Collection class</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobjectcollection">Section 6.2.4</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Feature Collection class</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Class: geo:SpatialFeatureCollection">[Class: geo:SpatialFeatureCollection]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Feature Properties</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasBoundingBox</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasboundingbox">Section 6.4.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasCentroid</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohascentroid">Section 6.4.4</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasLength</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohaslength">Section 6.4.5</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasArea</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasarea">Section 6.4.7</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasVolume</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasvolume">Section 6.4.9</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Geometry Serializations</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asWKT function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofaswkt">Section 8.4.1.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGML function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofasgml">Section 8.4.2.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geoJSONLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geogeojsonliteral">Section 8.4.3.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGeoJSON</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoasgeojson">Section 8.4.3.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGeoJSON function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofasgeojson">Section 8.4.3.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">kmlLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geokmlliteral">Section 8.4.4.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asKML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoaskml">Section 8.4.4.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asKML function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofaskml">Section 8.4.4.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">dggsLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geodggsliteral">Section 8.4.5.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">auspixDggsLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geoauspixdggsliteral">Section 8.4.5.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asDGGS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoasdggs">Section 8.4.5.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asDGGS function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geo:asDGGS">[Function: geo:asDGGS]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Non-topological Query Functions</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxx">Section 8.5.19</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxY</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxy">Section 8.5.20</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxZ</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxz">Section 8.5.21</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminx">Section 8.5.22</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minY</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminy">Section 8.5.23</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minZ</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminz">Section 8.5.24</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Spatial Aggregate Functions</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">BBOX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geosaf:BBOX">[Function: geosaf:BBOX]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">BoundingCircle</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:BoundingCircle">[Function: geoaf:BoundingCircle]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Centroid</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:Centroid">[Function: geoaf:Centroid]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConcatLines</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConcatLines">[Function: geoaf:ConcatLines]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConcaveHull</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConcaveHull">[Function: geoaf:ConcaveHull]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConvexHull</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConvexHull">[Function: geoaf:ConvexHull]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Union</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:Union">[Function: geoaf:Union]</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_v_changes_to_the_ogc_abstract_specification"><a class="anchor" href="#_v_changes_to_the_ogc_abstract_specification"></a>v. Changes to the OGC® Abstract Specification</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The OGC® Abstract Specification does not require changes to accommodate this OGC® standard.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_foreword"><a class="anchor" href="#_foreword"></a>Foreword</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights. However, to date, no such rights have been claimed or identified.</p>
+</div>
+<div class="paragraph">
+<p>Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the specification set forth in this document, and to provide supporting documentation.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_introduction"><a class="anchor" href="#_introduction"></a>Introduction</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The W3C Semantic Web Activity is defining a collection of technologies that enables a “web of data” where information is easily shared and reused across applications. Some key pieces of this technology stack are the RDF (Resource Description Framework) data model <a href="#RDF">[RDF]</a>, <a href="#RDFS">[RDFS]</a>, the OWL Web Ontology Language <a href="#OWL2">[OWL2]</a> and the SPARQL protocol and RDF query language <a href="#SPARQL">[SPARQL]</a>.</p>
+</div>
+<div class="sect2">
+<h3 id="_rdf"><a class="anchor" href="#_rdf"></a>RDF</h3>
+<div class="paragraph">
+<p>RDF is, among other things, a data model built on edge-node "graphs." Each link in a graph consists of three things (with many aliases depending on the mapping from other types of data models):</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Subject (start node, instance, entity, feature)</p>
+</li>
+<li>
+<p>Predicate (verb, property, attribute, relation, member, link, reference)</p>
+</li>
+<li>
+<p>Object (value, end node, non-literal values can be used as a Subject)</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Any of the three values in a triple can be represented with a Internationalized Resource Identifier (IRI) <a href="#IETF3987">[IETF3987]</a>, which globally and uniqueliy identifies the resource referenced. IRIs are an extension to Universal Resource Identifiers (URIs) that allow for non-ASCII characters. In addition to functioning as identifiers, IRIs are usually, but not necissarily, resolvable which means a person or machine can "dereference" them (<em>click on them</em> or otherwise action them) and be taken to more information about the resource, perhaps in a web browser.</p>
+</div>
+<div class="paragraph">
+<p>Subjects and objects within an RDF triple are called nodes and can also be be represented with a blank node (a local identifier with meaning outside the graph it is defined within). Objects can further be represented with a literal value. Basic literal values in RDF are those used in XML <a href="#XSD2">[XSD2]</a> but the basic types can be extended for specialised purposes and in this specification are, for geometry data.</p>
+</div>
+<div class="paragraph">
+<p>Note that the same node may be a subject in some triples, and tan object in others.</p>
+</div>
+<div id="img-rdf" class="imageblock text-center">
+<div class="content">
+<img src="img/01.png" alt="600" width="400">
+</div>
+<div class="title">Figure 1. RDF Triple</div>
+</div>
+<div class="paragraph">
+<p>Almost all data can be presented or represented in RDF. In particular, it is an easy match to the (feature-instance-by-id, attribute, value) tuples of the General Feature Model <a href="#ISO19109">[ISO19109]</a>, and for the relational model as (table primary key, column, value).</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_sparql"><a class="anchor" href="#_sparql"></a>SPARQL</h3>
+<div class="paragraph">
+<p>From <a href="#SPARQL">[SPARQL]</a>:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+SPARQL &#8230;&#8203; is a set of specifications that provide languages and protocols to query and manipulate RDF graph content on the Web or in an RDF store.
+</blockquote>
+</div>
+<div class="paragraph">
+<p>and, from Wikipedia<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+SPARQL (pronounced "sparkle" /ˈspɑːkəl/, a recursive acronym for SPARQL Protocol and RDF Query Language) is an RDF query language - that is, a semantic query language for databases — able to retrieve and manipulate data stored in Resource Description Framework (RDF) format. It was made a standard by the RDF Data Access Working Group (DAWG) of the World Wide Web Consortium, and is recognized as one of the key technologies of the semantic web. On 15 January 2008, SPARQL 1.0 was acknowledged by W3C as an official recommendation, and SPARQL 1.1 in March, 2013.
+</blockquote>
+</div>
+<div class="paragraph">
+<p>SPARQL queries work on RDF representations of data by finding patterns that match templates in the query, in effect finding information graphs in the RDF data based on the templates and filters (constraints on nodes and edges) expressed in the query. This query template is represented in the SPARQL query by a set of parameterized “query variables” appearing in a sequence of RDF triples and filters. If the query processor finds a set of triples in the data (converted to an RDF graph in some predetermined standard manner) then the values that the “query variables” take on in those triples become a solution to the query request. The values of the variables are returned in the query result in a format based on the “SELECT” clause of the query (similar to SQL).</p>
+</div>
+<div class="paragraph">
+<p>In addition to predicates defined in this manner, the SPARQL query may contain filter functions that can be used to further constrain the query. Several mechanisms are available to extend filter functions to allow for predicates calculated directly on data values. The SPARQL specification <a href="#SPARQL">[SPARQL]</a> in section 17.6<sup class="footnote">[<a id="_footnoteref_2" class="footnote" href="#_footnotedef_2" title="View footnote.">2</a>]</sup> describes the mechanism for invocation of such a filter function.</p>
+</div>
+<div class="paragraph">
+<p>The OGC GeoSPARQL standard supports representing and querying geospatial data on the Semantic Web. GeoSPARQL defines a vocabulary for representing geospatial data in RDF, and it defines extensions to the SPARQL query language for processing geospatial data.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_geosparql_standard_structure"><a class="anchor" href="#_geosparql_standard_structure"></a>GeoSPARQL Standard structure</h3>
+<div class="paragraph">
+<p>The GeoSPARQL standard comprises multiple parts:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>a formal <em>profile</em></p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="http://www.opengis.net/def/geosparql" class="bare">http://www.opengis.net/def/geosparql</a></p>
+</li>
+<li>
+<p>defined according to the <em>Profiles Vocabulary</em> <a href="#PROF">[PROF]</a></p>
+</li>
+<li>
+<p>this relates the parts in the standard together, provides access to them, and declares dependencies on other standards</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p><strong>this specification document</strong></p>
+<div class="ulist">
+<ul>
+<li>
+<p>which defines many of the standard&#8217;s parts</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a core RDF/OWL <a href="#RDF">[RDF]</a>,<a href="#OWL2">[OWL2]</a> ontology for geographic information representation</p>
+<div class="ulist">
+<ul>
+<li>
+<p>based on the General Feature Model <a href="#ISO19109">[ISO19109]</a>, Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>, Feature Geometry <a href="#ISO19107">[ISO19107]</a> and SQL MM <a href="#ISO13249">[ISO13249]</a></p>
+</li>
+<li>
+<p>defined within the specification document and delivered in RDF also</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a Functions &amp; Rules vocabulary, derived from the ontology</p>
+<div class="ulist">
+<ul>
+<li>
+<p>presented as a <a href="#SKOS">[SKOS]</a> taxonomy</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a Simple Features feature types vocabulary</p>
+<div class="ulist">
+<ul>
+<li>
+<p>presented as a <a href="#SKOS">[SKOS]</a> taxonomy</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a set of SPARQL <a href="#SPARQL">[SPARQL]</a> extension functions</p>
+<div class="ulist">
+<ul>
+<li>
+<p>defined within the specification document</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a set of RIF <a href="#RIFCORE">[RIFCORE]</a> rules, and</p>
+<div class="ulist">
+<ul>
+<li>
+<p>templated within the specification document</p>
+</li>
+<li>
+<p>also delivered as a RIF document also</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>SHACL <a href="#SHACL">[SHACL]</a> shapes for RDF data validation</p>
+<div class="ulist">
+<ul>
+<li>
+<p>defined within a shapes graph file</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>This specification document follows further modular design; it comprises several different components:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>a <em>core</em> component defining the top-level RDFS/OWL classes for spatial objects</p>
+</li>
+<li>
+<p>a <em>topology vocabulary</em> component defining the RDF properties for asserting and querying topological relations between spatial objects</p>
+</li>
+<li>
+<p>a <em>geometry</em> component defines RDFS data types for serializing geometry data, geometry-related RDF properties, and non-topological spatial query functions for geometry objects</p>
+</li>
+<li>
+<p>a <em>geometry topology</em> component defining topological query functions</p>
+</li>
+<li>
+<p>an <em>RDFS entailment</em> component defining mechanisms for matching implicit RDF triples that are derived based on RDF and RDFS semantics</p>
+</li>
+<li>
+<p>a <em>query rewrite</em> component defining rules for transforming a simple triple pattern that tests a topological relation between two features into an equivalent query involving concrete geometries and topological query functions</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Each of these specification components forms a <em>requirements class</em> (a set of requirements) for GeoSPARQL. Implementations can provide various levels of functionality by choosing which requirements classes to support. For example, a system based purely on qualitative spatial reasoning may support only the core and topological vocabulary components.</p>
+</div>
+<div class="paragraph">
+<p>In addition, GeoSPARQL is designed to accommodate systems based on qualitative spatial reasoning and systems based on quantitative spatial computations. Systems based on qualitative spatial reasoning, (e.g. those based on the Region Connection Calculus <a href="#QUAL">[QUAL]</a>, <a href="#LOGIC">[LOGIC]</a>) do not usually model explicit geometries, so queries in such systems will likely test for binary spatial relationships between features rather than between explicit geometries. To allow queries for spatial relations between features in quantitative systems, GeoSPARQL defines a series of query transformation rules that expand a feature-only query into a geometry-based query. With these transformation rules, queries about spatial relations between features will have the same specification in both qualitative systems and quantitative systems. The qualitative system will likely evaluate the query with a backward-chaining spatial “reasoner”, and the quantitative system can transform the query into a geometry-based query that can be evaluated with computational geometry.</p>
+</div>
+</div>
+</div>
+</div>
+<h1 id="_ogc_geosparql_a_geographic_query_language_for_rdf_data" class="sect0"><a class="anchor" href="#_ogc_geosparql_a_geographic_query_language_for_rdf_data"></a>OGC GeoSPARQL – A Geographic Query Language for RDF Data</h1>
+<div class="sect1">
+<h2 id="_scope"><a class="anchor" href="#_scope"></a>1. Scope</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This is the specification document for GeoSPARQL which, as a whole, comprises multiple parts. See the Introduction section <a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a> for details of the parts.</p>
+</div>
+<div class="paragraph">
+<p>GeoSPARQL does not define a comprehensive vocabulary for representing spatial information. It instead defines a core set of classes, properties and datatypes that can be used to construct query patterns. Many useful extensions to this vocabulary are possible, and we intend for the Semantic Web and Geographic Information System (GIS) communities to develop additional vocabulary for describing spatial information.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_conformance"><a class="anchor" href="#_conformance"></a>2. Conformance</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Conformance with this specification shall be checked using all the relevant tests specified in <em>Annex A — Abstract Test Suite</em>. The framework, concepts, and methodology for testing, and the criteria to be achieved to claim conformance are specified in <em>ISO 19105: Geographic information — Conformance and Testing</em> <a href="#ISO19105">[ISO19105]</a>.</p>
+</div>
+<div class="paragraph">
+<p>This document establishes several requirements classes and corresponding conformance classes (a conformance class is a set of tests for each requirement in a requirements class). Any GeoSPARQL implementation claiming conformance with one of the conformance classes shall pass all the tests in the associated abstract test suite.</p>
+</div>
+<div class="paragraph">
+<p>Requirements and conformance tests have IRIs that are relative to versioned namespace IRIs. Requirements and conformance test that are defined in GeoSPARQL 1.0 have IRIs relative to  <code><a href="http://www.opengis.net/spec/geosparql/1.0/" class="bare">http://www.opengis.net/spec/geosparql/1.0/</a></code>, requirements and conformance test that are added in GeoSPARQL 1.1 have IRIs relative to  <code><a href="http://www.opengis.net/spec/geosparql/1.1/" class="bare">http://www.opengis.net/spec/geosparql/1.1/</a></code>.</p>
+</div>
+<div class="paragraph">
+<p>Many conformance classes are parameterized. For parameterized conformance classes, the list of parameters is given within parenthesis.</p>
+</div>
+<table id="conformance_classes" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 1. Conformance Classes</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Conformance class</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Description</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Subclause of the abstract test suite</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Core</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines top-level spatial vocabulary components</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Topology Vocabulary Extension</p>
+<p class="tableblock">(relation_family)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines topological relation vocabulary</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Geometry Extension</p>
+<p class="tableblock">(serialization, version)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines geometry vocabulary and non- topological query functions</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.3</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Geometry Topology Extension</p>
+<p class="tableblock">(serialization, version, relation_family)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines topological query functions for geometry objects</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.4</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDFS Entailment Extension</p>
+<p class="tableblock">(serialization, version , relation_family)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines a mechanism for matching implicit RDF triples that are derived based on RDF and RDFS semantics</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.5</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Query Rewrite Extension</p>
+<p class="tableblock">(serialization, version, relation_family)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines query transformation rules for computing spatial relations between spatial objects based on their associated geometries</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.6</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Dependencies between each GeoSPARQL requirements class are shown below in Figure 2. To support a requirements class for a given set of parameter values, an implementation must support each dependent requirements class with the same set of parameter values.</p>
+</div>
+<div id="img-reqclasses" class="imageblock text-center">
+<div class="content">
+<img src="img/02.png" alt="02">
+</div>
+<div class="title">Figure 2. Requirements Class Dependency Graph</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_normative_references"><a class="anchor" href="#_normative_references"></a>3. Normative references</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The following normative documents contain provisions which, through reference in this text, constitute provisions of this document. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. However, parties to agreements based on this document are encouraged to investigate the possibility of applying the most recent editions of the normative documents indicated below. For undated references, the latest edition of the normative document referred to applies.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#ISO19125-1">[ISO19125-1]</a>, <em>ISO 19125-1: Geographic information — Simple feature access — Part 1: Common architecture</em></p>
+</li>
+<li>
+<p><a href="#OGC07-036">[OGC07-036]</a>, <em>OGC 07-036: Geography Markup Language (GML) Encoding Standard</em>, Version 3.2.1 (27 August 2007).</p>
+</li>
+<li>
+<p><a href="#IETF3987">[IETF3987]</a>, Internet Engineering Task Force, <em>RFC 3987: Internationalized Resource Identifiers (IRIs)</em>. IETF Request for Comment (January 2005). <a href="https://tools.ietf.org/html/rfc3987" class="bare">https://tools.ietf.org/html/rfc3987</a></p>
+</li>
+<li>
+<p><a href="#RIFCORE">[RIFCORE]</a>, <em>RIF Core Dialect (Second Edition)</em>, W3C Recommendation (5 February 2013) <a href="http://www.w3.org/TR/rif-core/" class="bare">http://www.w3.org/TR/rif-core/</a></p>
+</li>
+<li>
+<p><a href="#SPARQL">[SPARQL]</a>, <em>SPARQL 1.1 Query Language</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/sparql11-query/" class="bare">https://www.w3.org/TR/sparql11-query/</a></p>
+</li>
+<li>
+<p><a href="#SPARQLENT">[SPARQLENT]</a>, <em>SPARQL 1.1 Entailment Regimes</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/sparql11-entailment/" class="bare">https://www.w3.org/TR/sparql11-entailment/</a></p>
+</li>
+<li>
+<p><a href="#SPARQLPROT">[SPARQLPROT]</a>, <em>SPARQL 1.1 Protocol</em>, W3C Recommendation (21 March 2013)&gt; <a href="http://www.w3.org/TR/sparql11-protocol/" class="bare">http://www.w3.org/TR/sparql11-protocol/</a></p>
+</li>
+<li>
+<p><a href="#SPARQLRESX">[SPARQLRESX]</a>, <em>SPARQL Query Results XML Format (Second Edition)</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/rdf-sparql-XMLres/" class="bare">https://www.w3.org/TR/rdf-sparql-XMLres/</a></p>
+</li>
+<li>
+<p><a href="#SPARQLRESJ">[SPARQLRESJ]</a>, <em>SPARQL 1.1 Query Results JSON Format</em>, W3C Recommendation (21 March 2013). <a href="http://www.w3.org/TR/sparql11-results-json/" class="bare">http://www.w3.org/TR/sparql11-results-json/</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_terms_and_definitions"><a class="anchor" href="#_terms_and_definitions"></a>4. Terms and definitions</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>For the purposes of this document, the terms and definitions given in the above references apply.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_conventions"><a class="anchor" href="#_conventions"></a>5. Conventions</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_symbols_and_abbreviated_terms"><a class="anchor" href="#_symbols_and_abbreviated_terms"></a>5.1. Symbols and abbreviated terms</h3>
+<div class="paragraph">
+<p>In this specification, the following common acronyms are used:</p>
+</div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 85.7143%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">CRS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Coordinate Reference System</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">DGGS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Discrete Global Grid System</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoJSON</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Geographic JavaScript Object Notation</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GFM</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">General Feature Model (as defined in ISO 19109)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Geography Markup Language</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">KML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Keyhole Markup Language</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">OWL</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">OWL 2 Web Ontology Language</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RCC</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Region Connection Calculus</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDF</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Resource Description Framework</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDFS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDF Schema</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RIF</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Rule Interchange Format</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SPARQL</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SPARQL Protocol and RDF Query Language</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SRS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Spatial Reference System</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">WKT</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Well Known Text (as defined by Simple Features or ISO 19125)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">W3C</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">World Wide Web Consortium (<a href="http://www.w3.org/" class="bare">http://www.w3.org/</a>)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">XML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Extensible Markup Language</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_namespaces"><a class="anchor" href="#_namespaces"></a>5.2. Namespaces</h3>
+<div class="paragraph">
+<p>The following IRI namespace prefixes are used throughout this document:</p>
+</div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 85.7143%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ogc:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/" class="bare">http://www.opengis.net/</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">eg:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://example.com/" class="bare">http://example.com/</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geo:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#" class="bare">http://www.opengis.net/ont/geosparql#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geof:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/" class="bare">http://www.opengis.net/def/function/geosparql/</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geor:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/" class="bare">http://www.opengis.net/def/rule/geosparql/</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">sf:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/sf#" class="bare">http://www.opengis.net/ont/sf#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">skos:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/2004/02/skos/core#" class="bare">http://www.w3.org/2004/02/skos/core#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">gml:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/gml#" class="bare">http://www.opengis.net/ont/gml#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">my:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://example.org/ApplicationSchema#" class="bare">http://example.org/ApplicationSchema#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">xsd:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/2001/XMLSchema#" class="bare">http://www.w3.org/2001/XMLSchema#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">rdf:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#" class="bare">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">rdfs:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/2000/01/rdf-schema#" class="bare">http://www.w3.org/2000/01/rdf-schema#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">owl:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/2002/07/owl#" class="bare">http://www.w3.org/2002/07/owl#</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_placeholder_iris"><a class="anchor" href="#_placeholder_iris"></a>5.3. Placeholder IRIs</h3>
+<div class="paragraph">
+<p>The IRI <a href="http://www.opengis.net/def/geomLiteral"><code>ogc:geomLiteral</code></a> is used in requirement specifications as a placeholder for the geometry literal serialization used in a fully-qualified conformance class, e.g. <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>&lt;http://www.opengis.net/ont/geosparql#wktLiteral&gt;</code></a>.
+The IRI <a href="http://www.opengis.net/def/asGeomLiteral"><code>ogc:asGeomLiteral</code></a> is used in requirement specifications as a placeholder for the geometry literal serialization property used in a fully-qualified conformance class, e.g. <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a>.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_rdf_serializations"><a class="anchor" href="#_rdf_serializations"></a>5.4. RDF Serializations</h3>
+<div class="paragraph">
+<p>Three RDF serializations are used in this document. Terse RDF Triple Language (turtle) <a href="#TURTLE">[TURTLE]</a> is used for RDF snippets placed within the main body of the document, and turtle, JSON-LD <a href="#JSON-LD">[JSON-LD]</a> &amp; RDF/XML <a href="#RDFXML">[RDFXML]</a> is used for the examples in <em>Annex B — GeoSPARQL Examples</em>.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_core"><a class="anchor" href="#_core"></a>6. Core</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <strong>core</strong> requirements class, with IRI <code>/req/core</code>, which has a single corresponding conformance class, <strong>core</strong>, with IRI <code>/conf/core</code>. This requirements class defines a set of classes and properties for representing geospatial data. The resulting vocabulary can be used to construct SPARQL graph patterns for querying appropriately modeled geospatial data. RDFS and OWL vocabulary have both been used so that the vocabulary can be understood by systems that support only RDFS entailment and by systems that support OWL-based reasoning.</p>
+</div>
+<div class="sect2">
+<h3 id="_sparql_2"><a class="anchor" href="#_sparql_2"></a>6.1. SPARQL</h3>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 1</strong> Implementations shall support the SPARQL Query Language for RDF <a href="#SPARQL">[SPARQL]</a>, the SPARQL Protocol <a href="#SPARQLPROT">[SPARQLPROT]</a> and the SPARQL Query Results XML <a href="#SPARQLRESX">[SPARQLRESX]</a> and JSON <a href="#SPARQLRESJ">[SPARQLRESJ]</a> Formats.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/core/sparql-protocol"><code>http://www.opengis.net/spec/geosparql/1.0/req/core/sparql-protocol</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_classes"><a class="anchor" href="#_classes"></a>6.2. Classes</h3>
+<div class="paragraph">
+<p>Three main classes are defined: <a href="#_class_geospatialobject">Spatial Object</a>, <a href="#_class_geofeature">Feature</a>, and <a href="#_class_geospatialmeasure">Spatial Measure</a>. The class <a href="#_class_geofeature">Feature</a> is equivalent to the UML class <code>Feature</code> defined in <a href="#ISO19109">[ISO19109]</a>.</p>
+</div>
+<div class="paragraph">
+<p>Two container classes are defined: <a href="#_class_geospatialobjectcollection">Spatial Object Collection</a> and <a href="#_class_geofeaturecollection">Feature Collection</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="_class_geospatialobject"><a class="anchor" href="#_class_geospatialobject"></a>6.2.1. Class: geo:SpatialObject</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#SpatialObject">geo:SpatialObject</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:SpatialObject
+    a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Spatial Object"@en ;
+    skos:definition "The class Spatial Object represents everything that can
+                    have a spatial representation. It is superclass of feature
+                    and geometry"@en .</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 2</strong> Implementations shall allow the RDFS class <a href="#_class_geospatialobject">Spatial Object</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/core/spatial-object-class"><code>http://www.opengis.net/spec/geosparql/1.0/req/core/spatial-object-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>Example:</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:SpatialObject ;
+     skos:prefLabel "Object X";
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_class_geofeature"><a class="anchor" href="#_class_geofeature"></a>6.2.2. Class: geo:Feature</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#Feature">geo:Feature</a> is equivalent to the class <code>GFI_Feature</code> <a href="#ISO19156">[ISO19156]</a> and is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:Feature
+    a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Feature"@en ;
+    rdfs:subClassOf geo:SpatialObject ;
+    owl:disjointWith geo:Geometry ;
+    skos:definition "This class represents the top-level feature type. This
+                    class is equivalent to GFI_Feature defined in ISO 19156,
+                    and it is superclass of all feature types."@en .</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 3</strong> Implementations shall allow the RDFS class <a href="#_class_geofeature">Feature</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/core/feature-class"><code>http://www.opengis.net/spec/geosparql/1.0/req/core/feature-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_class_geospatialmeasure"><a class="anchor" href="#_class_geospatialmeasure"></a>6.2.3. Class: geo:SpatialMeasure</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#SpatialMeasure">geo:SpatialMeasure</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:SpatialMeasure
+    a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Spatial Measure"@en ;
+    skos:definition "This class represents a measurement of some dimension
+                    of a feature's spatial presence."@en .</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+Properties for Spatial Measure may need to indicate a use a unit of measure. When they do, OGC recommended units of measure vocabularies should be used. See the OGC Definitions Server<sup class="footnote">[<a id="_footnoteref_3" class="footnote" href="#_footnotedef_3" title="View footnote.">3</a>]</sup>.
+</td>
+</tr>
+</table>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 4</strong> Implementations shall allow the RDFS class <a href="#_class_geospatialmeasure">Spatial Measure</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-measure-class"><code>http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-measure-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_class_geospatialobjectcollection"><a class="anchor" href="#_class_geospatialobjectcollection"></a>6.2.4. Class: geo:SpatialObjectCollection</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#SpatialObjectCollection">geo:SpatialObjectCollection</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:SpatialObjectCollection
+  a owl:Class ;
+  rdfs:subClassOf rdfs:Container ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom geo:SpatialObject ;
+      owl:onProperty rdfs:member ;
+    ] ;
+  skos:prefLabel "Collection of spatial objects" ;
+  skos:definition "The class Spatial Object Collection represents any collection of things that can
+                  have a spatial representation. It is superclass of Feature Collection
+                  and Geometry Collection."@en ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 5</strong> Implementations shall allow the RDFS class <a href="#_class_geospatialobjectcollection">Spatial Object Collection</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-object-collection-class"><code>http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-object-collection-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_class_geofeaturecollection"><a class="anchor" href="#_class_geofeaturecollection"></a>6.2.5. Class: geo:FeatureCollection</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#FeatureCollection">geo:FeatureCollection</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:FeatureCollection
+  a owl:Class ;
+  rdfs:subClassOf geo:SpatialObjectCollection ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom :Feature ;
+      owl:onProperty rdfs:member ;
+    ] ;
+  skos:prefLabel "Collection of geospatial features" ;
+  skos:definition "The class Feature Collection represents
+                  any collection of individual Features."@en ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 6</strong> Implementations shall allow the RDFS class <a href="#_class_geofeaturecollection">Feature Collection</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/core/feature-collection-class"><code>http://www.opengis.net/spec/geosparql/1.1/req/core/feature-collection-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_standard_properties_for_geospatialobject"><a class="anchor" href="#_standard_properties_for_geospatialobject"></a>6.3. Standard Properties for geo:SpatialObject</h3>
+<div class="paragraph">
+<p><em>To be defined</em></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_standard_properties_for_geofeature"><a class="anchor" href="#_standard_properties_for_geofeature"></a>6.4. Standard Properties for geo:Feature</h3>
+<div class="paragraph">
+<p>Properties are defined for associating geometries with features.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 7</strong> Implementations shall allow the properties <a href="#_property_geohasgeometry">has geometry</a>,
+<a href="#_property_geohasdefaultgeometry">has default geometry</a>, <a href="#_property_geohaslength">has length</a>, <a href="#_property_geohasarea">has area</a>, <a href="#_property_geohasvolume">has volume</a> <a href="#_property_geohascentroid">has centroid</a>, <a href="#_property_geohasboundingbox">has bounding box</a> and <a href="#_property_geohasspatialresolution">has spatial resolution</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect3">
+<h4 id="_property_geohasgeometry"><a class="anchor" href="#_property_geohasgeometry"></a>6.4.1. Property: geo:hasGeometry</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasGeometry"><code>geo:hasGeometry</code></a> is used to link a feature with a geometry that represents its spatial extent. A given feature may have many associated geometries.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasGeometry
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has Geometry"@en ;
+    skos:definition "A spatial representation for a given feature."@en ;
+    rdfs:domain geo:Feature;
+    rdfs:range geo:Geometry .</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasdefaultgeometry"><a class="anchor" href="#_property_geohasdefaultgeometry"></a>6.4.2. Property: geo:hasDefaultGeometry</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasDefaultGeometry"><code>geo:hasDefaultGeometry</code></a> is used to link a feature with its default geometry. The default geometry is the geometry that should be used for spatial calculations in the absence of a request for a specific geometry (e.g. in the case of query rewrite).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasDefaultGeometry
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has Default Geometry"@en ;
+    skos:definition "The default geometry to be used in spatial calculations,
+                    usually the most detailed geometry."@en ;
+    rdfs:subPropertyOf geo:hasGeometry;
+    rdfs:domain geo:Feature;
+    rdfs:range geo:Geometry .</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>GeoSPARQL does not restrict the cardinality of the <a href="#_property_geohasdefaultgeometry">has default geometry</a> property. It is thus possible for a feature to have more than one distinct default geometry or to have no default geometry. This situation does not result in a query processing error; SPARQL graph pattern matching simply proceeds as normal. Certain queries may, however, give logically inconsistent results. For example, if a feature <code>my:f1</code> has two asserted default geometries, and those two geometries are disjoint polygons, the query below could return a non-zero count on a system supporting the GeoSPARQL Query Rewrite Extension (rule <a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint"><code>geor:sfDisjoint</code></a>).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+
+SELECT (COUNT(*) AS ?cnt)
+WHERE { :f1 geo:sfDisjoint :f1 }</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Such cases are application-specific data modeling errors and are therefore outside of the scope of the GeoSPARQL specification., however it is recommended that multiple geometries indicated with <a href="#_property_geohasdefaultgeometry">has default geometry</a> should be differentiated by <code>Geometry</code> class properties, perhaps relating to precision, SRS etc.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasboundingbox"><a class="anchor" href="#_property_geohasboundingbox"></a>6.4.3. Property: geo:hasBoundingBox</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasBoundingBox"><code>geo:hasBoundingBox</code></a> is used to link a feature with a simplified geometry-representation corresponding to the envelope of its geometry. Bounding-boxes are typically uses in indexing and discovery.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasBoundingBox
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:subPropertyOf geo:hasGeometry;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has bounding box"@en ;
+    skos:definition "The minimum or smallest bounding or enclosing box of a given feature."@en ;
+    skos:scopeNote "The target is a geometry that defines a rectilinear region whose edges are
+                    aligned with the axes of the coordinate reference system, which exactly
+                    contains the geometry or feature e.g. sf:Envelope"@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:Geometry .</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>GeoSPARQL does not restrict the cardinality of the <a href="#_property_geohasboundingbox">has bounding box</a> property. A feature may be associated with more than one bounding-box, for example in different coordinate reference systems.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohascentroid"><a class="anchor" href="#_property_geohascentroid"></a>6.4.4. Property: geo:hasCentroid</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasCentroid"><code>geo:hasCentroid</code></a> is used to link a feature with a point geometry corresponding with the centroid of its geometry. The centroid is typically used to show location on a low-resolution image, and for some indexing and discovery functions.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasCentroid
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:subPropertyOf geo:hasGeometry;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has centroid"@en ;
+    skos:definition "The arithmetic mean position of all the geometry points
+                    of a given feature."@en ;
+    skos:scopeNote "The target geometry shall describe a point, e.g. sf:Point"@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:Geometry .</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>GeoSPARQL does not restrict the cardinality of the <a href="#_property_geohascentroid">has centroid</a> property. A feature may be associated with more than one centroid, for example computed using different rules or in different coordinate reference systems.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohaslength"><a class="anchor" href="#_property_geohaslength"></a>6.4.5. Property: geo:hasLength</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasLength"><code>geo:hasLength</code></a> is used to indicate the length of a <a href="#_class_geofeature">Feature</a>. In the case of a one-dimensional <a href="#_class_geofeature">Feature</a>, it is the simple length. In the case of a two-dimensional <a href="#_class_geofeature">Feature</a>, it is interpreted to mean the perimeter length. The range of the property is <a href="#_class_geospatialmeasure">Spatial Measure</a>, which encodes the length value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasLength
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has length"@en ;
+    skos:definition "The length of a Feature, expressed as a Spatial Measure."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:SpatialMeasure .</code></pre>
+</div>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+A consistency check can be applied to geometries indicating both this property and the <a href="#_property_geodimension">dimension</a> property: if supplied, the <a href="#_property_geodimension">dimension</a> property&#8217;s range value must be the literal integer  1 or 2. The following SPARQL query will return <code>true</code> if applied to a graph where is not always the case for all geometries:
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">    PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+    ASK
+    WHERE {
+        ?g geo:hasLength ?l ;
+           geo:dimension ?d .
+
+        FILTER (?d &gt; 2)
+    }</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetriclength"><a class="anchor" href="#_property_geohasmetriclength"></a>6.4.6. Property: geo:hasMetricLength</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricLength"><code>geo:hasMetricLength</code></a> is similar to <a href="#_property_geohaslength">has length</a>, but is easier to specify and use because the unit is always meter (the standard length unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricLength
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has length in meters"@en ;
+    skos:definition "The length of a Feature in meters."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range xsd:double .</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasarea"><a class="anchor" href="#_property_geohasarea"></a>6.4.7. Property: geo:hasArea</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasArea"><code>geo:hasArea</code></a> is used to indicate the area of a <a href="#_class_geofeature">Feature</a>. The range of the property is <a href="#_class_geospatialmeasure">Spatial Measure</a>, which encodes the area value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasArea
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has area"@en ;
+    skos:definition "The two-dimensional area of a Feature, expressed as a Spatial Measure."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:SpatialMeasure .</code></pre>
+</div>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+A consistency check can be applied to geometries indicating both this property and the <a href="#_property_geodimension">dimension</a> property: if supplied, the <a href="#_property_geodimension">dimension</a> property&#8217;s range value must be the literal integer 2. The following SPARQL query will return <code>true</code> if applied to a graph where is not always the case for all geometries:
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">    PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+    ASK
+    WHERE {
+        ?g geo:hasArea ?a ;
+           geo:dimension ?d .
+
+        FILTER (?d != 2)
+    }</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetricarea"><a class="anchor" href="#_property_geohasmetricarea"></a>6.4.8. Property: geo:hasMetricArea</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricArea"><code>geo:hasMetricArea</code></a> is similar to <a href="#_property_geohasarea">has area</a>, but is easier to specify and use because the unit is always square meter (the standard area unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricArea
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has area in square meters"@en ;
+    skos:definition "The area of a Feature in square meters."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range xsd:double .</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasvolume"><a class="anchor" href="#_property_geohasvolume"></a>6.4.9. Property: geo:hasVolume</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasVolume"><code>geo:hasVolume</code></a> is used to indicate the volume of a <a href="#_class_geofeature">Feature</a>. The range of the property is <a href="#_class_geospatialmeasure">Spatial Measure</a>, which encodes the volume value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasVolume
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has volume"@en ;
+    skos:definition "The volume of a Feature, expressed as a Spatial Measure"@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:SpatialMeasure ;
+.</code></pre>
+</div>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+A consistency check can be applied to geometries indicating both this property and the <a href="#_property_geodimension">dimension</a> property: if supplied, the <a href="#_property_geodimension">dimension</a> property&#8217;s range value must be the literal integer 3. The following SPARQL query will return <code>true</code> if applied to a graph where is not always the case for all geometries:
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">    PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+    ASK
+    WHERE {
+        ?g geo:hasVolume ?a ;
+           geo:dimension ?d .
+
+        FILTER (?d != 3)
+    }</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetricvolume"><a class="anchor" href="#_property_geohasmetricvolume"></a>6.4.10. Property: geo:hasMetricVolume</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricVolume"><code>geo:hasMetricVolume</code></a> is similar to <a href="#_property_geohasvolume">has volume</a>, but is easier to specify and use because the unit is always cubic meter (the standard volume unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricVolume
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has volume in cubic meters"@en ;
+    skos:definition "The volume of a Feature in cubic meters."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range xsd:double .</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_standard_properties_for_geospatialmeasure"><a class="anchor" href="#_standard_properties_for_geospatialmeasure"></a>6.5. Standard Properties for geo:SpatialMeasure</h3>
+<div class="paragraph">
+<p><em>To be defined</em></p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_topology_vocabulary_extension_relation_family"><a class="anchor" href="#_topology_vocabulary_extension_relation_family"></a>7. Topology Vocabulary Extension (relation_family)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>Topology Vocabulary Extension (relation_family)</em> parameterized requirements class, with IRI <code>/req/topology-vocab-extension</code>, which has a single corresponding conformance class <em>Topology Vocabulary Extension (relation_family)</em>, with IRI <code>/conf/topology-vocab-extension</code>. This requirements class defines a vocabulary for asserting and querying topological relations between spatial objects. The class is parameterized so that different families of topological relations may be used, e.g. RCC8, Egenhofer. These relations are generalized so that they may connect features as well as geometries.</p>
+</div>
+<div class="paragraph">
+<p>A Dimensionally Extended 9-Intersection Model (DE-9IM) pattern, which specifies the spatial dimension of the intersections of the interiors, boundaries and exteriors of two geometric objects, is used to describe each spatial relation. Possible pattern values are <code>-1 (empty)</code>, <code>0, 1, 2, T (true) = {0, 1, 2}</code>, <code>F (false) = {-1}</code>, <code>* (don’t care) = {-1, 0, 1, 2}</code>. In the following descriptions, the notation <code>X/Y</code> is used denote applying a spatial relation to geometry types <code>X</code> and <code>Y</code> (i.e., <code>x</code> <em>relation</em> <code>y</code> where <code>x</code> is of type <code>X</code> and <code>y</code> is of type <code>Y</code>). The symbol <code>P</code> is used for 0- dimensional geometries (e.g. points). The symbol <code>L</code> is used for 1-dimensional geometries (e.g. lines), and the symbol <code>A</code> is used for 2-dimensional geometries (e.g. polygons). Consult the Simple Features specification <a href="#ISO19125-1">[ISO19125-1]</a> for a more detailed description of DE-9IM intersection patterns.</p>
+</div>
+<div class="sect2">
+<h3 id="_parameters"><a class="anchor" href="#_parameters"></a>7.1. Parameters</h3>
+<div class="paragraph">
+<p>The following parameter is defined for the <em>Topology Vocabulary Extension</em> requirements class.</p>
+</div>
+<div class="paragraph">
+<p><strong>relation_family</strong>: Specifies the set of topological spatial relations to support.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_simple_features_relation_family_relation_familysimple_features"><a class="anchor" href="#_simple_features_relation_family_relation_familysimple_features"></a>7.2. Simple Features Relation Family (relation_family=Simple Features)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the <em>Simple Features</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 8</strong> Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#sfEquals"><code>geo:sfEquals</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfDisjoint"><code>geo:sfDisjoint</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfIntersects"><code>geo:sfIntersects</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfTouches"><code>geo:sfTouches</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfCrosses"><code>geo:sfCrosses</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfWithin"><code>geo:sfWithin</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfContains"><code>geo:sfContains</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfOverlaps"><code>geo:sfOverlaps</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations"><code>http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Topological relations in the <em>Simple Features</em> family are summarized in <a href="#sf_relations">Table 2</a>. Multi-row intersection patterns should be interpreted as a logical <code>OR</code> of each row.</p>
+</div>
+<table id="sf_relations" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 2. Simple Features Topological Relations</caption>
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation Name</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation IRI</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Domain/Range</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Applies To Geometry Types</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfEquals"><code>geo:sfEquals</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disjoint</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfDisjoint"><code>geo:sfDisjoint</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FF**FF****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">intersects</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfIntersects"><code>geo:sfIntersects</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T******** *T******* ***T***** ****T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">touches</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfTouches"><code>geo:sfTouches</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All except P/P</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">within</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfWithin"><code>geo:sfWithin</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*F**F***)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">contains</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfContains"><code>geo:sfContains</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*****FF*)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">overlaps</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfOverlaps"><code>geo:sfOverlaps</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A, P/P, L/L</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**) for A/A, P/P</code>; <code>(1*T***T**) for L/L</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">crosses</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfCrosses"><code>geo:sfCrosses</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>P/L, P/A, L/A, L/L</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**) for P/L, P/A,
+L/A</code>; <code>(0********) for L/L</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_egenhofer_relation_family_relation_familyegenhofer"><a class="anchor" href="#_egenhofer_relation_family_relation_familyegenhofer"></a>7.3. Egenhofer Relation Family (relation_family=Egenhofer)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the 9-intersection model for binary topological relations (<em>Egenhofer</em>) relation family. Consult references <a href="#FORMAL">[FORMAL]</a> and <a href="#CATEG">[CATEG]</a> for a more detailed discussion of <em>Egenhofer</em> relations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 9</strong> Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#ehEquals"><code>geo:ehEquals</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehDisjoint"><code>geo:ehDisjoint</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehMeet"><code>geo:ehMeet</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehOverlap"><code>geo:ehOverlap</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehCovers"><code>geo:ehCovers</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehCoveredBy"><code>geo:ehCoveredBy</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehInside"><code>geo:ehInside</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehContains"><code>geo:ehContains</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations"><code>http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Topological relations in the <em>Egenhofer</em> family are summarized in <a href="#genhofer_relations">Table 3</a>. Multi-row intersection patterns should be interpreted as a logical <code>OR</code> of each row.</p>
+</div>
+<table id="genhofer_relations" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 3. Egenhofer Topological Relations</caption>
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation Name</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation IRI</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Domain/Range</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Applies To Geometry Types</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehEquals"><code>geo:ehEquals</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disjoint</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehDisjoint"><code>geo:ehDisjoint</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FF*FF****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">meet</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehMeet"><code>geo:ehMeet</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All except P/P</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">overlap</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehOverlap"><code>geo:ehOverlap</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">covers</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehCovers"><code>geo:ehCovers</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A, A/L, L/L</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*TFT*FF*)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">covered by</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehCoveredBy"><code>geo:ehCoveredBy</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A, L/A, L/L</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFF*TFT**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">inside</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehInside"><code>geo:ehInside</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFF*FFT**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">contains</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehContains"><code>geo:ehContains</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*TFF*FF*)</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_rcc8_relation_family_relation_familyrcc8"><a class="anchor" href="#_rcc8_relation_family_relation_familyrcc8"></a>7.4. RCC8 Relation Family (relation_family=RCC8)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the region connection calculus basic 8 (<em>RCC8</em>) relation family. Consult references <a href="#QUAL">[QUAL]</a> and <a href="#LOGIC">[LOGIC]</a> for a more detailed discussion of <em>RCC8</em> relations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 10</strong> Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#rcc8eq"><code>geo:rcc8eq</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8dc"><code>geo:rcc8dc</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8ec"><code>geo:rcc8ec</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8po"><code>geo:rcc8po</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tppi"><code>geo:rcc8tppi</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tpp"><code>geo:rcc8tpp</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8ntpp"><code>geo:rcc8ntpp</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8ntppi"><code>geo:rcc8ntppi</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations"><code>http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Topological relations in the <em>RCC8</em> family are summarized in <a href="#rcc8_relations">Table 4</a>.</p>
+</div>
+<table id="rcc8_relations" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 4. RCC8 Topological Relations</caption>
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation Name</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation IRI</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Domain/Range</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Applies To Geometry Types</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8eq"><code>geo:rcc8eq</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disconnected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8dc"><code>geo:rcc8dc</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FFTFFTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">externally connected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ec"><code>geo:rcc8ec</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FFTFTTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">partially overlapping</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8po"><code>geo:rcc8po</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTTTTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">tangential proper part inverse</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8tppi"><code>geo:rcc8tppi</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTFTTFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">tangential proper part</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8tpp"><code>geo:rcc8tpp</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFTTFTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">non-tangential proper part</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ntpp"><code>geo:rcc8ntpp</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFTFFTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">non-tangential proper part inverse</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ntppi"><code>geo:rcc8ntppi</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTFFTFFT)</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_equivalent_rcc8_egenhofer_and_simple_features_topological_relations"><a class="anchor" href="#_equivalent_rcc8_egenhofer_and_simple_features_topological_relations"></a>7.5. Equivalent RCC8, Egenhofer and Simple Features Topological Relations</h3>
+<div class="paragraph">
+<p><a href="#relation_equivalences">Table 5</a> summarizes the equivalences between <em>Egenhofer</em>, <em>RCC8</em> and <em>Simple Features</em> spatial relations for closed, non-empty regions. The symbol <code>+</code> denotes logical <code>OR</code>, and the symbol <code>¬</code> denotes negation.</p>
+</div>
+<table id="relation_equivalences" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 5. Equivalent Simple Features, RCC8 and Egenhofer relations</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Simple Features</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">RCC8</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Egenhofer</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disjoint</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disconnected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disjoint</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">intersects</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>¬</code> disconnected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>¬</code> disjoint</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">touches</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">externally connected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">meet</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">within</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">non-tangential proper part <code>+</code> tangential proper part</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">inside <code>+</code> coveredBy</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">contains</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">non-tangential proper part inverse <code>+</code> tangential proper part inverse</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">contains <code>+</code> covers</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">overlaps</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">partially overlapping</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">overlap</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_geometry_extension_serialization_version"><a class="anchor" href="#_geometry_extension_serialization_version"></a>8. Geometry Extension (serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>Geometry Extension (serialization, version)</em> parameterized requirements class, with IRI <code>/req/geometry-extension</code>, which has a single corresponding conformance class <em>Geometry Extension (serialization, version)</em>, with IRI <code>/conf/geometry-extension</code>. This requirements class defines a vocabulary for asserting and querying information about geometry data, and it defines query functions for operating on geometry data.</p>
+</div>
+<div class="paragraph">
+<p>As part of the vocabulary, an RDFS datatype is defined for encoding detailed geometry information as a literal value. A literal representation of a geometry is needed so that geometric values may be treated as a single unit. Such a representation allows geometries to be passed to external functions for computations and to be returned from a query.</p>
+</div>
+<div class="paragraph">
+<p>Other schemes for encoding simple geometry data in RDF have been implemented. The W3C Basic Geo vocabulary<sup class="footnote">[<a id="_footnoteref_4" class="footnote" href="#_footnotedef_4" title="View footnote.">4</a>]</sup> was an early (2003) RDF vocabulary for "representing lat(itude), long(itude) and other information about spatially-located things, using WGS84 as a reference datum" and many widely used Semantic Web vocabularies contain some spatial data support. For example, <em>Dublin Core Terms</em> provides a <em>Location</em> class<sup class="footnote">[<a id="_footnoteref_5" class="footnote" href="#_footnotedef_5" title="View footnote.">5</a>]</sup> for "A spatial region or named place." and <em>schema.org</em> provides a number of spatial object and geometry classes, such as <code>GeoCoordinates</code> <sup class="footnote">[<a id="_footnoteref_6" class="footnote" href="#_footnotedef_6" title="View footnote.">6</a>]</sup> and <code>GeoShape</code> <sup class="footnote">[<a id="_footnoteref_7" class="footnote" href="#_footnotedef_7" title="View footnote.">7</a>]</sup>.</p>
+</div>
+<div class="paragraph">
+<p>Many vocabularies, such as these two, provide little specific support for detailed geometries and only support the WGS84 Coordinate Reference System (CSR).</p>
+</div>
+<div class="paragraph">
+<p>Since 2012 and the first version of GeoSPARQL, many ontologies have imported GeoSPARQL, for example, the <em>ISA Programme Location Core Vocabulary</em> <sup class="footnote">[<a id="_footnoteref_8" class="footnote" href="#_footnotedef_8" title="View footnote.">8</a>]</sup> whose usage notes provide examples containing GeoSPARQL literals and the use of GeoSPARQL&#8217;s "geometry class". The W3C&#8217;s more recent <em>Data Catalog Vocabulary, Version 2</em> (DCAT2) standard<sup class="footnote">[<a id="_footnoteref_9" class="footnote" href="#_footnotedef_9" title="View footnote.">9</a>]</sup> similarly contains usage notes for <code>geometry</code>, <code>bbox</code> and other properties that suggest the use of GeoSPARQL literals.</p>
+</div>
+<div class="paragraph">
+<p>Some of the properties defined in these vocabularies, such as DCAT2&#8217;s <code>spatialResolution</code> have motivated the inclusion of new properties in this version of GeoSPARQL. In this case the equivalent property is <a href="#_property_geohasspatialresolution">has spatial resolution</a>. The GeoSPARQL 1.1 Standards Working Group charter <a href="#CHARTER">[CHARTER]</a> contains references to a number of vocabularies/ontologies that were influential in the generation of this verison of GeoSPARQL.</p>
+</div>
+<div class="sect2">
+<h3 id="_parameters_2"><a class="anchor" href="#_parameters_2"></a>8.1. Parameters</h3>
+<div class="paragraph">
+<p>The following parameters are defined for the <em>Geometry Extension</em> requirements class.</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">serialization</dt>
+<dd>
+<p>Specifies the serialization standard to use when generating geometry literals and also the supported geometry types.</p>
+</dd>
+</dl>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+a serialization strongly affects the geometry conceptualization. The WKT serialization aligns the geometry types with <em>ISO 19125 Simple Features</em> <a href="#ISO19125-1">[ISO19125-1]</a>, and the GML serialization aligns the geometry types with <em>ISO 19107 Spatial Schema</em> <a href="#ISO19107">[ISO19107]</a>.
+</td>
+</tr>
+</table>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">version</dt>
+<dd>
+<p>Specifies the version of the serialization format used.</p>
+</dd>
+</dl>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_geometry_class"><a class="anchor" href="#_geometry_class"></a>8.2. Geometry Class</h3>
+<div class="paragraph">
+<p>A single root geometry class is defined: <a href="#_class_geogeometry">Geometry</a>. In addition, properties are defined for describing geometry data and for associating geometries with features.</p>
+</div>
+<div class="paragraph">
+<p>One container class is defined: <a href="#_class_geogeometrycollection">Geometry Collection</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="_class_geogeometry"><a class="anchor" href="#_class_geogeometry"></a>8.2.1. Class: geo:Geometry</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#Geometry"><code>geo:Geometry</code></a> is equivalent to <code>GM_Object</code> <a href="#ISO19107">[ISO19107]</a> and is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:Geometry
+    a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Geometry"@en ;
+    rdfs:subClassOf geo:SpatialObject ;
+    owl:disjointWith geo:Feature;
+    skos:definition "The class represents the top-level geometry type. This class
+                    is equivalent to the UML class GM_Object defined in ISO 19107,
+                    and it is superclass of all geometry types."@en ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 11</strong> Implementations shall allow the RDFS class <a href="#_class_geogeometry">Geometry</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-class"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_class_geogeometrycollection"><a class="anchor" href="#_class_geogeometrycollection"></a>8.2.2. Class: geo:GeometryCollection</h4>
+<div class="paragraph">
+<p>The class <a href="#_class_geogeometrycollection">Geometry Collection</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:GeometryCollection
+  a owl:Class ;
+  rdfs:isDefinedBy geo: ;
+  skos:prefLabel "Collection of geometry entities"@en ;
+  skos:definition "The class Geometry Collection represents any collection of Geometry entities."@en ;
+  rdfs:subClassOf geo:SpatialObjectCollection ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom geo:Geometry ;
+      owl:onProperty rdfs:member ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 12</strong> Implementations shall allow the RDFS class <a href="#_class_geogeometrycollection">Geometry Collection</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/core/geometry-collection-class"><code>http://www.opengis.net/spec/geosparql/1.1/req/core/geometry-collection-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_standard_properties_for_geogeometry"><a class="anchor" href="#_standard_properties_for_geogeometry"></a>8.3. Standard Properties for geo:Geometry</h3>
+<div class="paragraph">
+<p>Properties are defined for describing geometry metadata.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 13</strong> Implementations shall allow the properties <a href="#_property_geodimension">dimension</a>, <a href="#_property_geocoordinatedimension">coordinate dimension</a>, <a href="#_property_geospatialdimension">spatial dimension</a>, <a href="#_property_geoisempty">is empty</a>, <a href="#_property_geoissimple">is simple</a>, <a href="#_property_geohasserialization">has serialization</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-properties"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-properties</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect3">
+<h4 id="_property_geodimension"><a class="anchor" href="#_property_geodimension"></a>8.3.1. Property: geo:dimension</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#dimension"><code>geo:dimension</code></a> is used to link the a geometry object to its topological dimension, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this will return the largest topological dimension of the contained objects.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:dimension
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "dimension"@en ;
+    skos:definition "The topological dimension of this geometric object, which
+                    must be less than or equal to the coordinate dimension. In
+                    non-homogeneous collections, this is the largest
+                    topological dimension of the contained objects."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:integer ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geocoordinatedimension"><a class="anchor" href="#_property_geocoordinatedimension"></a>8.3.2. Property: geo:coordinateDimension</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#coordinateDimension"><code>geo:coordinateDimension</code></a> is defined to link a geometry object to the dimension of direct positions (coordinate tuples) used in the geometry&#8217;s definition.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:coordinateDimension
+    a rdf:Property, owl:DatatypeProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "coordinate dimension"@en ;
+    skos:definition "The number of measurements or axes needed to describe the
+                    position of this geometry in a coordinate system."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:integer ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geospatialdimension"><a class="anchor" href="#_property_geospatialdimension"></a>8.3.3. Property: geo:spatialDimension</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#spatialDimension"><code>geo:spatialDimension</code></a> is defined to link a geometry object to the dimension of the spatial portion of the direct positions (coordinate tuples) used in its serializations. If the direct positions do not carry a measure coordinate, this will be equal to the coordinate dimension.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:spatialDimension
+    a rdf:Property, owl:DatatypeProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "spatial dimension"@en ;
+    skos:definition "The number of measurements or axes needed to describe the
+                    spatial position of this geometry in a coordinate system."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:integer ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasspatialresolution"><a class="anchor" href="#_property_geohasspatialresolution"></a>8.3.4. Property: geo:hasSpatialResolution</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasSpatialResolution"><code>geo:hasSpatialResolution</code></a> is defined to indicate spatial resolution of the elements within a Geometry. Spatial resolution specifies the level of detail of a Geometry. It the smallest dinstinghuishable distance between adjacent coordinate sets. Therefore this property is not applicable to a point Geometry, because it consists of a single coordinate set.</p>
+</div>
+<div class="paragraph">
+<p>Since this property is defined for a <a href="#_class_geogeometry">Geometry</a>, all literal representations of that Geometry instance must have the same spatial resolution.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasSpatialResolution
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has spatial resolution"@en ;
+    skos:definition "The spatial resolution of a Geometry"@en ;
+    rdfs:domain geo:Geometry ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetricspatialresolution"><a class="anchor" href="#_property_geohasmetricspatialresolution"></a>8.3.5. Property: geo:hasMetricSpatialResolution</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution"><code>geo:hasMetricSpatialResolution</code></a> is similar to <a href="#_property_geohasspatialresolution">has spatial resolution</a>, specifies that the unit of resolution distance is always meter (the standard distance unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricSpatialResolution
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has spatial resolution in meters"@en ;
+    skos:definition "The spatial resolution of a Geometry in meters."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:double ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasspatialaccuracy"><a class="anchor" href="#_property_geohasspatialaccuracy"></a>8.3.6. Property: geo:hasSpatialAccuracy</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasSpatialAccuracy"><code>geo:hasSpatialAccuracy</code></a> is applicable when a Geometry is used to represent a Feature. It is expressed as a distance that indicates the truthfullness of the positions (coordinates) that define the Geometry. In this case accuracy defines a zone surrounding each coordinate within wich the real positions are known to be. The accuracy value defines this zone as a distance from the coordinate(s) in all directions (e.g. a line, a circle or a sphere, depending on spatial dimension).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasSpatialAccuracy
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has spatial accuracy"@en ;
+    skos:definition "The positional accuracy of the coordinates of a Geometry."@en ;
+    rdfs:domain geo:Geometry ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetricspatialaccuracy"><a class="anchor" href="#_property_geohasmetricspatialaccuracy"></a>8.3.7. Property: geo:hasMetricSpatialAccuracy</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy"><code>geo:hasMetricSpatialAccuracy</code></a> is similar to <a href="#_property_geohasspatialaccuracy">has spatial accuracy</a>, but it is easier to specify and use because the unit of distance is always meter (the standard distance unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricSpatialAccuracy
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has spatial accuracy in meters"@en ;
+    skos:definition "The positional accuracy of the coordinates of a Geometry in meters."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:double ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geoisempty"><a class="anchor" href="#_property_geoisempty"></a>8.3.8. Property: geo:isEmpty</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#isEmpty"><code>geo:isEmpty</code></a> will indicate a Boolean object set to <code>true</code> if and only if the geometry contains no information.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:isEmpty
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "is empty"@en ;
+    skos:definition "(true) if this geometric object is the empty Geometry. If
+                    true, then this geometric object represents the empty point
+                    set for the coordinate space."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:boolean ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geoissimple"><a class="anchor" href="#_property_geoissimple"></a>8.3.9. Property: geo:isSimple</h4>
+<div class="paragraph">
+<p>The proeprty <a href="http://www.opengis.net/ont/geosparql#isSimple"><code>geo:isSimple</code></a> will indicate a Boolean object set to <code>true</code>, only if the geometry contains no self-intersections, with the possible exception of its boundary.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:isSimple
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "is simple"@en ;
+    skos:definition "(true) if this geometric object has no anomalous geometric
+                    points, such as self intersection or self tangency."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:boolean ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasserialization"><a class="anchor" href="#_property_geohasserialization"></a>8.3.10. Property: geo:hasSerialization</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasSerialization"><code>geo:hasSerialization</code></a> is defined to connect a geometry with its text-based serialization (e.g., its WKT serialization).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasSerialization
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has serialization"@en ;
+    skos:definition "Connects a geometry object with its text-based serialization."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range rdfs:Literal ;
+.</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+this property is the generic property used to connect a geometry with its serialization. GeoSPARQL also contains a number of sub properties of this one for connecting serializations of common types with geometries, for example <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> which can be used for GeoJSON <a href="#GEOJSON">[GEOJSON]</a> literals.
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_geometry_serializations"><a class="anchor" href="#_geometry_serializations"></a>8.4. Geometry Serializations</h3>
+<div class="paragraph">
+<p>This section establishes the requirements for representing geometry data in RDF based on different systems.</p>
+</div>
+<div class="sect3">
+<h4 id="_well_known_text_serializationwkt"><a class="anchor" href="#_well_known_text_serializationwkt"></a>8.4.1. Well-Known Text (serialization=WKT)</h4>
+<div class="paragraph">
+<p>This section establishes the requirements for representing geometry data in RDF based on Well-Known Text (WKT) as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>. It defines one RDFS Datatype: <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>http://www.opengis.net/ont/geosparql#wktLiteral</code></a> and one property, <a href="#_function_geofaswkt">as WKT</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geowktliteral"><a class="anchor" href="#_rdfs_datatype_geowktliteral"></a>8.4.1.1. RDFS Datatype: geo:wktLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> is used to contain the Well-Known Text (WKT) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:wktLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Well-known Text literal"@en ;
+    skos:definition "A Well-known Text serialization of a geometry object."@en ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 14</strong> All RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> shall consist of an optional IRI identifying the coordinate reference system and a required Well Known Text (WKT) description of a geometric value. Valid <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiterals</code></a> are formed by either a WKT string as defined in <a href="#ISO13249">[ISO13249]</a> or by concatenating a valid absolute IRI, as defined in <a href="#IETF3987">[IETF3987]</a>, enclose in angled brackets (<code>&lt;</code> &amp; <code>&gt;</code>) followed by a single space (Unicode U+0020 character) as a separator, and a WKT string as defined in <a href="#ISO13249">[ISO13249]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The following <em>ABNF</em> <a href="#IETF5234">[IETF5234]</a> syntax specification formally defines this literal:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>wktLiteral ::= opt-iri-and-space geometric-data
+
+opt-iri-and-space = "&lt;" IRI "&gt;" LWSP / ""</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The token <code>opt-iri-and-space</code> may be either an IRI and space or nothing (<code>""</code>), the token <code>IRI</code> (Internationalized Resource Identifier) is essentially a web address and is defined in <a href="#IETF3987">[IETF3987]</a> and the token <code>LWSP</code>, is one or more white space characters, as defined in <a href="#IETF5234">[IETF5234]</a>. <code>geometric-data</code> is the Well-Known Text representation of the geometry, defined in <a href="#ISO13249">[ISO13249]</a>.</p>
+</div>
+<div class="paragraph">
+<p>In the absence of a leading spatial reference system IRI, the following spatial reference system IRI will be assumed: <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><code>&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</code></a>. This IRI denotes WGS 84 longitude-latitude.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 15</strong> The IRI <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><code>&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</code></a> shall be assumed as the spatial reference system for <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> instances that do not specify an explicit spatial reference system IRI.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-default-srs"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-default-srs</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The OGC maintains a set of SRS IRIs under the <code>http://www.opengis.net/def/crs/</code> namespace and IRIs from this set are recommended for use, however others may also be used, as long as they are valid IRIs.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 16</strong> Coordinate tuples within <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> shall be interpreted using the axis order defined in the spatial reference system used.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-axis-order"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-axis-order</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"Point(-83.38 33.95)"^^&lt;http://www.opengis.net/ont/geosparql#wktLiteral&gt;</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>A second example below encodes the same point as encoded in the example above but using a SRS identified by <a href="http://www.opengis.net/def/SRS/EPSG/0/4326"><code>http://www.opengis.net/def/SRS/EPSG/0/4326</code></a>: a WGS 84 geodetic latitude-longitude spatial reference system (note that this spatial reference system defines a different axis order):</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; Point(33.95 -83.38)"^^&lt;http://www.opengis.net/ont/geosparql#wktLiteral&gt;</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 17</strong> An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> shall be interpreted as an empty geometry.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoaswkt"><a class="anchor" href="#_property_geoaswkt"></a>8.4.1.2. Property: geo:asWKT</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> is defined to link a geometry with its WKT serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 18</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-wkt-literal"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-wkt-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> is used to link a geometric element with its WKT serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asWKT
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as WKT"@en ;
+    skos:definition "The WKT serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:wktLiteral ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofaswkt"><a class="anchor" href="#_function_geofaswkt"></a>8.4.1.3. Function: geof:asWKT</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asWKT (geom: ogc:geomLiteral): geo:wktLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a> converts <code>geom</code> to an equivalent WKT representation preserving the coordinate reference system.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 19</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asWKT-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asWKT-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_geography_markup_language_serializationgml"><a class="anchor" href="#_geography_markup_language_serializationgml"></a>8.4.2. Geography Markup Language (serialization=GML)</h4>
+<div class="paragraph">
+<p>This section establishes requirements for representing geometry data in RDF based on GML as defined by Geography Markup Language Encoding Standard <a href="#OGC07-036">[OGC07-036]</a>. It defines one RDFS Datatype:
+<a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>http://www.opengis.net/ont/geosparql#gmlLiteral</code></a> and one property, <a href="#_function_geofasgml">as GML</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geogmlliteral"><a class="anchor" href="#_rdfs_datatype_geogmlliteral"></a>8.4.2.1. RDFS Datatype: geo:gmlLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> is used to contain the Geography Markup Language (GML) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:gmlLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "GML literal"@en ;
+    skos:definition "The datatype of GML literal values"@en ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> instances are formed by encoding geometry information as a valid element from the GML schema that implements a subtype of <code>GM_Object</code>. For example, in GML 3.2.1 this is every element directly or indirectly in the substitution group of the element <code>{http://www.opengis.net/ont/gml/3.2}AbstractGeometry</code>. In GML 3.1.1 and GML 2.1.2 this is every element directly or indirectly in the substitution group of the element <code>{http://www.opengis.net/ont/gml}_Geometry</code>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 20</strong> All <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> instances shall consist of a valid element from the GML schema that implements a subtype of <code>GM_Object</code> as defined in <a href="#OGC07-036">[OGC07-036]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> below encodes a point geometry in the WGS 84 geodetic longitude-latitude spatial reference system using GML version 3.2:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"""
+&lt;gml:Point
+        srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"
+        xmlns:gml=\"http://www.opengis.net/ont/gml\"&gt;
+    &lt;gml:pos&gt;-83.38 33.95&lt;/gml:pos&gt;
+&lt;/gml:Point&gt;
+"""^^&lt;http://www.opengis.net/ont/geosparql#gmlLiteral&gt;</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 21</strong> An empty <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> shall be interpreted as an empty geometry.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 22</strong> Implementations shall document supported GML profiles.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-profile"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-profile</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoasgml"><a class="anchor" href="#_property_geoasgml"></a>8.4.2.2. Property: geo:asGML</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> is defined to link a geometry with its GML serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 23</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-gml-literal"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-gml-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> is used to link a geometric element with its GML serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asGML
+    a rdf:Property ;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as GML"@en ;
+    skos:definition "The GML serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:gmlLiteral ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofasgml"><a class="anchor" href="#_function_geofasgml"></a>8.4.2.3. Function: geof:asGML</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asGML (geom: ogc:geomLiteral, gmlProfile: xsd:string): geo:gmlLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a> converts <code>geom</code> to an equivalent GML representation defined by a gmlProfile version string preserving the coordinate reference system.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 24</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asGML-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asGML-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_geojson_serializationgeojson"><a class="anchor" href="#_geojson_serializationgeojson"></a>8.4.3. GeoJSON (serialization=GEOJSON)</h4>
+<div class="paragraph">
+<p>This section establishes requirements for representing geometry data in RDF based on GeoJSON as defined by <a href="#GeoJSON">[GeoJSON]</a>. It defines one RDFS Datatype:
+<a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>http://www.opengis.net/ont/geosparql#geoJSONLiteral</code></a> and one property, <a href="#_function_geofasgeojson">as GeoJSON</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geogeojsonliteral"><a class="anchor" href="#_rdfs_datatype_geogeojsonliteral"></a>8.4.3.1. RDFS Datatype: geo:geoJSONLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:geoJSONLiteral</code></a> is used to contain the Geo JavaScript Object Notation (GeoJSON) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:geoJSONLiteral a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "GeoJSON Literal"@en ;
+    skos:definition "A GeoJSON serialization of a geometry object."@en .</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> instances are formed by encoding geometry information as a Geometry object as defined in the GeoJSON specification <a href="#GEOJSON">[GEOJSON]</a>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 25</strong> All <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> instances shall consist of the Geometry objects as defined in the GeoJSON specification <a href="#GEOJSON">[GEOJSON]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 26</strong> RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> do not contain a SRS definition. All literals of this type shall, according to the GeoJSON specification, be encoded only in, and be assumed to use, the WGS84 geodetic longitude-latitude spatial reference system (<a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><code>http://www.opengis.net/def/crs/OGC/1.3/CRS84</code></a>).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-srs"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-srs</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"""
+{"type": "Point", "coordinates": [-83.38,33.95]}
+"""^^&lt;http://www.opengis.net/ont/geosparql#geoJSONLiteral&gt;</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 27</strong> An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> shall be interpreted as an empty geometry, i.e. <code>{"geometry": null}</code> in GeoJSON .</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoasgeojson"><a class="anchor" href="#_property_geoasgeojson"></a>8.4.3.2. Property: geo:asGeoJSON</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> is defined to link a geometry with its GeoJSON serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 28</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-geojson-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-geojson-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> is used to link a geometric element with its GeoJSON serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asGeoJSON
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as GeoJSON"@en ;
+    skos:definition "The GeoJSON serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:geoJSONLiteral ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofasgeojson"><a class="anchor" href="#_function_geofasgeojson"></a>8.4.3.3. Function: geof:asGeoJSON</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asGeoJSON (geom: ogc:geomLiteral): geo:geoJSONLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a> converts <code>geom</code> to an equivalent GeoJSON representation. Coordinates are converted to the CRS84 coordinate system, the only valid coordinate system to be used in a GeoJSON literal.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 29</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asGeoJSON-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asGeoJSON-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_keyhole_markup_language_serializationkml"><a class="anchor" href="#_keyhole_markup_language_serializationkml"></a>8.4.4. Keyhole Markup Language (serialization=KML)</h4>
+<div class="paragraph">
+<p>This section establishes requirements for representing geometry data in RDF based on KML as defined by <a href="#OGCKML">[OGCKML]</a>. It defines one RDFS Datatype:
+<a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>http://www.opengis.net/ont/geosparql#kmlLiteral</code></a> and one property, <a href="#_function_geofaskml">as KML</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geokmlliteral"><a class="anchor" href="#_rdfs_datatype_geokmlliteral"></a>8.4.4.1. RDFS Datatype: geo:kmlLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> is used to contain the Keyhole Markup Language (KML) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:kmlLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "KML Literal"@en ;
+    skos:definition "A KML serialization of a geometry object."@en ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> instances are formed by encoding geometry information as a Geometry object as defined in the KML specification <a href="#OGCKML">[OGCKML]</a>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 30</strong> All <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> instances shall consist of the Geometry objects as defined in the KML specification <a href="#OGCKML">[OGCKML]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 31</strong> RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> do not contain a SRS definition. All literals of this type shall according to the KML specification only be encoded in and assumed to use the WGS84 geodetic longitude-latitude spatial reference system (<a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><code>http://www.opengis.net/def/crs/OGC/1.3/CRS84</code></a>).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-srs"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-srs</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"""
+&lt;Point xmlns=\"http://www.opengis.net/kml/2.2\"&gt;
+    &lt;coordinates&gt;-83.38,33.95&lt;/coordinates&gt;
+&lt;/Point&gt;
+"""^^&lt;http://www.opengis.net/ont/geosparql#kmlLiteral&gt;</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 32</strong> An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> shall be interpreted as an empty geometry .</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoaskml"><a class="anchor" href="#_property_geoaskml"></a>8.4.4.2. Property: geo:asKML</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a> is defined to link a geometry with its KML serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 33</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-kml-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-kml-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a> is used to link a geometric element with its KML serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asKML
+    a rdf:Property, owl:DatatypeProperty;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as KML"@en ;
+    skos:definition "The KML serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:kmlLiteral ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofaskml"><a class="anchor" href="#_function_geofaskml"></a>8.4.4.3. Function: geof:asKML</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asKML (geom: ogc:geomLiteral): geo:kmlLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a> converts <code>geom</code> to an equivalent KML representation. Coordinates are converted to the CRS84 coordinate system, the only valid coordinate system to be used in a KML literal.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 34</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asKML-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asKML-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_discrete_global_grid_system_serializationdggs"><a class="anchor" href="#_discrete_global_grid_system_serializationdggs"></a>8.4.5. Discrete Global Grid System (serialization=DGGS)</h4>
+<div class="paragraph">
+<p>This section establishes the requirements for representing Discrete Global Grid System (DGGS) geometry data as RDF literals. The form of representation is specific to individual DGGS implementations: known DGGSes are not compatible or even very similar.</p>
+</div>
+<div class="paragraph">
+<p>Here are defined two RDFS Datatypes:
+<a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>http://www.opengis.net/ont/geosparql#dggsLiteral</code></a> &amp; <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>http://www.opengis.net/ont/geosparql#auspixDggsLiteral</code></a> and one property, <a href="#_function_geofasdggs">as DGGS</a>.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+The two datatypes defined here are for an abstract DGGS implementation (<a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a>) and a specific one, AusPIX <a href="#AUSPIX">[AUSPIX]</a> (<a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a>). The purposes of including both of these are to indicate the conceptual position of DGGS literals in this specification - the abstract form acts as a parent of all other potential, specific, DGGS datatypes - and to exemplify a specific system implementation which allows for real examples of use.
+</td>
+</tr>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geodggsliteral"><a class="anchor" href="#_rdfs_datatype_geodggsliteral"></a>8.4.5.1. RDFS Datatype: geo:dggsLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a> is used to contain the Discrete Global Grid System (DGGS) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:dggsLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "DGGS Literal"@en ;
+    skos:definition "A textual serialization of a Discrete Global Grid System (DGGS) geometry object."@en
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a> instances are formed by encoding geometry information according to specific DGGS implementation. The specific implementation should be indicated by use of a subclass of the <code>geo:dggsLiteral</code> datatype.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 35</strong> All RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a> shall consist of a DGGS geometry serialization formulated according to a specific DGGS.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 36</strong> An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a>, or one of its data subtypes, shall be interpreted as an empty <code>geo:Geometry</code>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geoauspixdggsliteral"><a class="anchor" href="#_rdfs_datatype_geoauspixdggsliteral"></a>8.4.5.2. RDFS Datatype: geo:auspixDggsLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a> is used to contain the AusPIX Discrete Global Grid System (DGGS) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:auspixDggsLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "AusPIX DGGS Literal"@en ;
+    skos:definition "A textual serialization of an AusPIX Discrete Global Grid System (DGGS) geometry object."@en ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a> instances are formed by encoding geometry information according to the AusPIX DGGS implementation <a href="#AUSPIX">[AUSPIX]</a>.</p>
+</div>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a> below encodes a point geometry according to the <em>AusPIX</em> DGGS. The DGGS geometry type is indicated with the token <code>CellList</code> and the list of values, a single cell, is enclosed in parenthesis. The cell value of <em>R3234</em> is analogous to either a <code>Point</code> or simple <code>Polygon</code> in WKT geometries, so a single coordinate pair or a list of them:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"CellList (R3234)"^^&lt;http://www.opengis.net/ont/geosparql#auspixDggsLiteral&gt;</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+What <code>R3234</code> means is not handled by GeoSPARQL but by the AusPIX DGGS specification <a href="#AUSPIX">[AUSPIX]</a>, just as GeoPSARQL does not delve into the internals of other geometry formats such as WKT or GeoJSON.
+</td>
+</tr>
+</table>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 37</strong> All RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a> shall consist of a DGGS geometry serialization formulated according to the AusPIX DGGS.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/auspix-dggs-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/auspix-dggs-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoasdggs"><a class="anchor" href="#_property_geoasdggs"></a>8.4.5.3. Property: geo:asDGGS</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> is defined to link a geometry with its DGGS serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 38</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-dggs-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-dggs-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> is used to link a Geometry instance with its serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asDGGS
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as DGGS"@en ;
+    skos:definition "A DGGS Well-Known Text serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:dggsLiteral ;
+.</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+It is expected that this property will be used to indicate specific DGGS data types, such as <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a>, descibed above, as opposed to the generic <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a>.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofasdggs"><a class="anchor" href="#_function_geofasdggs"></a>8.4.5.4. Function: geof:asDGGS</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asDGGS (geom: ogc:geomLiteral, specificDggsDatatype: xsd:anyURI): geo:DggsLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a> converts <code>geom</code> to an equivalent DGGS representation, formulated according to the specific DGGS literal indicated using the <code>specificDggsDatatype</code> parameter.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 39</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asDGGS-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asDGGS-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_non_topological_query_functions"><a class="anchor" href="#_non_topological_query_functions"></a>8.5. Non-topological Query Functions</h3>
+<div class="paragraph">
+<p>This clause defines SPARQL functions for performing non-topological spatial operations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 40</strong> Implementations shall support <a href="#_function_geofdistance">distance</a>, <a href="#_function_geofbuffer">buffer</a>, <a href="#_function_geofconvexhull">convex hull</a>, <a href="#_function_geofintersection">intersection</a>, <a href="#_function_geofunion">union</a>,
+<a href="#_function_geofisempty">is empty</a>, <a href="#_function_geofissimple">is simple</a>,
+<a href="#_function_geofarea">area</a>, <a href="#_function_geoflength">length</a>,
+<a href="#_function_geofnumgeometries">num geometries</a>,
+<a href="#_function_geofgeometryn">geometry n</a>, <a href="#_function_geoftransform">transform</a>,
+<a href="#_function_geofdimension">dimension</a>, <a href="#_function_geofdifference">difference</a>, <a href="#_function_geofsymdifference">sym difference</a>, <a href="#_function_geofenvelope">envelope</a>, <a href="#_function_geofboundary">boundary</a> as SPARQL extension functions, consistent with the definitions of their corresponding functions in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a> (<code>distance</code>, <code>buffer</code>, <code>convexHull</code>, <code>intersection</code>, <code>union</code>, <code>isEmpty</code>, <code>isSimple</code>, <code>area</code>, <code>length</code>, <code>numGeometries</code>, <code>geometryN</code>, <code>transform</code>, <code>dimension</code>, <code>difference</code>, <code>symDifference</code>, <code>envelope</code> and <code>boundary</code> respectively) and other attached definitions.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>An invocation of any of the following functions with invalid arguments produces an error. An invalid argument includes any of the following:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>An argument of an unexpected type</p>
+</li>
+<li>
+<p>An invalid geometry literal value</p>
+</li>
+<li>
+<p>A geometry literal from a spatial reference system that is incompatible with the spatial reference system used for calculations</p>
+</li>
+<li>
+<p>An invalid units IRI</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>For further discussion of the effects of errors during FILTER evaluation, consult Section 17<sup class="footnote">[<a id="_footnoteref_10" class="footnote" href="#_footnotedef_10" title="View footnote.">10</a>]</sup> of the SPARQL specification <a href="#SPARQL">[SPARQL]</a>.</p>
+</div>
+<div class="paragraph">
+<p>Note that returning values instead of raising an error serves as an extension mechanism of SPARQL.</p>
+</div>
+<div class="paragraph">
+<p>From Section 17.3.1<sup class="footnote">[<a id="_footnoteref_11" class="footnote" href="#_footnotedef_11" title="View footnote.">11</a>]</sup> of the SPARQL specification <a href="#SPARQL">[SPARQL]</a>:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+SPARQL language extensions may provide additional associations between operators and operator functions; &#8230;&#8203; No additional operator may yield a result that replaces any result other &#8230;&#8203; . The consequence of this rule is that SPARQL <code>FILTER</code> s will produce at least the same intermediate bindings after applying a <code>FILTER</code> as an unextended implementation.
+</blockquote>
+</div>
+<div class="paragraph">
+<p>This extension mechanism enables GeoSPARQL implementations to simultaneously support multiple geometry serializations. For example, a system that supports <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> serializations may also support <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> serializations and consequently would not raise an error if it encounters multiple geometry datatypes while processing a given query.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+Several non-topological query functions use a unit of measure IRI. The OGC has recommended units of measure vocabularies for use, see the OGC Definitions Server<sup class="footnote">[<a id="_footnoteref_12" class="footnote" href="#_footnotedef_12" title="View footnote.">12</a>]</sup>.
+</td>
+</tr>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_function_geofdistance"><a class="anchor" href="#_function_geofdistance"></a>8.5.1. Function: geof:distance</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:distance (geom1: ogc:geomLiteral,
+               geom2: ogc:geomLiteral,
+               units: xsd:anyURI): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the shortest distance between any two Points in the two geometric objects. Calculations are in spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofbuffer"><a class="anchor" href="#_function_geofbuffer"></a>8.5.2. Function: geof:buffer</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:buffer (geom: ogc:geomLiteral,
+             radius: xsd:double,
+             units: xsd:anyURI): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns a geometric object that represents all Points whose distance from <code>geom1</code> is less than or equal to the <code>radius</code> measured in <code>units</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofconvexhull"><a class="anchor" href="#_function_geofconvexhull"></a>8.5.3. Function: geof:convexHull</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:convexHull (geom1: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns a geometric object that represents all Points in the convex hull of <code>geom1</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofisempty"><a class="anchor" href="#_function_geofisempty"></a>8.5.4. Function: geof:isEmpty</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:isEmpty (geom1: ogc:geomLiteral): xsd:boolean</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns true if <code>geom1</code> is an empty geometry, i.e. contains no coordinates.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofissimple"><a class="anchor" href="#_function_geofissimple"></a>8.5.5. Function: geof:isSimple</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:isSimple (geom1: ogc:geomLiteral): xsd:boolean</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns true if <code>geom1</code> is a simple geometry, i.e. has no anomalous geometric points, such as self intersection or self tangency.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofarea"><a class="anchor" href="#_function_geofarea"></a>8.5.6. Function: geof:area</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:area (geom1: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the area of <code>geom1</code> in squaremeters.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geoflength"><a class="anchor" href="#_function_geoflength"></a>8.5.7. Function: geof:length</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:length (geom1: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the length of <code>geom1</code> in meters.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofdimension"><a class="anchor" href="#_function_geofdimension"></a>8.5.8. Function: geof:dimension</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:dimension (geom1: ogc:geomLiteral): xsd:integer</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the dimension of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofnumgeometries"><a class="anchor" href="#_function_geofnumgeometries"></a>8.5.9. Function: geof:numGeometries</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:numGeometries (geom1: ogc:geomLiteral): xsd:integer</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the number of geometries of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofgeometryn"><a class="anchor" href="#_function_geofgeometryn"></a>8.5.10. Function: geof:geometryN</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:geometryN (geom1: ogc:geomLiteral): xsd:integer</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the nth geometry of <code>geom1</code> if it is a GeometryCollection .</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geoftransform"><a class="anchor" href="#_function_geoftransform"></a>8.5.11. Function: geof:transform</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:transform (geom: ogc:geomLiteral, srsIRI: xsd:anyURI): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><a href="http://www.opengis.net/def/function/geosparql/transform">geof:transform</a> converts <code>geom</code> to a spatial reference system defined by srsIRI. The function raises an error if a transformation is not mathematically possible.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+We recommend that implementers use the same literal type as a result of this function that is passed as a parameter to this function.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofintersection"><a class="anchor" href="#_function_geofintersection"></a>8.5.12. Function: geof:intersection</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:intersection (geom1: ogc:geomLiteral,
+                   geom2: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns a geometric object that represents all Points in the intersection of <code>geom1</code> with <code>geom2</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofunion"><a class="anchor" href="#_function_geofunion"></a>8.5.13. Function: geof:union</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:union (geom1: ogc:geomLiteral,
+            geom2: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns a geometric object that represents all Points in the union of <code>geom1</code> with <code>geom2</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofdifference"><a class="anchor" href="#_function_geofdifference"></a>8.5.14. Function: geof:difference</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:difference (geom1: ogc:geomLiteral,
+                 geom2: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns a geometric object that represents all Points in the set difference of <code>geom1</code> with <code>geom2</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofsymdifference"><a class="anchor" href="#_function_geofsymdifference"></a>8.5.15. Function: geof:symDifference</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:symDifference (geom1: ogc:geomLiteral,
+                    geom2: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns a geometric object that represents all Points in the set symmetric difference of <code>geom1</code> with <code>geom2</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofenvelope"><a class="anchor" href="#_function_geofenvelope"></a>8.5.16. Function: geof:envelope</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:envelope (geom1: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns the minimum bounding box of <code>geom1</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofboundary"><a class="anchor" href="#_function_geofboundary"></a>8.5.17. Function: geof:boundary</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:boundary (geom1: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns the closure of the boundary of <code>geom1</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 41</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/getSRID"><code>geof:getSRID</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/srid-function"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/srid-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_function_geofgetsrid"><a class="anchor" href="#_function_geofgetsrid"></a>8.5.18. Function: geof:getSRID</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:getSRID (geom: ogc:geomLiteral): xsd:anyURI</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the spatial reference system IRI for <code>geom</code>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 42</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/concaveHull"><code>geof:concaveHull</code></a>, <a href="http://www.opengis.net/def/function/geosparql/boundingCircle"><code>geof:boundingCircle</code></a>, <a href="http://www.opengis.net/def/function/geosparql/union2"><code>geof:union2</code></a>, <a href="http://www.opengis.net/def/function/geosparql/concatLines"><code>geof:concatLines</code></a>, <a href="http://www.opengis.net/def/function/geosparql/concatLines"><code>geof:centroid</code></a>, <a href="http://www.opengis.net/def/function/geosparql/minX"><code>geof:maxX</code></a>,
+<a href="http://www.opengis.net/def/function/geosparql/maxY"><code>geof:maxY</code></a>, <a href="http://www.opengis.net/def/function/geosparql/maxZ"><code>geof:maxZ</code></a>,  <a href="http://www.opengis.net/def/function/geosparql/minX"><code>geof:minX</code></a>, <a href="http://www.opengis.net/def/function/geosparql/minY"><code>geof:minY</code></a> and <a href="http://www.opengis.net/def/function/geosparql/minZ"><code>geof:minZ</code></a> as a SPARQL extension functions.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_function_geofmaxx"><a class="anchor" href="#_function_geofmaxx"></a>8.5.19. Function: geof:maxX</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:maxX (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/maxX"><code>geof:maxX</code></a> returns the maximum X coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofmaxy"><a class="anchor" href="#_function_geofmaxy"></a>8.5.20. Function: geof:maxY</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:maxY (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/maxY"><code>geof:maxY</code></a> returns the maximum Y coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofmaxz"><a class="anchor" href="#_function_geofmaxz"></a>8.5.21. Function: geof:maxZ</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:maxZ (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/maxZ"><code>geof:maxZ</code></a> returns the maximum Z coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofminx"><a class="anchor" href="#_function_geofminx"></a>8.5.22. Function: geof:minX</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:minX (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/minX"><code>geof:minX</code></a> returns the minimum X coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofminy"><a class="anchor" href="#_function_geofminy"></a>8.5.23. Function: geof:minY</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:minY (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/minY"><code>geof:minY</code></a> returns the minimum Y coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofminz"><a class="anchor" href="#_function_geofminz"></a>8.5.24. Function: geof:minZ</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:minZ (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/minZ"><code>geof:minZ</code></a> returns the minimum Z coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofboundingcircle"><a class="anchor" href="#_function_geofboundingcircle"></a>8.5.25. Function: geof:boundingCircle</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:boundingCircle (geom: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/boundingCircle"><code>geof:boundingCircle</code></a> calculates a minimum bounding circle of the set of given geometries.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofcentroid"><a class="anchor" href="#_function_geofcentroid"></a>8.5.26. Function: geof:centroid</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:centroid (geom: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/centroid"><code>geof:centroid</code></a> valculates the centroid of the set of given geometries.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofconcatlines"><a class="anchor" href="#_function_geofconcatlines"></a>8.5.27. Function: geof:concatLines</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:concatLines (geom: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/concatLines"><code>geof:concatLines</code></a>  Concatenates a set of LineStrings.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofconcavehull"><a class="anchor" href="#_function_geofconcavehull"></a>8.5.28. Function: geof:concaveHull</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:concaveHull (geom: ogc:geomLiteral, targetPercent: xsd:double): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/concaveHull"><code>geof:concaveHull</code></a> calculates the concave hull of the set of given geometries.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofunion2"><a class="anchor" href="#_function_geofunion2"></a>8.5.29. Function: geof:union2</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:union2 (geom: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/union2"><code>geof:union2</code></a> calculates the union of the set of given geometries.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="geometry_extension"><a class="anchor" href="#geometry_extension"></a>9. Geometry Topology Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>Geometry Topology Extension (relation_family, serialization, version)</em> parameterized requirements class, with IRI <code>/req/geometry-topology-extension</code>, which defines a collection of topological query functions that operate on geometry literals. This class is parameterized to give implementations flexibility in the topological relation families and geometry serializations that they choose to support. This requirements class has a single corresponding conformance class <em>Geometry Topology Extension (relation_family, serialization, version)</em>, with IRI <code>/conf/geometry-topology-extension</code>.</p>
+</div>
+<div class="paragraph">
+<p>The Dimensionally Extended Nine Intersection Model (DE-9IM) <a href="#DE-9IM">[DE-9IM]</a> has been used to define the relation tested by the query functions introduced in this section. Each query function is associated with a defining DE-9IM intersection pattern. Possible pattern values are:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>-1</code> (empty)</p>
+</li>
+<li>
+<p><code>0</code>, <code>1</code>, <code>2</code>, <code>T</code> (true) = <code>{0, 1, 2}</code></p>
+</li>
+<li>
+<p><code>F</code> (false) = <code>{-1}</code></p>
+</li>
+<li>
+<p><code>*</code> (don’t care) = <code>{-1, 0, 1, 2}</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>In the following descriptions, the notation <code>X/Y</code> is used denote applying a spatial relation to geometry types <code>X</code> and <code>Y</code> (i.e., <code>x</code> <em>relation</em> <code>y</code> where <code>x</code> is of type <code>X</code> and <code>y</code> is of type <code>Y</code>). The symbol <code>P</code> is used for 0-dimensional geometries (e.g. points). The symbol <code>L</code> is used for 1- dimensional geometries (e.g. lines), and the symbol <code>A</code> is used for 2-dimensional geometries (e.g. polygons). Consult the Simple Features specification <a href="#ISO19125-1">[ISO19125-1]</a> for a more detailed description of DE-9IM intersection patterns.</p>
+</div>
+<div class="sect2">
+<h3 id="_parameters_3"><a class="anchor" href="#_parameters_3"></a>9.1. Parameters</h3>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>relation_family</strong>: Specifies the set of topological spatial relations to support.</p>
+</li>
+<li>
+<p><strong>serialization</strong>: Specifies the serialization standard to use for geometry literals.</p>
+</li>
+<li>
+<p><strong>version</strong>: Specifies the version of the serialization format used.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_common_query_functions"><a class="anchor" href="#_common_query_functions"></a>9.2. Common Query Functions</h3>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 43</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/relate"><code>geof:relate</code></a> as a SPARQL extension function, consistent with the relate operator defined in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/relate-query-function"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/relate-query-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:relate (geom1: ogc:geomLiteral,
+             geom2: ogc:geomLiteral,
+             pattern-matrix: xsd:string): xsd:boolean</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns <code>true</code> if the spatial relationship between <code>geom1</code> and <code>geom2</code> corresponds to one with acceptable values for the specified pattern-matrix. Otherwise, this function returns <code>false</code>. <code>pattern-matrix</code> represents a DE-9IM intersection pattern consisting of <code>T</code> (true) and <code>F</code> (false) values. The spatial reference system for <code>geom1</code> is used for spatial calculations.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_simple_features_relation_family_relation_familysimple_features_2"><a class="anchor" href="#_simple_features_relation_family_relation_familysimple_features_2"></a>9.3. Simple Features Relation Family (relation_family=Simple Features)</h3>
+<div class="paragraph">
+<p>This clause establishes requirements for the <em>Simple Features</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 44</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/sfEquals"><code>geof:sfEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfDisjoint"><code>geof:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfIntersects"><code>geof:sfIntersects</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfTouches"><code>geof:sfTouches</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfCrosses"><code>geof:sfCrosses</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfWithin"><code>geof:sfWithin</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfContains"><code>geof:sfContains</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfOverlaps"><code>geof:sfOverlaps</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/sf-query-functions"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/sf-query-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Boolean query functions defined for the Simple Features relation family, along with their associated DE-9IM intersection patterns, are shown in <a href="#simple_features_query_functions">Table 6</a> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (<code>geom1</code> and <code>geom2</code>) of the geometry literal <em>serialization</em> type <em>specified</em> by serialization and version. Each function returns an <a href="http://www.w3.org/2001/XMLSchema#boolean"><code>xsd:boolean</code></a> value of <code>true</code> if the specified relation exists between <code>geom1</code> and <code>geom2</code> and returns false otherwise. In each case, the spatial reference system of <code>geom1</code> is used for spatial calculations.</p>
+</div>
+<table id="simple_features_query_functions" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 6. Simple Features Query Functions</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Query Function</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Defining DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfEquals(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfDisjoint(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FF*FF****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfIntersects(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfTouches(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfCrosses(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**) for P/L, P/A, L/A; (0*T***T**) for L/L</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfWithin(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*F**F***)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfContains(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*****FF*)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfOverlaps(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**) for A/A, P/P; (1*T***T**) for L/L</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_egenhofer_relation_family_relation_familyegenhofer_2"><a class="anchor" href="#_egenhofer_relation_family_relation_familyegenhofer_2"></a>9.4. Egenhofer Relation Family (relation_family=Egenhofer)</h3>
+<div class="paragraph">
+<p>This clause establishes requirements for the <em>Egenhofer</em> relation family. Consult references <a href="#FORMAL">[FORMAL]</a> and <a href="#CATEG">[CATEG]</a> for a more detailed discussion of <em>Egenhofer</em> relations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 45</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/ehEquals"><code>geof:ehEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehDisjoint"><code>geof:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehMeet"><code>geof:ehMeet</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehOverlap"><code>geof:ehOverlap</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCovers"><code>geof:ehCovers</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCoveredBy"><code>geof:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehInside"><code>geof:ehInside</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehContains"><code>geof:ehContains</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/eh-query-functions"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/eh-query-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Boolean query functions defined for the <em>Egenhofer</em> relation family, along with their associated DE-9IM intersection patterns, are shown in <a href="#egenhofer_query_functions">Table 7</a> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (<code>geom1</code> and <code>geom2</code>) of the geometry literal serialization type specified by <em>serialization</em> and <em>version</em>. Each function returns an <a href="http://www.w3.org/2001/XMLSchema#boolean"><code>xsd:boolean</code></a> value of <code>true</code> if the specified relation exists between <code>geom1</code> and <code>geom2</code> and returns <code>false</code> otherwise. In each case, the spatial reference system of geom1 is used for spatial calculations.</p>
+</div>
+<table id="egenhofer_query_functions" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 7. Egenhofer Query Functions</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Query Function</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Defining DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehEquals(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehDisjoint(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FF*FF****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehMeet(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehOverlap(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehCovers(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*TFT*FF*)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehCoveredBy(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFF*TFT**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehInside(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFF*FFT**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehContains(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*TFF*FF*)</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_requirements_for_rcc8_relation_family_relation_familyrcc8"><a class="anchor" href="#_requirements_for_rcc8_relation_family_relation_familyrcc8"></a>9.5. Requirements for RCC8 Relation Family (relation_family=RCC8)</h3>
+<div class="paragraph">
+<p>This clause establishes requirements for the <em>RCC8</em> relation family. Consult references <a href="#QUAL">[QUAL]</a> and <a href="#LOGIC">[LOGIC]</a> for a more detailed discussion of <em>RCC8</em> relations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 46</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/rcc8eq"><code>geof:rcc8eq</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8dc"><code>geof:rcc8dc</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ec"><code>geof:rcc8ec</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8po"><code>geof:rcc8po</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tppi"><code>geof:rcc8tppi</a></code>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tpp"><code>geof:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntpp"><code>geof:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntppi"><code>geof:rcc8ntppi</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/rcc8-query-functions"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/rcc8-query-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Boolean query functions defined for the <em>RCC8</em> relation family, along with their associated DE-9IM intersection patterns, are shown in <a href="#rcc8_query_functions">Table 8</a> below. Each function accepts two arguments (<code>geom1</code> and <code>geom2</code>) of the geometry literal serialization type specified by <em>serialization</em> and <em>version</em>. Each function returns an <a href="http://www.w3.org/2001/XMLSchema#boolean"><code>xsd:boolean</code></a> value of <code>true</code> if the specified relation exists between <code>geom1</code> and <code>geom2</code> and returns <code>false</code> otherwise. In each case, the spatial reference system of geom1 is used for spatial calculations.</p>
+</div>
+<table id="rcc8_query_functions" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 8. RCC8 Query Functions</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Query Function</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Defining DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8eq(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8dc(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FFTFFTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8ec(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FFTFTTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8po(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTTTTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8tppi(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTFTTFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8tpp(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFTTFTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8ntpp(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFTFFTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8ntppi(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTFFTFFT)</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_rdfs_entailment_extension_relation_family_serialization_version"><a class="anchor" href="#_rdfs_entailment_extension_relation_family_serialization_version"></a>10. RDFS Entailment Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>RDFS Entailment Extension (relation_family, serialization, version)</em> parameterized requirements class, with IRI <code>/req/rdfs-entailment-extension</code>, which defines a mechanism for matching implicitly-derived RDF triples in GeoSPARQL queries. This class is parameterized to give implementations flexibility in the topological relation families and geometry types that they choose to support. This requirements class has a single corresponding conformance class <em>RDFS Entailment Extension (relation_family, serialization, version)</em>, <code>with IRI /conf/rdfs-entailment-extension</code>.</p>
+</div>
+<div class="sect2">
+<h3 id="_parameters_4"><a class="anchor" href="#_parameters_4"></a>10.1. Parameters</h3>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>relation_family</strong>: Specifies the set of topological spatial relations to support.</p>
+</li>
+<li>
+<p><strong>serialization</strong>: Specifies the serialization standard to use for geometry literals.</p>
+</li>
+<li>
+<p><strong>version</strong>: Specifies the version of the serialization format used.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_common_requirements"><a class="anchor" href="#_common_requirements"></a>10.2. Common Requirements</h3>
+<div class="paragraph">
+<p>The basic mechanism for supporting RDFS entailment has been defined by the W3C SPARQL 1.1 RDFS Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 47</strong> Basic graph pattern matching shall use the semantics defined by the RDFS Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/bgp-rdfs-ent"><code>http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/bgp-rdfs-ent</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_wkt_serialization_serializationwkt"><a class="anchor" href="#_wkt_serialization_serializationwkt"></a>10.3. WKT Serialization (serialization=WKT)</h3>
+<div class="paragraph">
+<p>This section establishes the requirements for representing geometry data in RDF based on WKT as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="_geometry_class_hierarchy"><a class="anchor" href="#_geometry_class_hierarchy"></a>10.3.1. Geometry Class Hierarchy</h4>
+<div class="paragraph">
+<p>The Simple Features specification presents a geometry class hierarchy. It is straightforward to represent this class hierarchy in RDFS and OWL by constructing IRIs for geometry classes using the following pattern: <code>http://www.opengis.net/ont/sf#{geometry class}</code> and by asserting appropriate <a href="http://www.w3.org/2000/01/rdf-schema#subClassOf"><code>rdfs:subClassOf</code></a> statements.</p>
+</div>
+<div class="paragraph">
+<p>The example RDF snippet below encodes the Polygon class from Simple Features 1.0.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">sf:Polygon a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Polygon"@en ;
+    rdfs:subClassOf sf:Surface ;
+    skos:definition "A planar surface defined by 1 exterior boundary and 0 or
+                    more interior boundaries"@en .</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 48</strong> Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/wkt-geometry-types"><code>http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/wkt-geometry-types</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_gml_serialization_serializationgml"><a class="anchor" href="#_gml_serialization_serializationgml"></a>10.4. GML Serialization (serialization=GML)</h3>
+<div class="paragraph">
+<p>This section establishes requirements for representing geometry data in RDF based on GML as defined by Geography Markup Language Encoding Standard <a href="#OGC07-036">[OGC07-036]</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="_geometry_class_hierarchy_2"><a class="anchor" href="#_geometry_class_hierarchy_2"></a>10.4.1. Geometry Class Hierarchy</h4>
+<div class="paragraph">
+<p>An RDF/OWL class hierarchy can be generated from the GML schema that implements <code>GM_Object</code> by constructing IRIs for geometry classes using the following pattern: <code>http://www.opengis.net/ont/gml#{GML Element}</code> and by asserting appropriate <a href="http://www.w3.org/2000/01/rdf-schema#subClassOf"><code>rdfs:subClassOf</code></a> statements.</p>
+</div>
+<div class="paragraph">
+<p>The example RDF snippet below encodes the Polygon class from GML 3.2.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">gml:Polygon a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Polygon"@en ;
+    rdfs:subClassOf gml:SurfacePatch ;
+    skos:definition "A planar surface defined by 1 exterior boundary and 0 or
+                    more interior boundaries."@en .</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 49</strong> Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the GML schema that implements <code>GM_Object</code> using the specified <em>version</em> of GML <a href="#OGC07-036">[OGC07-036]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/gml-geometry-types"><code>http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/gml-geometry-types</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_query_rewrite_extension_relation_family_serialization_version"><a class="anchor" href="#_query_rewrite_extension_relation_family_serialization_version"></a>11. Query Rewrite Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>Query Rewrite Extension (relation_family, serialization, version)</em> parameterized requirements class, with IRI <code>/req/query-rewrite-extension</code>, which has a single corresponding conformance class <em>Query Rewrite Extension (relation_family, serialization, version)</em>, with IRI <code>/conf/query-rewrite-extension</code>. This requirements class defines a set of RIF rules <a href="#RIF">[RIF]</a> that use topological extension functions defined in Clause 9 to establish the existence of direct topological predicates defined in Clause 7. One possible implementation strategy is to transform a given query by expanding a triple pattern involving a direct spatial predicate into a series of triple patterns and an invocation of the corresponding extension function as specified in the RIF rule.</p>
+</div>
+<div class="paragraph">
+<p>The following rule specified using the RIF Core Dialect <a href="#RIFCORE">[RIFCORE]</a> is used as a template to describe rules in the remainder of this clause. <a href="http://www.opengis.net/def/relation"><code>ogc:relation</code></a> is used as a placeholder for the spatial relation IRIs defined in Clause 7, and <a href="http://www.opengis.net/def/function"><code>ogc:function</code></a> is used as a placeholder for the spatial functions defined in <a href="#geometry_extension">Clause 9</a>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-rif" data-lang="rif">Forall ?f1 ?f2 ?g1 ?g2 ?g1Serial ?g2Serial
+    (?f1[ogc:relation-&gt;?f2] :-
+        Or(
+            And
+                # feature – feature rule
+                (?f1[geo:hasDefaultGeometry-&gt;?g1]
+                 ?f2[geo:hasDefaultGeometry-&gt;?g2]
+                 ?g1[ogc:asGeomLiteral-&gt;?g1Serial]
+                 ?g2[ogc:asGeomLiteral-&gt;?g2Serial]
+                 External(ogc:function (?g1Serial,?g2Serial)))
+            And
+                # feature – geometry rule
+                (?f1[geo:hasDefaultGeometry-&gt;?g1]
+                 ?g1[ogc:asGeomLiteral-&gt;?g1Serial]
+                 ?f2[ogc:asGeomLiteral-&gt;?g2Serial]
+                 External(ogc:function (?g1Serial,?g2Serial)))
+            And
+                # geometry - feature rule
+                (?f2[geo:hasDefaultGeometry-&gt;?g2]
+                 ?f1[ogc:asGeomLiteral-&gt;?g1Serial]
+                 ?g2[ogc:asGeomLiteral-&gt;?g2Serial]
+                 External(ogc:function (?g1Serial,?g2Serial)))
+            And
+                # geometry - geometry rule
+                (?f1[ogc:asGeomLiteral-&gt;?g1Serial]
+                 ?f2[ogc:asGeomLiteral-&gt;?g2Serial]
+                 External(ogc:function (?g1Serial,?g2Serial)))
+    )
+)</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+The GeoSPARQL 1.1 Standard contains a RIF rules artefact expanded for all function generated from this template and Python software for re-issuing the expanded artefact. See <a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a>.
+</td>
+</tr>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_parameters_5"><a class="anchor" href="#_parameters_5"></a>11.1. Parameters</h3>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>relation_family</strong>: Specifies the set of topological spatial relations to support.</p>
+</li>
+<li>
+<p><strong>serialization</strong>: Specifies the serialization standard to use for geometry literals.</p>
+</li>
+<li>
+<p><strong>version</strong>: Specifies the version of the serialization format used.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_simple_features_relation_family_relation_familysimple_features_3"><a class="anchor" href="#_simple_features_relation_family_relation_familysimple_features_3"></a>11.2. Simple Features Relation Family (relation_family=Simple Features)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the <em>Simple Features</em> relation family. <a href="#sf_query_transformation_rules">Table 9</a> specifies the function and property substitutions for each rule in the <em>Simple Features</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 50</strong> Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/sfEquals"><code>geor:sfEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint"><code>geor:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfIntersects"><code>geor:sfIntersects</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfTouches"><code>geor:sfTouches</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfCrosses"><code>geor:sfCrosses</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfWithin"><code>geor:sfWithin</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfContains"><code>geor:sfContains</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfOverlaps"><code>geor:sfOverlaps</code></a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/sf-query-rewrite"><code>http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/sf-query-rewrite</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table id="sf_query_transformation_rules" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 9. Simple Features Query Transformation Rules</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Rule</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:relation</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfEquals">geor:sfEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfEquals">geo:sfEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfEquals">geof:sfEquals</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint">geor:sfDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfDisjoint">geo:sfDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfDisjoint">geof:sfDisjoint</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfIntersects">geor:sfIntersects</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfIntersects">geo:sfIntersects</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfIntersects">geof:sfIntersects</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfTouches">geor:sfTouches</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfTouches">geo:sfTouches</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfTouches">geof:sfTouches</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfCrosses">geor:sfCrosses</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfCrosses">geo:sfCrosses</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfCrosses">geof:sfCrosses</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfWithin">geor:sfWithin</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfWithin">geof:sfWithin</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfContains">geor:sfContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfContains">geof:sfContains</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfOverlaps">geor:sfOverlaps</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfOverlaps">geo:sfOverlaps</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfOverlaps">geof:sfOverlaps</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_egenhofer_relation_family_relation_familyegenhofer_3"><a class="anchor" href="#_egenhofer_relation_family_relation_familyegenhofer_3"></a>11.3. Egenhofer Relation Family (relation_family=Egenhofer)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the <em>Egenhofer</em> relation family. <a href="#eh_query_transformation_rules">Table 10</a> specifies the function and property substitutions for each rule in the <em>Egenhofer</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 51</strong> Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/ehEquals"><code>geor:ehEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehDisjoint"><code>geor:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehMeet"><code>geor:ehMeet</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehOverlap"><code>geor:ehOverlap</code></a>,
+<a href="http://www.opengis.net/def/rule/geosparql/ehCovers"><code>geor:ehCovers</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCoveredBy"><code>geor:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehInside"><code>geor:ehInside</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehContains"><code>geor:ehContains</code></a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/eh-query-rewrite"><code>http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/eh-query-rewrite</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table id="eh_query_transformation_rules" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 10. Egenhofer Query Transformation Rules</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Rule</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:relation</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehEquals">geor:ehEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehEquals">geo:ehEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehEquals">geof:ehEquals</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehDisjoint">geor:ehDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehDisjoint">geo:ehDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehDisjoint">geof:ehDisjoint</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehMeet">geor:ehMeet</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehMeet">geo:ehMeet</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehMeet">geof:ehMeet</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehOverlap">geor:ehOverlap</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehOverlap">geo:ehOverlap</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehOverlap">geof:ehOverlap</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehCovers">geor:ehCovers</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehCovers">geo:ehCovers</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehCovers">geof:ehCovers</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehCoveredBy">geor:ehCoveredBy</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehCoveredBy">geo:ehCoveredBy</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehCoveredBy">geof:ehCoveredBy</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehInside">geor:ehInside</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehInside">geo:ehInside</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehInside">geof:ehInside</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehContains">geor:ehContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehContains">geo:ehContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehContains">geof:ehContains</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_rcc8_relation_family_relation_familyrcc8_2"><a class="anchor" href="#_rcc8_relation_family_relation_familyrcc8_2"></a>11.4. RCC8 Relation Family (relation_family=RCC8)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the <em>RCC8</em> relation family. <a href="#rcc8_query_transformation_rules">Table 11</a> specifies the function and property substitutions for each rule in the <em>RCC8</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 52</strong> Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/rcc8eq"><code>geor:rcc8eq</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8dc"><code>geor:rcc8dc</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ec"><code>geor:rcc8ec</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8po"><code>geor:rcc8po</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tppi"><code>geor:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tpp"><code>geor:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntpp"><code>geor:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntppi"><code>geor:rcc8ntppi</code></a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/rcc8-query-rewrite"><code>http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/rcc8-query-rewrite</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table id="rcc8_query_transformation_rules" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 11. RCC8 Query Transformation Rules</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Rule</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:relation</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8eq">geor:rcc8eq</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8eq">geo:rcc8eq</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8eq">geof:rcc8eq</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8dc">geor:rcc8dc</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8dc">geo:rcc8dc</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8dc">geof:rcc8dc</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8ec">geor:rcc8ec</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ec">geo:rcc8ec</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8ec">geof:rcc8ec</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8po">geor:rcc8po</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8po">geo:rcc8po</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8po">geof:rcc8po</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8tppi">geor:rcc8tppi</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8tppi">geo:rcc8tppi</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8tppi">geof:rcc8tppi</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8tpp">geor:rcc8tpp</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8tpp">geo:rcc8tpp</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8tpp">geof:rcc8tpp</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8ntpp">geor:rcc8ntpp</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ntpp">geo:rcc8ntpp</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8ntpp">geof:rcc8ntpp</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8ntppi">geor:rcc8ntppi</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ntppi">geo:rcc8ntppi</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8ntppi">geof:rcc8ntppi</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_special_considerations"><a class="anchor" href="#_special_considerations"></a>11.5. Special Considerations</h3>
+<div class="paragraph">
+<p>The applicability of GeoSPARQL rules in certain circumstances has intentionally been left undefined.</p>
+</div>
+<div class="paragraph">
+<p>The first situation arises for triple patterns with unbound predicates. Consider the query pattern below:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>{ my:feature1 ?p my:feature2 }</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>When using a query transformation strategy, this triple pattern could invoke none of the GeoSPARQL rules or all of the rules. Implementations are free to support either of these alternatives.</p>
+</div>
+<div class="paragraph">
+<p>The second situation arises when supporting GeoSPARQL rules in the presence of RDFS Entailment. The existence of a topological relation (possibly derived from a GeoSPARQL rule) can entail other RDF triples. For example, if <a href="http://www.opengis.net/ont/geosparql#sfOverlaps"><code>geo:sfOverlaps</code></a> has been defined as an <a href="http://www.w3.org/2000/01/rdf-schema#subPropertyOf"><code>rdfs:subPropertyOf</code></a> the property <code>my:overlaps</code>, and the RDF triple <code>my:feature1 <a href="http://www.opengis.net/ont/geosparql#sfOverlaps">geo:sfOverlaps</a> my:feature2</code> has been derived from a GeoSPARQL rule, then the RDF triple <code>my:feature1 my:overlaps my:feature2</code> can be entailed. Implementations may support such entailments but are not required to.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_future_work"><a class="anchor" href="#_future_work"></a>12. Future Work</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Many future extensions of this standard are possible and, since the release of GeoSPARQL 1.0, many extensions have been made.</p>
+</div>
+<div class="paragraph">
+<p>The GeoSPARQL 1.1 release tried to incorporate many additions requested of the GeoSPARQL 1.0 Standard, including options the use of other serializations of geometry data (e.g. KML, GeoJSON, DGGS) and the addition of handling spatial scalar measurements.</p>
+</div>
+<div class="paragraph">
+<p>Plans for future GeoSPARQL releases have been mooted but won&#8217;t be articulated here, instead they will be discussed and decided apon by the OGC GeoSPARQL Standards Working Group and related groups. Readers of this document are encouraged to see out those groups' lists of issues and standards change requests rather than looking for ideas here that will surely age badly.</p>
+</div>
+</div>
+</div>
+<h1 id="_annex_a_normative_abstract_test_suite" class="sect0"><a class="anchor" href="#_annex_a_normative_abstract_test_suite"></a>Annex A (normative) Abstract Test Suite</h1>
+<div class="sect1">
+<h2 id="_a_1_conformance_class_core"><a class="anchor" href="#_a_1_conformance_class_core"></a>A.1 Conformance Class: <em>Core</em></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/core</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_1_1_confcoresparql_protocol"><a class="anchor" href="#_a_1_1_confcoresparql_protocol"></a>A.1.1 <code>/conf/core/sparql-protocol</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/sparql-protocol</code></p>
+</div>
+<div class="paragraph">
+<p>Implementations shall support the SPARQL Query Language for RDF <a href="#SPARQL">[SPARQL]</a>, the SPARQL Protocol for RDF <a href="#SPARQLPROT">[SPARQLPROT]</a> and the SPARQL Query Results XML Format <a href="#SPARQLRESX">[SPARQLRESX]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that the implementation accepts SPARQL queries and returns the correct results in the correct format, according to the SPARQL Query Language for RDF, the SPARQL Protocol for RDF and SPARQL Query Results XML Format W3C specifications.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_sparql_2">Section 6.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_2_confcorespatial_object_class"><a class="anchor" href="#_a_1_2_confcorespatial_object_class"></a>A.1.2 <code>/conf/core/spatial-object-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/spatial-object-class</code></p>
+</div>
+<div class="paragraph">
+<p>Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#SpatialObject">geo:SpatialObject</a> to be used in SPARQL graph
+patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#SpatialObject">geo:SpatialObject</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geospatialobject">Section 6.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_3_confcorefeature_class"><a class="anchor" href="#_a_1_3_confcorefeature_class"></a>A.1.3 <code>/conf/core/feature-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/feature-class</code>
+Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#Feature">geo:Feature</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: verify that queries involving <a href="http://www.opengis.net/ont/geosparql#Feature">geo:Feature</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geofeature">Section 6.2.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_4_confcorespatial_measure_class"><a class="anchor" href="#_a_1_4_confcorespatial_measure_class"></a>A.1.4 <code>/conf/core/spatial-measure-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/spatial-measure-class</code>
+Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#SpatialMeasure">geo:SpatialMeasure</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#SpatialMeasure">geo:SpatialMeasure</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geospatialmeasure">Section 6.2.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_5_confcorespatial_object_collection_class"><a class="anchor" href="#_a_1_5_confcorespatial_object_collection_class"></a>A.1.5 <code>/conf/core/spatial-object-collection-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/spatial-object-collection-class</code></p>
+</div>
+<div class="paragraph">
+<p>Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#SpatialObjectCollection">geo:SpatialObjectCollection</a> to be used in SPARQL graph
+patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: verify that queries involving <a href="http://www.opengis.net/ont/geosparql#SpatialObjectCollection">geo:SpatialObjectCollection</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geospatialobjectcollection">Section 6.2.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_6_confcorefeature_collection_class"><a class="anchor" href="#_a_1_6_confcorefeature_collection_class"></a>A.1.6 <code>/conf/core/feature-collection-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/feature-collection-class</code></p>
+</div>
+<div class="paragraph">
+<p>Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#FeatureCollection">geo:FeatureCollection</a> to be used in SPARQL graph
+patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: verify that queries involving <a href="http://www.opengis.net/ont/geosparql#FeatureCollection">geo:FeatureCollection</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geofeaturecollection">Section 6.2.5</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_2_conformance_class_topology_vocabulary_extension_relation_family"><a class="anchor" href="#_a_2_conformance_class_topology_vocabulary_extension_relation_family"></a>A.2 Conformance Class: Topology Vocabulary Extension (relation_family)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/topology-vocab-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_2_1_relation_family_simple_features"><a class="anchor" href="#_a_2_1_relation_family_simple_features"></a>A.2.1 relation_family = Simple Features</h3>
+<div class="sect3">
+<h4 id="_a_2_1_1_conftopology_vocab_extensionsf_spatial_relations"><a class="anchor" href="#_a_2_1_1_conftopology_vocab_extensionsf_spatial_relations"></a>A.2.1.1 <code>/conf/topology-vocab-extension/sf-spatial-relations</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/topology-vocab-extension/sf-spatial-relations</code>
+Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#sfEquals"><code>geo:sfEquals</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfDisjoint"><code>geo:sfDisjoint</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfIntersects"><code>geo:sfIntersects</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfTouches"><code>geo:sfTouches</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfCrosses"><code>geo:sfCrosses</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfWithin"><code>geo:sfWithin</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfContains"><code>geo:sfContains</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfOverlaps"><code>geo:sfOverlaps</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_simple_features_relation_family_relation_familysimple_features">Section 7.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_2_2_relation_family_egenhofer"><a class="anchor" href="#_a_2_2_relation_family_egenhofer"></a>A.2.2 relation_family = Egenhofer</h3>
+<div class="sect3">
+<h4 id="_a_2_2_1_conftopology_vocab_extensioneh_spatial_relations"><a class="anchor" href="#_a_2_2_1_conftopology_vocab_extensioneh_spatial_relations"></a>A.2.2.1 <code>/conf/topology-vocab-extension/eh-spatial-relations</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/topology-vocab-extension/eh-spatial-relations</code>
+Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#ehEquals"><code>geo:ehEquals</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehDisjoint"><code>geo:ehDisjoint</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehMeet"><code>geo:ehMeet</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehOverlap"><code>geo:ehOverlap</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehCovers"><code>geo:ehCovers</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehCoveredBy"><code>geo:ehCoveredBy</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehInside"> <code>geo:ehInside</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehContains"><code>geo:ehContains</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_egenhofer_relation_family_relation_familyegenhofer">Section 7.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_2_3_relation_family_rcc8"><a class="anchor" href="#_a_2_3_relation_family_rcc8"></a>A.2.3 relation_family = RCC8</h3>
+<div class="sect3">
+<h4 id="_a_2_3_1_conftopology_vocab_extensionrcc8_spatial_relations"><a class="anchor" href="#_a_2_3_1_conftopology_vocab_extensionrcc8_spatial_relations"></a>A.2.3.1 <code>/conf/topology-vocab-extension/rcc8-spatial-relations</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/topology-vocab-extension/rcc8-spatial-relations</code>
+Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#rcc8eq"><code>geo:rcc8eq</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8dc"><code>geo:rcc8dc</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8ec"><code>geo:rcc8ec</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8po"><code>geo:rcc8po</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tppi"><code>geo:rcc8tppi</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tpp"><code>geo:rcc8tpp</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tpp"><code>geo:rcc8ntpp</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tppi"><code>geo:rcc8ntppi</code></a> to be used in SPARQL graph patterns</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rcc8_relation_family_relation_familyrcc8">Section 7.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_3_conformance_class_geometry_extension_serialization_version"><a class="anchor" href="#_a_3_conformance_class_geometry_extension_serialization_version"></a>A.3 Conformance Class: Geometry Extension (serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/geometry-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_3_1_tests_for_all_serializations"><a class="anchor" href="#_a_3_1_tests_for_all_serializations"></a>A.3.1 Tests for all Serializations</h3>
+<div class="sect3">
+<h4 id="_a_3_1_1_confgeometry_extensiongeometry_class"><a class="anchor" href="#_a_3_1_1_confgeometry_extensiongeometry_class"></a>A.3.1.1 <code>/conf/geometry-extension/geometry-class</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-class</code>
+Implementations shall allow the RDFS class <a href="#_class_geogeometry">Geometry</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="#_class_geogeometry">Geometry</a> return the correct result on a test dataset</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geogeometry">Section 8.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_6_confgeometry_extensiongeometry_collection_class"><a class="anchor" href="#_a_3_1_6_confgeometry_extensiongeometry_collection_class"></a>A.3.1.6 <code>/conf/geometry-extension/geometry-collection-class</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-collection-class</code>
+Implementations shall allow the RDFS class <a href="#_class_geogeometrycollection">Geometry Collection</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: verify that queries involving <a href="#_class_geogeometrycollection">Geometry Collection</a> return the correct result on a test dataset</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geogeometrycollection">Section 8.2.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_2_confgeometry_extensionfeature_properties"><a class="anchor" href="#_a_3_1_2_confgeometry_extensionfeature_properties"></a>A.3.1.2 <code>/conf/geometry-extension/feature-properties</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/feature-properties</code>
+Implementations shall allow the properties <a href="#_property_geohasgeometry">has geometry</a> and <a href="#_property_geohasdefaultgeometry">has default geometry</a>,
+<a href="#_property_geohaslength">has length</a>,
+<a href="#_property_geohasarea">has area</a>,
+<a href="http://www.opengis.net/ont/geosparql#hasCentroid"><code>geo:hasVolume</code></a>
+<a href="#_property_geohasboundingbox">has bounding box</a>
+<a href="#_property_geohascentroid">has centroid</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_standard_properties_for_geofeature">Section 6.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_3_confgeometry_extensiongeometry_properties"><a class="anchor" href="#_a_3_1_3_confgeometry_extensiongeometry_properties"></a>A.3.1.3 <code>/conf/geometry-extension/geometry-properties</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-properties</code>
+Implementations shall allow the properties <a href="#_property_geodimension">dimension</a>, <a href="#_property_geocoordinatedimension">coordinate dimension</a>, <a href="#_property_geospatialdimension">spatial dimension</a>,  <a href="#_property_geoisempty">is empty</a>,  <a href="#_property_geoissimple">is simple</a>,  <a href="#_property_geohasserialization">has serialization</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_standard_properties_for_geogeometry">Section 8.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_4_confgeometry_extensionquery_functions"><a class="anchor" href="#_a_3_1_4_confgeometry_extensionquery_functions"></a>A.3.1.4 <code>/conf/geometry-extension/query-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/query-functions</code>
+Implementations shall support <a href="#_function_geofdistance">distance</a>, <a href="#_function_geofbuffer">buffer</a>, <a href="#_function_geofconvexhull">convex hull</a>, <a href="#_function_geofintersection">intersection</a>, <a href="#_function_geofunion">union</a>, <a href="#_function_geofdifference">difference</a>, <a href="#_function_geofsymdifference">sym difference</a>, <a href="#_function_geofenvelope">envelope</a> and <a href="#_function_geofboundary">boundary</a> as SPARQL extension functions, consistent with the definitions of the corresponding functions (distance, buffer, convexHull, intersection, difference, symDifference, envelope and boundary respectively) in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: <a href="#_function_geofdistance">distance</a>, <a href="#_function_geofbuffer">buffer</a>, <a href="#_function_geofconvexhull">convex hull</a>, <a href="#_function_geofintersection">intersection</a>, <a href="#_function_geofunion">union</a>, <a href="#_function_geofdifference">difference</a>, <a href="#_function_geofsymdifference">sym difference</a>, <a href="#_function_geofenvelope">envelope</a> and <a href="#_function_geofboundary">boundary</a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_non_topological_query_functions">Section 8.5</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_5_confgeometry_extensionsrid_function"><a class="anchor" href="#_a_3_1_5_confgeometry_extensionsrid_function"></a>A.3.1.5 <code>/conf/geometry-extension/srid-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/srid-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/getSRID"><code>geof:getSRID</code></a> as a SPARQL extension function.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a SPARQL query involving the <a href="http://www.opengis.net/def/function/geosparql/getSRID"><code>geof:getSRID</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_geofgetsrid">Section 8.5.18</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_5_confgeometry_extensionsa_functions"><a class="anchor" href="#_a_3_1_5_confgeometry_extensionsa_functions"></a>A.3.1.5 <code>/conf/geometry-extension/sa-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/-functions</code>
+Implementations shall support geof:concaveHull, geof:boundingCircle, geof:union2, geof:concatLines, geof:centroid, geof:maxX, geof:maxY, geof:maxZ, geof:minX, geof:minY and geof:minZ as a SPARQL extension functions.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these functions return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_safuncs">[_function_safuncs]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_2_serialization_wkt"><a class="anchor" href="#_a_3_2_serialization_wkt"></a>A.3.2 serialization = WKT</h3>
+<div class="sect3">
+<h4 id="_a_3_2_1_confgeometry_extensionwkt_literal"><a class="anchor" href="#_a_3_2_1_confgeometry_extensionwkt_literal"></a>A.3.2.1 <code>/conf/geometry-extension/wkt-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/wkt-literal</code>
+All <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> instances shall consist of an optional IRI identifying the Spatial Reference System (SRS) followed by Simple Features Well Known Text (WKT) describing a geometric value. Valid <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> instances are formed by concatenating a valid, absolute IRI as defined in <a href="#IETF3987">[IETF3987]</a>, one or more spaces (Unicode U+0020 character) as a separator, and a WKT string as defined in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving  <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geowktliteral">Section 8.4.1.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_2_confgeometry_extensionwkt_literal_default_srs"><a class="anchor" href="#_a_3_2_2_confgeometry_extensionwkt_literal_default_srs"></a>A.3.2.2 <code>/conf/geometry-extension/wkt-literal-default-srs</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/wkt-literal-default-srs</code>
+The IRI <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84">&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</a> shall be assumed as the SRS for  <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiterals</code></a> that do not specify an explicit SRS IRI.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving  <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> values without an explicit encoded SRS IRI return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geowktliteral">Section 8.4.1.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_3_confgeometry_extensionwkt_axis_order"><a class="anchor" href="#_a_3_2_3_confgeometry_extensionwkt_axis_order"></a>A.3.2.3 <code>/conf/geometry-extension/wkt-axis-order</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/wkt-axis-order</code>
+Coordinate tuples within <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiterals</code></a> shall be interpreted using the axis order defined in the SRS used.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving  <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geowktliteral">Section 8.4.1.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_4_confgeometry_extensionwkt_literal_empty"><a class="anchor" href="#_a_3_2_4_confgeometry_extensionwkt_literal_empty"></a>A.3.2.4 <code>/conf/geometry-extension/wkt-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/wkt-literal-empty</code>
+An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geowktliteral">Section 8.4.1.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_5_confgeometry_extensiongeometry_as_wkt_literal"><a class="anchor" href="#_a_3_2_5_confgeometry_extensiongeometry_as_wkt_literal"></a>A.3.2.5 <code>/conf/geometry-extension/geometry-as-wkt-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-wkt-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoaswkt">Section 8.4.1.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_6_reqgeometry_extensionaswkt_function"><a class="anchor" href="#_a_3_2_6_reqgeometry_extensionaswkt_function"></a>A.3.2.6 <code>/req/geometry-extension/asWKT-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asWKT-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_aswkt">[_function_aswkt]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_3_serialization_gml"><a class="anchor" href="#_a_3_3_serialization_gml"></a>A.3.3 serialization = GML</h3>
+<div class="sect3">
+<h4 id="_a_3_3_1_confgeometry_extensiongml_literal"><a class="anchor" href="#_a_3_3_1_confgeometry_extensiongml_literal"></a>A.3.3.1 <code>/conf/geometry-extension/gml-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/gml-literal</code>
+All <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> instances shall consist of a valid element from the GML schema that implements a subtype of GM_Object as defined in [OGC 07-036].</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogmlliteral">Section 8.4.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_3_2_confgeometry_extensiongml_literal_empty"><a class="anchor" href="#_a_3_3_2_confgeometry_extensiongml_literal_empty"></a>A.3.3.2 <code>/conf/geometry-extension/gml-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/gml-literal-empty</code>
+An empty <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogmlliteral">Section 8.4.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_3_3_confgeometry_extensiongml_profile"><a class="anchor" href="#_a_3_3_3_confgeometry_extensiongml_profile"></a>A.3.3.3 <code>/conf/geometry-extension/gml-profile</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/gml-profile</code>
+Implementations shall document supported GML profiles.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Examine the implementation’s documentation to verify that the supported GML profiles are documented.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogmlliteral">Section 8.4.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Documentation</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_3_4_confgeometry_extensiongeometry_as_gml_literal"><a class="anchor" href="#_a_3_3_4_confgeometry_extensiongeometry_as_gml_literal"></a>A.3.3.4 <code>/conf/geometry-extension/geometry-as-gml-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-gml-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoasgml">Section 8.4.2.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_3_5_reqgeometry_extensionasgml_function"><a class="anchor" href="#_a_3_3_5_reqgeometry_extensionasgml_function"></a>A.3.3.5 <code>/req/geometry-extension/asGML-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asGML-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_asgml">[_function_asgml]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_4_serialization_geojson"><a class="anchor" href="#_a_3_4_serialization_geojson"></a>A.3.4 serialization = GEOJSON</h3>
+<div class="sect3">
+<h4 id="_a_3_4_1_reqgeometry_extensiongeojson_literal"><a class="anchor" href="#_a_3_4_1_reqgeometry_extensiongeojson_literal"></a>A.3.4.1 <code>/req/geometry-extension/geojson-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geojson-literal</code>
+All <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> instances shall consist of valid JSON that conforms to the GeoJSON specification <a href="#GEOJSON">[GEOJSON]</a></p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoasgml">Section 8.4.2.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_4_2_reqgeometry_extensiongeojson_literal_srs"><a class="anchor" href="#_a_3_4_2_reqgeometry_extensiongeojson_literal_srs"></a>A.3.4.2 <code>/req/geometry-extension/geojson-literal-srs</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geojson-literal-default-srs</code>
+The IRI <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84">&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</a> shall be assumed as the SRS for <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> instances that do not specify an explicit SRS IRI.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> values without an explicit encoded SRS IRI return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogeojsonliteral">Section 8.4.3.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_4_3_reqgeometry_extensiongeojson_literal_empty"><a class="anchor" href="#_a_3_4_3_reqgeometry_extensiongeojson_literal_empty"></a>A.3.4.3 <code>/req/geometry-extension/geojson-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geojson-literal-empty</code>
+An empty <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogeojsonliteral">Section 8.4.3.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_4_4_reqgeometry_extensiongeometry_as_geojson_literal"><a class="anchor" href="#_a_3_4_4_reqgeometry_extensiongeometry_as_geojson_literal"></a>A.3.4.4 <code>/req/geometry-extension/geometry-as-geojson-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-geojson-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoasgeojson">Section 8.4.3.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_4_5_reqgeometry_extensionasgeojson_function"><a class="anchor" href="#_a_3_4_5_reqgeometry_extensionasgeojson_function"></a>A.3.4.5 <code>/req/geometry-extension/asGeoJSON-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asGeoJSON-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_asgeojson">[_function_asgeojson]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_5_serialization_kml"><a class="anchor" href="#_a_3_5_serialization_kml"></a>A.3.5 serialization = KML</h3>
+<div class="sect3">
+<h4 id="_a_3_5_1_reqgeometry_extensionkml_literal"><a class="anchor" href="#_a_3_5_1_reqgeometry_extensionkml_literal"></a>A.3.5.1 <code>/req/geometry-extension/kml-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/kml-literal</code>
+All <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> instances shall consist of a valid element from the KML schema that implements a <code>kml:AbstractObjectGroup</code> as defined in <a href="#OGCKML">[OGCKML]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geomklliteral">[_rdfs_datatype_geomklliteral]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_5_2_reqgeometry_extensionkml_literal_srs"><a class="anchor" href="#_a_3_5_2_reqgeometry_extensionkml_literal_srs"></a>A.3.5.2 <code>/req/geometry-extension/kml-literal-srs</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/kml-literal-default-srs</code>
+The IRI <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84">&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</a> shall be assumed as the SRS for <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiterals</code></a> that do not specify an explicit SRS IRI.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a>  values without an explicit encoded SRS IRI return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geomklliteral">[_rdfs_datatype_geomklliteral]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_5_3_reqgeometry_extensionkml_literal_empty"><a class="anchor" href="#_a_3_5_3_reqgeometry_extensionkml_literal_empty"></a>A.3.5.3 <code>/req/geometry-extension/kml-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/kml-literal-empty</code>
+An empty <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geomklliteral">[_rdfs_datatype_geomklliteral]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_5_4_reqgeometry_extensiongeometry_as_kml_literal"><a class="anchor" href="#_a_3_5_4_reqgeometry_extensiongeometry_as_kml_literal"></a>A.3.5.4 <code>/req/geometry-extension/geometry-as-kml-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-kml-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a>  property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoaskml">Section 8.4.4.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_5_5_reqgeometry_extensionaskml_function"><a class="anchor" href="#_a_3_5_5_reqgeometry_extensionaskml_function"></a>A.3.5.5 <code>/req/geometry-extension/asKML-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asKML-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_askml">[_function_askml]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_6_serialization_dggs"><a class="anchor" href="#_a_3_6_serialization_dggs"></a>A.3.6 serialization = DGGS</h3>
+<div class="sect3">
+<h4 id="_a_3_6_1_reqgeometry_extensiondggs_literal"><a class="anchor" href="#_a_3_6_1_reqgeometry_extensiondggs_literal"></a>A.3.6.1 <code>/req/geometry-extension/dggs-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/dggs-literal</code>
+All RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a> shall consist of a DGGS geometry serialization formulated according to a specific DGGS literal type identified by a datatype specializing this generic datatype.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries do not use use this datatype but instead use specializations of it.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_dggs_serialization_serializationdggs">[_dggs_serialization_serializationdggs]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_6_2_reqgeometry_extensiondggs_literal_empty"><a class="anchor" href="#_a_3_6_2_reqgeometry_extensiondggs_literal_empty"></a>A.3.6.2 <code>/req/geometry-extension/dggs-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/dggs-literal-empty</code>
+An empty <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:dggsLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:dggsLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_dggs_serialization_serializationdggs">[_dggs_serialization_serializationdggs]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_6_3_reqgeometry_extensiongeometry_as_dggs_literal"><a class="anchor" href="#_a_3_6_3_reqgeometry_extensiongeometry_as_dggs_literal"></a>A.3.6.3 <code>/req/geometry-extension/geometry-as-dggs-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-dggs-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoasdggs">Section 8.4.5.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_6_4_reqgeometry_extensionasdggs_function"><a class="anchor" href="#_a_3_6_4_reqgeometry_extensionasdggs_function"></a>A.3.6.4 <code>/req/geometry-extension/asDGGS-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asDGGS-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_asdggs">[_function_asdggs]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_4_conformance_class_geometry_topology_extension_relation_family_serialization_version"><a class="anchor" href="#_a_4_conformance_class_geometry_topology_extension_relation_family_serialization_version"></a>A.4 Conformance Class: Geometry Topology Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/geometry-topology-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_4_1_tests_for_all_relation_families"><a class="anchor" href="#_a_4_1_tests_for_all_relation_families"></a>A.4.1 Tests for all relation families</h3>
+<div class="sect3">
+<h4 id="_a_4_1_1_confgeometry_topology_extensionrelate_query_function"><a class="anchor" href="#_a_4_1_1_confgeometry_topology_extensionrelate_query_function"></a>A.4.1.1 <code>/conf/geometry-topology-extension/relate-query-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-topology-extension/relate-query-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/relate"><code>geof:relate</code></a> as a SPARQL extension function, consistent with the relate operator defined in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/relate"><code>geof:relate</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_common_query_functions">Section 9.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_4_2_relation_family_simple_features"><a class="anchor" href="#_a_4_2_relation_family_simple_features"></a>A.4.2 relation_family = Simple Features</h3>
+<div class="sect3">
+<h4 id="_a_4_2_1_confgeometry_topology_extensionsf_query_functions"><a class="anchor" href="#_a_4_2_1_confgeometry_topology_extensionsf_query_functions"></a>A.4.2.1 <code>/conf/geometry-topology-extension/sf-query-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-topology-extension/sf-query-functions</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/sfEquals"><code>geof:sfEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfDisjoint"><code>geof:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/efIntersects"><code>geof:sfIntersects</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfTouches"><code>geof:sfTouches</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfCrosses"><code>geof:sfCrosses</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfWithin"><code>geof:sfWithin</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfContains"><code>geof:sfContains</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfOverlaps"><code>geof:sfOverlaps</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/function/geosparql/sfEquals"><code>geof:sfEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfDisjoint"><code>geof:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/efIntersects"><code>geof:sfIntersects</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfTouches"><code>geof:sfTouches</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfCrosses"><code>geof:sfCrosses</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfWithin"><code>geof:sfWithin</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfContains"><code>geof:sfContains</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfOverlaps"><code>geof:sfOverlaps</code></a> .</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_simple_features_relation_family_relation_familysimple_features">Section 7.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_4_3_relation_family_egenhofer"><a class="anchor" href="#_a_4_3_relation_family_egenhofer"></a>A.4.3 relation_family = Egenhofer</h3>
+<div class="sect3">
+<h4 id="_a_4_3_1_confgeometry_topology_extensioneh_query_functions"><a class="anchor" href="#_a_4_3_1_confgeometry_topology_extensioneh_query_functions"></a>A.4.3.1 <code>/conf/geometry-topology-extension/eh-query-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-topology-extension/eh-query-functions</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/ehEquals"><code>geof:ehEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehDisjoint"><code>geof:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehMeet"><code>geof:ehMeet</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehOverlap"><code>geof:ehOverlap</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCovers"><code>geof:ehCovers</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCoveredBy"><code>geof:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehInside"><code>geof:ehInside</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehContains"><code>geof:ehContains</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features [ISO 19125- 1].</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/function/geosparql/ehEquals"><code>geof:ehEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehDisjoint"><code>geof:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehMeet"><code>geof:ehMeet</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehOverlap"><code>geof:ehOverlap</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCovers"><code>geof:ehCovers</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCoveredBy"><code>geof:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehInside"><code>geof:ehInside</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehContains"><code>geof:ehContains</code></a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_egenhofer_relation_family_relation_familyegenhofer">Section 7.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_4_4_relation_family_rcc8"><a class="anchor" href="#_a_4_4_relation_family_rcc8"></a>A.4.4 relation_family = RCC8</h3>
+<div class="sect3">
+<h4 id="_a_4_4_1_confgeometry_topology_extensionrcc8_query_functions"><a class="anchor" href="#_a_4_4_1_confgeometry_topology_extensionrcc8_query_functions"></a>A.4.4.1 <code>/conf/geometry-topology-extension/rcc8-query-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-topology-extension/rcc8-query-functions</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/rcc8eq"><code>geof:rcc8eq</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8dc"><code>geof:rcc8dc</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ec"><code>geof:rcc8ec</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8po"><code>geof:rcc8po</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tppi"><code>geof:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tpp"><code>geof:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntpp"><code>geof:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntppi"><code>geof:rcc8ntppi</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/function/geosparql/rcc8eq"><code>geof:rcc8eq</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8dc"><code>geof:rcc8dc</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ec"><code>geof:rcc8ec</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8po"><code>geof:rcc8po</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tppi"><code>geof:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tpp"><code>geof:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntpp"><code>geof:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntppi"><code>geof:rcc8ntppi</code></a> .</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rcc8_relation_family_relation_familyrcc8">Section 7.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_5_conformance_class_rdfs_entailment_extension_relation_family_serialization_version"><a class="anchor" href="#_a_5_conformance_class_rdfs_entailment_extension_relation_family_serialization_version"></a>A.5 Conformance Class: RDFS Entailment Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/rdfs-entailment-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_5_1_tests_for_all_implementations"><a class="anchor" href="#_a_5_1_tests_for_all_implementations"></a>A.5.1 Tests for all implementations</h3>
+<div class="sect3">
+<h4 id="_a_5_1_1_confrdfsentailmentextensionbgp_rdfs_ent"><a class="anchor" href="#_a_5_1_1_confrdfsentailmentextensionbgp_rdfs_ent"></a>A.5.1.1 <code>/conf/rdfsentailmentextension/bgp-rdfs-ent</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/rdfs-entailment-extension/bgp-rdfs-ent</code>
+Basic graph pattern matching shall use the semantics defined by the RDFS Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving entailed RDF triples returns the correct result for a test dataset using the specified serialization, version and relation_family.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_common_requirements">Section 10.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_5_2_serializationwkt"><a class="anchor" href="#_a_5_2_serializationwkt"></a>A.5.2 serialization=WKT</h3>
+<div class="sect3">
+<h4 id="_a_5_2_1_confrdfs_entailment_extensionwkt_geometry_types"><a class="anchor" href="#_a_5_2_1_confrdfs_entailment_extensionwkt_geometry_types"></a>A.5.2.1 <code>/conf/rdfs-entailment-extension/wkt-geometry-types</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/rdfs-entailment-extension/wkt-geometry-types</code>
+Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving WKT Geometry types returns the correct result for a test dataset using the specified version of Simple Features.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_geometry_class_hierarchy">Section 10.3.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_5_3_serializationgml"><a class="anchor" href="#_a_5_3_serializationgml"></a>A.5.3 serialization=GML</h3>
+<div class="sect3">
+<h4 id="_a_5_3_1_confrdfs_entailment_extensiongml_geometry_types"><a class="anchor" href="#_a_5_3_1_confrdfs_entailment_extensiongml_geometry_types"></a>A.5.3.1 <code>/conf/rdfs-entailment-extension/gml-geometry-types</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/rdfs-entailment-extension/gml-geometry-types</code>
+Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the GML schema that implements GM_Object using the specified version of GML <a href="#OGC07-036">[OGC07-036]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving GML Geometry types returns the correct result for a test dataset using the specified version of GML.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_geometry_class_hierarchy_2">Section 10.4.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_6_conformance_class_query_rewrite_extension_relation_family_serialization_version"><a class="anchor" href="#_a_6_conformance_class_query_rewrite_extension_relation_family_serialization_version"></a>A.6 Conformance Class: Query Rewrite Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/query-rewrite-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_6_1_relation_family_simple_features"><a class="anchor" href="#_a_6_1_relation_family_simple_features"></a>A.6.1 relation_family = Simple Features</h3>
+<div class="sect3">
+<h4 id="_a_6_1_1_confquery_rewrite_extensionsf_query_rewrite"><a class="anchor" href="#_a_6_1_1_confquery_rewrite_extensionsf_query_rewrite"></a>A.6.1.1 <code>/conf/query-rewrite-extension/sf-query-rewrite</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/query-rewrite-extension/sf-query-rewrite</code>
+Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/sfEquals"><code>geor:sfEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint"><code>geor:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfIntersects"><code>geor:sfIntersects</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfTouches"><code>geor:sfTouches</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfCrosses"><code>geor:sfCrosses</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfWithin"><code>geor:sfWithin</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfContains"><code>geor:sfContains</code></a> and <a href="http://www.opengis.net/def/rule/geosparql/sfOverlaps"><code>geor:sfOverlaps</code></a>..</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/rule/geosparql/sfEquals"><code>geor:sfEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint"><code>geor:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfIntersects"><code>geor:sfIntersects</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfTouches"><code>geor:sfTouches</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfCrosses"><code>geor:sfCrosses</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfWithin"><code>geor:sfWithin</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfContains"><code>geor:sfContains</code></a> and <a href="http://www.opengis.net/def/rule/geosparql/sfOverlaps"><code>geor:sfOverlaps</code></a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_simple_features_relation_family_relation_familysimple_features_2">Section 9.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_6_2_relation_family_egenhofer"><a class="anchor" href="#_a_6_2_relation_family_egenhofer"></a>A.6.2 relation_family = Egenhofer</h3>
+<div class="sect3">
+<h4 id="_a_6_2_1_confquery_rewrite_extensioneh_query_rewrite"><a class="anchor" href="#_a_6_2_1_confquery_rewrite_extensioneh_query_rewrite"></a>A.6.2.1 <code>/conf/query-rewrite-extension/eh-query-rewrite</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/query-rewrite-extension/eh-query-rewrite</code>
+Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/ehEquals"><code>geor:ehEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehDisjoint"><code>geor:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehMeet"><code>geor:ehMeet</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehOverlap"><code>geor:ehOverlap</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCovers"><code>geor:ehCovers</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCoveredBy"><code>geor:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehInside"><code>geor:ehInside</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehContains"><code>geor:ehContains</code></a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/rule/geosparql/ehEquals"><code>geor:ehEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehDisjoint"><code>geor:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehMeet"><code>geor:ehMeet</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehOverlap"><code>geor:ehOverlap</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCovers"><code>geor:ehCovers</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCoveredBy"><code>geor:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehInside"><code>geor:ehInside</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehContains"><code>geor:ehContains</code></a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_egenhofer_relation_family_relation_familyegenhofer_2">Section 9.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_6_3_relation_family_rcc8"><a class="anchor" href="#_a_6_3_relation_family_rcc8"></a>A.6.3 relation_family = RCC8</h3>
+<div class="sect3">
+<h4 id="_a_6_3_1_confquery_rewrite_extensionrcc8_query_rewrite"><a class="anchor" href="#_a_6_3_1_confquery_rewrite_extensionrcc8_query_rewrite"></a>A.6.3.1 <code>/conf/query-rewrite-extension/rcc8-query-rewrite</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/query-rewrite-extension/rcc8-query-rewrite</code>
+Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/rcc8eq"><code>geor:rcc8eq</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8dc"><code>geor:rcc8dc</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ec"><code>geor:rcc8ec</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8po"><code>geor:rcc8po</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tppi"><code>geor:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tpp"><code>geor:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntpp"><code>geor:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntppi"><code>geor:rcc8ntppi</code></a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/rule/geosparql/rcc8eq"><code>geor:rcc8eq</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8dc"><code>geor:rcc8dc</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ec"><code>geor:rcc8ec</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8po"><code>geor:rcc8po</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tppi"><code>geor:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tpp"><code>geor:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntpp"><code>geor:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntppi"><code>geor:rcc8ntppi</code></a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rcc8_relation_family_relation_familyrcc8_2">Section 11.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h1 id="_annex_b_informative_geosparql_examples" class="sect0"><a class="anchor" href="#_annex_b_informative_geosparql_examples"></a>Annex B (informative) GeoSPARQL Examples</h1>
+<div class="openblock partintro">
+<div class="content">
+This Annex provides examples of the GeoSPARQL ontology and functions. In addition to these, extended examples are provided seperately by the GeoSPARQL 1.1 profile, see the <a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a> for the link to those examples.
+</div>
+</div>
+<div class="sect1">
+<h2 id="_b_1_rdf_examples"><a class="anchor" href="#_b_1_rdf_examples"></a>B.1 RDF Examples</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This Section illustrates GeoSPARQL ontology modelling with extended examples.</p>
+</div>
+<div class="paragraph">
+<p><em>New Features checklist - to be removed when all examples are complete:</em></p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Classes</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Spatial Measure class</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialmeasure">Section 6.2.3</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect2">
+<h3 id="_b_1_1_classes"><a class="anchor" href="#_b_1_1_classes"></a>B.1.1 Classes</h3>
+<div class="sect3">
+<h4 id="_b_1_1_1_spatialobject"><a class="anchor" href="#_b_1_1_1_spatialobject"></a>B 1.1.1 <code>SpatialObject</code></h4>
+<div class="paragraph">
+<p>The <code>SpatialObject</code> class is defined in <a href="#_class_geospatialobject">Spatial Object</a>.</p>
+</div>
+<div class="paragraph">
+<p>Basic use (as per the example in the class definition)</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:SpatialObject ;
+    skos:prefLabel "Object X";
+.</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+It is unlikely that users of GeoSPARQL will create many instances of <a href="#_class_geospatialobject">Spatial Object</a> as its two more concrete subclasses, <a href="#_class_geofeature">Feature</a> &amp; <a href="#_class_geogeometry">Geometry</a>, are more directly relatable to real-world phenomena and use.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_1_2_feature"><a class="anchor" href="#_b_1_1_2_feature"></a>B 1.1.2 <code>Feature</code></h4>
+<div class="paragraph">
+<p>The <code>Feature</code> class is defined in <a href="#_class_geofeature">Section 6.2.2</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_1_basic_use"><a class="anchor" href="#_b_1_1_2_1_basic_use"></a>B 1.1.2.1 Basic use</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Feature</code> is declared and given a preferred label.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_2_a_feature_related_to_a_geometry"><a class="anchor" href="#_b_1_1_2_2_a_feature_related_to_a_geometry"></a>B 1.1.2.2 A <code>Feature</code> related to a <code>Geometry</code></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Feature</code> is declared, given a preferred label and a geometry for that <code>Feature</code> is indicated with the use of <a href="#_property_geohasgeometry">has geometry</a>. The <code>Geometry</code> indicated is described using a <em>Well-Known Text</em> literal value, indicated by the property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> and the literal type <code>geo:wktLiteral</code>.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_3_feature_with_both_geometry_and_spatialmeasure_instances_indicated"><a class="anchor" href="#_b_1_1_2_3_feature_with_both_geometry_and_spatialmeasure_instances_indicated"></a>B 1.1.2.3 <code>Feature</code> with both <code>Geometry</code> and <code>SpatialMeasure</code> instances indicated</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+        geo:hasGeometry [
+            geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasArea [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 8.7 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Feature</code> and a <code>Geometry</code> are described as per the previous example but an additional <code>SpatialMeasure</code> for the <code>Feature</code> is indicated with the use of the property <a href="#_property_geohasarea">has area</a>. This property indicates a <code>SpatialMeasure</code> instance which conveys its value using the <em>Quantities, Units, Dimensions and Types (QUDT)</em> ontology<sup class="footnote">[<a id="_footnoteref_13" class="footnote" href="#_footnotedef_13" title="View footnote.">13</a>]</sup></p>
+</div>
+<div class="paragraph">
+<p>Note that in this example, the use of QUDT and its <a href="http://qudt.org/schema/qudt#numericValue"><code>qudt:numericValue</code></a> &amp; <a href="http://qudt.org/schema/qudt#numericValue"><code>qudt:unit</code></a> is just one of many possible ways to convey a <code>SpatialMeasure</code> instance&#8217;s value.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_4_feature_with_metric_area"><a class="anchor" href="#_b_1_1_2_4_feature_with_metric_area"></a>B 1.1.2.4 <code>Feature</code> with metric area</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+        geo:hasGeometry [
+            geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasMetricArea "8.7E4"^^xsd:double;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This example encodes the same data as the example above (B 1.1.2.3), but it uses the simpler metric expression of area.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_5_feature_with_two_different_geometry_instances_indicated"><a class="anchor" href="#_b_1_1_2_5_feature_with_two_different_geometry_instances_indicated"></a>B 1.1.2.5 <code>Feature</code> with two different <code>Geometry</code> instances indicated</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        rdfs:label "Official boundary" ;
+        rdfs:comment "Official boundary from the Department of Xxx" ;
+        geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
+    ] ,
+    [
+        rdfs:label "Unofficial boundary" ;
+        rdfs:comment "Unofficial boundary as actually used by everyone" ;
+        geo:asWKT "MULTIPOLYGON (((149.06016597 -35.23610603, 149.060620715 -35.236043435, ... , 149.06016597 -35.23610603)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>In this example, <code>Feature X</code> has two different <code>Geometry</code> instances indicated with their different explained in annotation properties. No ontology properties are used to indicate a difference in these <code>Geometry</code> thus machine use of this <code>Feature</code> woud not be easily able to differentiate them.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_6_feature_with_two_different_geometry_instances_with_different_property_values"><a class="anchor" href="#_b_1_1_2_6_feature_with_two_different_geometry_instances_with_different_property_values"></a>B 1.1.2.6 <code>Feature</code> with two different <code>Geometry</code> instances with different property values</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:hasSpatialResolution [
+            qudt:numericValue 100 ;
+            qudt:unit &lt;http://qudt.org/vocab/unit/M&gt; ;  # metre
+        ] ;
+        geo:asWKT "MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+    ] ,
+    [
+        geo:hasSpatialResolution [
+            qudt:numericValue 5 ;
+            qudt:unit &lt;http://qudt.org/vocab/unit/M&gt; ;  # metre
+        ] ;
+        geo:asWKT "MULTIPOLYGON (((149.06016597 -35.23610603, 149.060620715 -35.236043435, ... , 149.06016597 -35.23610603)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>In this example, <code>Feature X</code> has two different <code>Geometry</code> instances indicated with different spatial resolutions. This use of the <a href="#_property_geohasspatialresolution">has spatial resolution</a> property follows Example <a href="#_b_1_1_2_3_feature_with_both_geometry_and_spatialmeasure_instances_indicated">B 1.1.2.3 <code>Feature</code> with both <code>Geometry</code> and <code>SpatialMeasure</code> instances indicated</a> with its use of QUDT for unit &amp; value.</p>
+</div>
+<div class="paragraph">
+<p>Machine use of this <code>Feature</code> would be able to differentiate the two <code>Geometry</code> instnaces based on this use of <a href="#_property_geohasspatialresolution">has spatial resolution</a>.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_7_feature_with_two_different_geometry_instances_using_metric_spatial_resolution"><a class="anchor" href="#_b_1_1_2_7_feature_with_two_different_geometry_instances_using_metric_spatial_resolution"></a>B 1.1.2.7 <code>Feature</code> with two different <code>Geometry</code> instances using metric spatial resolution</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:hasMetricSpatialResolution "100"^^xsd:double ;
+        geo:asWKT "MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+    ] ,
+    [
+        geo:hasMetricSpatialResolution "5"^^xsd:double ;
+        geo:asWKT "MULTIPOLYGON (((149.06016597 -35.23610603, 149.060620715 -35.236043435, ... , 149.06016597 -35.23610603)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This example encodes the same data as the example above (B 1.1.2.7), but uses the simpler metric property to indicate spatial resolution.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_8_feature_with_two_different_types_of_geometry_instances"><a class="anchor" href="#_b_1_1_2_8_feature_with_two_different_types_of_geometry_instances"></a>B 1.1.2.8 <code>Feature</code> with two different types of <code>Geometry</code> instances</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:asWKT "POLYGON ((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasCentroid [
+        geo:asWKT "POINT (149.06017784 -35.23612321)"^^geo:WktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Feature</code> instance has two geometries, one indicated with the general property <code>hasGeometry</code> and a second indicated with the specialised property <code>hasCentroid</code> which suggests the role that the indicated geometry plays. Note that while <code>hasGeometry</code> may indicate any type of <code>Geometry</code>, <code>hasCentroid</code> should only be used to indicate a point geometry. It may be informally inferred that the polygonal geometry is the <code>Feature</code> instance&#8217;s boundary.</p>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_1_3_geometry"><a class="anchor" href="#_b_1_1_3_geometry"></a>B.1.1.3 <code>Geometry</code></h4>
+<div class="paragraph">
+<p>The <code>Geometry</code> class is defined in <a href="#_class_geogeometry">Section 8.2.1</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_b1_1_3_1_basic_use"><a class="anchor" href="#_b1_1_3_1_basic_use"></a>B1.1.3.1 Basic Use</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:y a geo:Geometry ;
+    skos:prefLabel "Geometry Y";
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Geometry</code> is declared and given a preferred label.</p>
+</div>
+<div class="paragraph">
+<p>From GeoSPARQL 1.0 use, the most commonly observed use of a <code>Geometry</code> is in relation to a <code>Feature</code> as per the example in <a href="#_b_1_1_2_2_a_feature_related_to_a_geometry">B 1.1.2.2 A <code>Feature</code> related to a <code>Geometry</code></a> and often the <code>Geometry</code> is indirectly declared by the use of <code>hasGeometry</code> on the <code>Feature</code> instance indicating a Blank Node, however it is entirely possible to declare <code>Geometry</code> instances without any <code>Feature</code> instances. The next basic example declares a <code>Geometry</code> instance with an demonstration absolute URI and data.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">&lt;https://example.com/geometry/y&gt;
+    a geo:Geometry ;
+    skos:prefLabel "Geometry Y";
+    geo:asWKT "MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here the <code>Geometry</code> instance has data in WKT form and, since no CRS is declared, WGS84 is the assumed, default, CRS.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b1_1_3_2_a_geometry_with_multiple_serializations"><a class="anchor" href="#_b1_1_3_2_a_geometry_with_multiple_serializations"></a>B1.1.3.2 A <code>Geometry</code> with multiple serializations</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:asWKT "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+        geo:asDGGS "&lt;https://w3id.org/dggs/aspix&gt; CELLLIST ((R1234 R1235 R1236 ... R1256))"^^geo:auspixDggsLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a single <code>Geometry</code>, linked to a <code>Feature</code> instance, is expressed using two different serializations: Well-known Text and the AusPIX DGGS.</p>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_1_4_spatialmeasure"><a class="anchor" href="#_b_1_1_4_spatialmeasure"></a>B 1.1.4 <code>SpatialMeasure</code></h4>
+<div class="paragraph">
+<p>The <code>SpatialMeasure</code> class is defined in <a href="#_class_geospatialmeasure">Section 6.2.3</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_b1_1_4_1_basic_use"><a class="anchor" href="#_b1_1_4_1_basic_use"></a>B1.1.4.1 Basic Use</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:z
+    a geo:SpatialMeasure ;
+    skos:prefLabel "Area Z" ;
+    qudt:numericValue 8.7 ;
+    qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This example defines an instance of <code>SpatialMeasure</code> and supplies it with a preferred label, a numeric value and a unit of measure.</p>
+</div>
+<div class="paragraph">
+<p><code>SpatialMeasure</code> instances may be declared in isolation like this - without reference to a <code>Feature</code> instance, just as Geometry instances may be - and future use of GeoSPARQL may see such declarations used widely however, at the time of writing GeoSPARQL 1.1, anticipated use of <code>SpatialMeasure</code> is with reference to a <code>Feature</code> instance: the <em>thing</em> for which the spatial measure is defined. The next example give use in relation to a <code>Feature</code> instance.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x
+    a geo:Feature ;
+    skos:prefLabel "Feature X" ;
+    geo:hasArea [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 8.7 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare
+    ] ;</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>In this example, the <code>SpatialMeasure</code> instance has no label - only a numeric value and a unit of measure - but it is declared to be the area for "Feature X".</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b1_1_4_1_multiple_measures"><a class="anchor" href="#_b1_1_4_1_multiple_measures"></a>B1.1.4.1 Multiple measures</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x
+    a geo:Feature ;
+    skos:prefLabel "Lake X" ;
+    eg:hasFeatureCategory &lt;http://example.com/cat/lake&gt; ;
+    geo:hasArea [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 8.7 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare
+    ] ;
+    geo:hasVolume [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 624432 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/M3&gt; ;  # cubic metre
+    ]</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This example shows a <code>Feature</code> instance with area and volume declared. A categorization of the feature is given through the use of the <code>eg:hasFeatureCategory</code> dummy property which, along with the feature&#8217;s preferred label, indicate that this feature is a lake. Having both an area and a volume makes sense for a lake.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_b_1_2_properties"><a class="anchor" href="#_b_1_2_properties"></a>B.1.2 Properties</h3>
+<div class="paragraph">
+<p><em>New Features checklist - to be removed when all examples are complete:</em></p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Feature Properties</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasBoundingBox</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasboundingbox">Section 6.4.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasCentroid</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohascentroid">Section 6.4.4</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasLength</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohaslength">Section 6.4.5</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasArea</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasarea">Section 6.4.7</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasVolume</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasvolume">Section 6.4.9</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Geometry Serializations</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geoJSONLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geogeojsonliteral">Section 8.4.3.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGeoJSON</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoasgeojson">Section 8.4.3.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">kmlLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geokmlliteral">Section 8.4.4.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asKML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoaskml">Section 8.4.4.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">dggsWKTLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#RDFS Datatype: geo:dggsWKTLiteral">[RDFS Datatype: geo:dggsWKTLiteral]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">auspixDggsWKTLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#RDFS Datatype: geo:auspixDggsWKTLiteral">[RDFS Datatype: geo:auspixDggsWKTLiteral]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asDGGS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoasdggs">Section 8.4.5.3</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect3">
+<h4 id="_b_1_2_1_feature_properties"><a class="anchor" href="#_b_1_2_1_feature_properties"></a>B.1.2.1 Feature Properties</h4>
+<div class="paragraph">
+<p>This example shows a <code>Feature</code> instance with each of the properties defined in <a href="#8.3. Standard Properties for geo:Feature">[8.3. Standard Properties for geo:Feature]</a> used.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:Feature ;
+    skos:preferredLabel "Feature X" ;
+    geo:hasGeometry [
+        geo:asWKT "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; POLYGON ((149.06016 -35.23610, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasDefaultGeometry [
+        geo:asWKT "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; POLYGON ((149.0601 -35.2361, ... , 149.0601 -35.2361)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasLength [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 355 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/M&gt; ;  # metre
+    ] ;
+    geo:hasArea [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 8.7 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare
+    ] ;
+    geo:hasVolume [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 624432 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/M3&gt; ;  # cubic metre
+    ]
+    geo:hasCentroid [
+        geo:asWKT "POINT (149.06017784 -35.23612321)"^^geo:wktLiteral ;
+    ] ;
+    geo:hasBoundingBox [
+        geo:asWKT "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; POLYGON ((149.060 -35.236, ... , 149.060 -35.236)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasSpatialResolution [
+        qudt:numericValue 5 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/M&gt; ;  # metre
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The properties defined for this example&#8217;s <code>Feature</code> instance are vaguely aligned in that the values are not real but are not unrealistic either. It is outside the scope of GeoSPARQL to validate <code>Feature</code> instances' property values.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_2_2_geometry_properties"><a class="anchor" href="#_b_1_2_2_geometry_properties"></a>B.1.2.2 Geometry Properties</h4>
+<div class="paragraph">
+<p>This example shows a <code>Geometry</code> instance declaread in relation to a <code>Feature</code> instance with each of the properties defined in <a href="#8.4. Standard Properties for geo:Geometry">[8.4. Standard Properties for geo:Geometry]</a> used.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:Feature ;
+    geo:hasGeometry [
+        skos:prefLabel "Geometry Y" ;
+        geo:dimension 2 ;
+        geo:coordinateDimension 2 ;
+        geo:spatialDimension 2 ;
+        geo:isEmpty false ;
+        geo:isSimple true ;
+        geo:hasSerialization "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; POLYGON ((149.060 -35.236, ... , 149.060 -35.236)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>In this example, each of the standards properties defined for a <code>Geometry</code> instance has realistic values, for example, the <a href="#_property_geoisempty">is empty</a> is set to <code>false</code> since the <code>Geometry</code> contains information.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_2_3_geometry_serializations"><a class="anchor" href="#_b_1_2_3_geometry_serializations"></a>B.1.2.3 Geometry Serializations</h4>
+<div class="paragraph">
+<p>This section shows a <code>Geometry</code> instance for a <code>Feature</code> instance which is represented in all supported GeoSPARQL serlializations. The geometry values given are real geometry values and approximate <a href="https://en.wikipedia.org/wiki/Moreton_Island">Moreton Island</a> in Queensland, Australia.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:Feature ;
+    geo:hasGeometry [
+        geo:asWKT """&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt;
+            POLYGON ((
+                153.3610112 -27.0621757,
+                153.3658177 -27.1990606,
+                153.421436 -27.3406573,
+                153.4269292 -27.3607835,
+                153.4434087 -27.3315078,
+                153.4183848 -27.2913403,
+                153.4189391 -27.2039578,
+                153.4673476 -27.0267166,
+                153.3610112 -27.0621757
+            ))"""^^geo:wktLiteral ;
+
+        geo:asGML """&lt;gml:Polygon
+                srsName="http://www.opengis.net/def/crs/EPSG/0/4326"&gt;
+                &lt;gml:exterior&gt;
+                    &lt;gml:LinearRing&gt;
+                        &lt;gml:posList&gt;
+                            -27.0621757 153.3610112
+                            -27.1990606 153.3658177
+                            -27.3406573 153.421436
+                            -27.3607835 153.4269292
+                            -27.3315078 153.4434087
+                            -27.2913403 153.4183848
+                            -27.2039578 153.4189391
+                            -27.0267166 153.4673476
+                            -27.0621757 153.3610112
+                        &lt;/gml:posList&gt;
+                    &lt;/gml:LinearRing&gt;
+                &lt;/gml:exterior&gt;
+            &lt;/gml:Polygon&gt;"""^^go:gmlLiteral ;
+
+        geo:asKML """&lt;Polygon&gt;
+                &lt;outerBoundaryIs&gt;
+                    &lt;LinearRing&gt;
+                        &lt;coordinates&gt;
+                        153.3610112,-27.0621757
+                        153.3658177,-27.1990606
+                        153.421436,-27.3406573
+                        153.4269292,-27.3607835
+                        153.4434087,-27.3315078
+                        153.4183848,-27.2913403
+                        153.4189391,-27.2039578
+                        153.4673476,-27.0267166
+                        153.3610112,-27.0621757
+                        &lt;/coordinates&gt;
+                    &lt;/LinearRing&gt;
+                &lt;/outerBoundaryIs&gt;
+            &lt;/Polygon&gt;"""^^go:kmlLiteral ;
+
+        geo:asGeoJSON """{
+                "type": "Polygon",
+                "coordinates": [[
+                    [153.3610112, -27.0621757],
+                    [153.3658177, -27.1990606],
+                    [153.421436, -27.3406573],
+                    [153.4269292, -27.3607835],
+                    [153.4434087, -27.3315078],
+                    [153.4183848, -27.2913403],
+                    [153.4189391, -27.2039578],
+                    [153.4673476, -27.0267166],
+                    [153.3610112, -27.0621757]
+                ]]
+            }"""^^geo:geoJSONLiteral ;
+
+        geo:asDGGS """CELLLIST ((R8346031 R8346034 R8346037
+            R83460058 R83460065 R83460068 R83460072 R83460073 R83460074 R83460075 R83460076
+            R83460077 R83460078 R83460080 R83460081 R83460082 R83460083 R83460084 R83460085
+            R83460086 R83460087 R83460088 R83460302 R83460305 R83460308 R83460320 R83460321
+            R83460323 R83460324 R83460326 R83460327 R83460332 R83460335 R83460338 R83460350
+            R83460353 R83460356 R83460362 R83460365 R83460380 R83460610 R83460611 R83460612
+            R83460613 R83460614 R83460615 R83460617 R83460618 R83460641 R83460642 R83460644
+            R83460645 R83460648 R83460672 R83460686 R83463020 R83463021 R834600487 R834600488
+            R834600557 R834600558 R834600564 R834600565 R834600566 R834600567 R834600568
+            R834600571 R834600572 R834600573 R834600574 R834600575 R834600576 R834600577
+            R834600578 R834600628 R834600705 R834600706 R834600707 R834600708 R834600712
+            R834600713 R834600714 R834600715 R834600716 R834600717 R834600718 R834601334
+            R834601335 R834601336 R834601337 R834601338 R834601360 R834601361 R834601363
+            R834601364 R834601366 R834601367 R834601600 R834601601 R834601603 R834601606
+            R834601630 R834601633 R834603220 R834603221 R834603223 R834603224 R834603226
+            R834603227 R834603250 R834603251 R834603253 R834603256 R834603280 R834603283
+            R834603510 R834603511 R834603512 R834603513 R834603514 R834603515 R834603516
+            R834603517 R834603540 R834603541 R834603543 R834603544 R834603546 R834603547
+            R834603570 R834603573 R834603576 R834603681 R834603682 R834603684 R834603685
+            R834603687 R834603688 R834603810 R834603830 R834603831 R834603832 R834603833
+            R834603834 R834603835 R834603836 R834603837 R834603860 R834603861 R834603863
+            R834603864 R834603866 R834603867 R834606021 R834606022 R834606024 R834606025
+            R834606028 R834606052 R834606055 R834606160 R834606161 R834606162 R834606164
+            R834606165 R834606167 R834606168 R834606200 R834606203 R834606206 R834606230
+            R834606233 R834606236 R834606260 R834606263 R834606266 R834606401 R834606402
+            R834606405 R834606408 R834606432 R834606471 R834606472 R834606474 R834606475
+            R834606477 R834606478 R834606500 R834606503 R834606506 R834606530 R834606533
+            R834606536 R834606560 R834606563 R834606566 R834606712 R834606715 R834606718
+            R834606750 R834606751 R834606752 R834606753 R834606754 R834606755 R834606757
+            R834606758 R834606781 R834606782 R834606784 R834606785 R834606788 R834606800
+            R834606803 R834606806 R834606807 R834606830 R834606831 R834606833 R834606834
+            R834606835 R834606836 R834606837 R834606838 R834606870 R834606873 R834606874
+            R834606876 R834606877 R834630122 R834630125 R834630226 R834630230 R834630231
+            R834630232 R834630234 R834630235 R834630237 R834630238 R834630240 R834630241
+            R834630242 R834630243 R834630244 R834630245 R834630246 R834630247 R834630261
+            R834630262 R834630264 R834630265 R834630268 R834630270 R834630271 R834630273
+            R834630276 R834630502))""""^^geo:auspixDggsLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_b_2_example_sparql_queries_rules"><a class="anchor" href="#_b_2_example_sparql_queries_rules"></a>B.2 Example SPARQL Queries &amp; Rules</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><em>New Features checklist - to be removed when all examples are complete:</em></p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Non-topological Query Functions</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxx">Section 8.5.19</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxY</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxy">Section 8.5.20</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxZ</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxz">Section 8.5.21</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminx">Section 8.5.22</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minY</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminy">Section 8.5.23</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minZ</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminz">Section 8.5.24</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Spatial Aggregate Functions</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">BBOX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geosaf:BBOX">[Function: geosaf:BBOX]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">BoundingCircle</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:BoundingCircle">[Function: geoaf:BoundingCircle]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Centroid</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:Centroid">[Function: geoaf:Centroid]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConcatLines</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConcatLines">[Function: geoaf:ConcatLines]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConcaveHull</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConcaveHull">[Function: geoaf:ConcaveHull]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConvexHull</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConvexHull">[Function: geoaf:ConvexHull]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Union</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:Union">[Function: geoaf:Union]</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>This Section provides example data and then illustrates the use of GeoSPARQL functions and the application of rules with that data.</p>
+</div>
+<div class="sect2">
+<h3 id="_b_2_1_example_data"><a class="anchor" href="#_b_2_1_example_data"></a>B.2.1 Example Data</h3>
+<div class="paragraph">
+<p>The following RDF data (Turtle format) encodes application-specific spatial data. The resulting spatial data is illustrated in Figure 3. The RDF statements define the feature class <code>my:PlaceOfInterest</code>, and two properties are created for associating geometries with features: <code>my:hasExactGeometry</code> and <code>my:hasPointGeometry</code>. <code>my:hasExactGeometry</code> is designated as the default geometry for the <code>my:PlaceOfInterest</code> feature class.</p>
+</div>
+<div class="paragraph">
+<p>All the following examples use the parameter values relation_family = Simple Features, serialization = WKT, and version = 1.0.</p>
+</div>
+<div id="img-illustration" class="imageblock text-center">
+<div class="content">
+<img src="img/03.png" alt="600" width="400">
+</div>
+<div class="title">Figure 3. Illustration of spatial data</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix geo: &lt;http://www.opengis.net/ont/geosparql#&gt; .
+@prefix my: &lt;http://example.org/ApplicationSchema#&gt; .
+@prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
+@prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix sf: &lt;http://www.opengis.net/ont/sf#&gt; .
+
+my:PlaceOfInterest a rdfs:Class ;
+    rdfs:subClassOf geo:Feature .
+
+my:A a my:PlaceOfInterest ;
+    my:hasExactGeometry my:AExactGeom ;
+    my:hasPointGeometry my:APointGeom .
+
+my:B a my:PlaceOfInterest ;
+    my:hasExactGeometry my:BExactGeom ;
+    my:hasPointGeometry my:BPointGeom .
+
+my:C a my:PlaceOfInterest ;
+    my:hasExactGeometry my:CExactGeom ;
+    my:hasPointGeometry my:CPointGeom .
+
+my:D a my:PlaceOfInterest ;
+    my:hasExactGeometry my:DExactGeom ;
+    my:hasPointGeometry my:DPointGeom .
+
+my:E a my:PlaceOfInterest ;
+    my:hasExactGeometry my:EExactGeom .
+
+my:F a my:PlaceOfInterest ;
+    my:hasExactGeometry my:FExactGeom .
+
+my:hasExactGeometry a rdf:Property ;
+    rdfs:subPropertyOf geo:hasDefaultGeometry,
+        geo:hasGeometry .
+
+my:hasPointGeometry a rdf:Property ;
+    rdfs:subPropertyOf geo:hasGeometry .
+
+my:AExactGeom a sf:Polygon ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Polygon((-83.6 34.1, -83.2 34.1, -83.2 34.5,
+                 -83.6 34.5, -83.6 34.1))"""^^geo:wktLiteral.
+
+my:APointGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.4 34.3)"""^^geo:wktLiteral.
+
+my:BExactGeom a sf:Polygon ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Polygon((-83.6 34.1, -83.4 34.1, -83.4 34.3,
+                 -83.6 34.3, -83.6 34.1))"""^^geo:wktLiteral.
+
+my:BPointGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.5 34.2)"""^^geo:wktLiteral.
+
+my:CExactGeom a sf:Polygon ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Polygon((-83.2 34.3, -83.0 34.3, -83.0 34.5,
+                 -83.2 34.5, -83.2 34.3))"""^^geo:wktLiteral.
+
+my:CPointGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.1 34.4)"""^^geo:wktLiteral.
+
+my:DExactGeom a sf:Polygon ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Polygon((-83.3 34.0, -83.1 34.0, -83.1 34.2,
+                 -83.3 34.2, -83.3 34.0))"""^^geo:wktLiteral.
+
+my:DPointGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.2 34.1)"""^^geo:wktLiteral.
+
+my:EExactGeom a sf:LineString ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 LineString(-83.4 34.0, -83.3 34.3)"""^^geo:wktLiteral.
+
+my:FExactGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.4 34.4)"""^^geo:wktLiteral.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_b_2_2_example_queries"><a class="anchor" href="#_b_2_2_example_queries"></a>B.2.2 Example Queries</h3>
+<div class="paragraph">
+<p>This Section illustrates the use of GeoSPARQL functions through a series of example queries.</p>
+</div>
+<div id="annexB_example1" class="paragraph">
+<p><strong>Example 1</strong>: <em>Find all features that feature <code>my:A</code> contains, where spatial calculations are based on</em> <code>my:hasExactGeometry</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?f
+WHERE {
+    my:A my:hasExactGeometry ?aGeom .
+    ?aGeom geo:asWKT ?aWKT .
+    ?f my:hasExactGeometry ?fGeom .
+    ?fGeom geo:asWKT ?fWKT .
+
+    FILTER (
+        geof:sfContains(?aWKT, ?fWKT) &amp;&amp;
+            !sameTerm(?aGeom, ?fGeom)
+        )
+)</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:B</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:F</code></p></td>
+</tr>
+</tbody>
+</table>
+<div id="annexB_example2" class="paragraph">
+<p><strong>Example 2</strong>: <em>Find all features that are within a transient bounding box geometry, where spatial calculations are based on</em> <code>my:hasPointGeometry</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?f
+WHERE {
+    ?f my:hasPointGeometry ?fGeom .
+    ?fGeom geo:asWKT ?fWKT .
+    FILTER (
+        geof:sfWithin(
+            ?fWKT,
+            "&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+            Polygon ((-83.4 34.0, -83.1 34.0,
+                        -83.1 34.2, -83.4 34.2,
+                        -83.4 34.0))"^^geo:wktLiteral
+        )
+    )
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:D</code></p></td>
+</tr>
+</tbody>
+</table>
+<div id="annexB_example3" class="paragraph">
+<p><strong>Example 3</strong>: <em>Find all features that touch the union of feature <code>my:A</code> and feature <code>my:D</code>, where computations are based on</em> <code>my:hasExactGeometry</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?f
+WHERE {
+    ?f my:hasExactGeometry ?fGeom .
+    ?fGeom geo:asWKT ?fWKT .
+    my:A my:hasExactGeometry ?aGeom .
+    ?aGeom geo:asWKT ?aWKT .
+    my:D my:hasExactGeometry ?dGeom .
+    ?dGeom geo:asWKT ?dWKT .
+    FILTER (
+        geof:sfTouches(
+            ?fWKT,
+            geof:union(?aWKT, ?dWKT)
+        )
+    )
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:C</code></p></td>
+</tr>
+</tbody>
+</table>
+<div id="annexB_example4" class="paragraph">
+<p><strong>Example 4</strong>: <em>Find the 3 closest features to feature my:C, where computations are based on</em> <code>my:hasExactGeometry</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX uom: &lt;http://www.opengis.net/def/uom/OGC/1.0/&gt;
+PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/geosparql/function&gt;
+
+SELECT ?f
+WHERE {
+    my:C my:hasExactGeometry ?cGeom .
+    ?cGeom geo:asWKT ?cWKT .
+    ?f my:hasExactGeometry ?fGeom .
+    ?fGeom geo:asWKT ?fWKT .
+    FILTER (?fGeom != ?cGeom)
+}
+ORDER BY ASC (geof:distance(?cWKT, ?fWKT, uom:metre))
+LIMIT 3</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:A</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:D</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:E</code></p></td>
+</tr>
+</tbody>
+</table>
+<div id="annexB_example5" class="paragraph">
+<p><strong>Example 5</strong>: Find the maximum and minimum coordinates of a given set of geometries .</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?minX ?minY ?minZ ?maxX ?maxY ?maxZ
+WHERE {
+    BIND ("&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+            Polygon Z((-83.4 34.0 0, -83.1 34.0 1,
+                        -83.1 34.2 1, -83.4 34.2 1,
+                        -83.4 34.0 0))"^^geo:wktLiteral) AS ?testgeom)
+    BIND(geof:minX(?testgeom) AS ?minX)
+    BIND(geof:maxX(?testgeom) AS ?maxX)
+    BIND(geof:minY(?testgeom) AS ?minY)
+    BIND(geof:maxY(?testgeom) AS ?maxY)
+    BIND(geof:maxZ(?testgeom) AS ?maxZ)
+    BIND(geof:minZ(?testgeom) AS ?minZ)
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?minX</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?minY</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?minZ</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?maxX</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?maxY</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?maxZ</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>-83.4</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>34.0</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>0</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>-83.1</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>34.2</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>1</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_b_2_3_example_rule_application"><a class="anchor" href="#_b_2_3_example_rule_application"></a>B.2.3 Example Rule Application</h3>
+<div class="paragraph">
+<p>This section illustrates the query transformation strategy for implementing GeoSPARQL rules.</p>
+</div>
+<div id="annexB_example6" class="paragraph">
+<p><strong>Example 6</strong>: <em>Find all features or geometries that overlap feature</em> <code>my:A</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Original Query</strong>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+
+SELECT ?f
+WHERE { ?f geo:sfOverlaps my:A }</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Transformed Query (application of transformation rule geor:sfOverlaps)</strong>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?f
+WHERE {
+    { # check for asserted statement
+        ?f geo:sfOverlaps my:A }
+    UNION
+    { # feature – feature
+        ?f geo:hasDefaultGeometry ?fGeom .
+        ?fGeom geo:asWKT ?fSerial .
+        my:A geo:hasDefaultGeometry ?aGeom .
+        ?aGeom geo:asWKT ?aSerial .
+        FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+    }
+    UNION
+    { # feature – geometry
+        ?f geo:hasDefaultGeometry ?fGeom .
+        ?fGeom geo:asWKT ?fSerial .
+        my:A geo:asWKT ?aSerial .
+        FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+    }
+    UNION
+    { # geometry – feature
+        ?f geo:asWKT ?fSerial .
+        my:A geo:hasDefaultGeometry ?aGeom .
+        ?aGeom geo:asWKT ?aSerial .
+        FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+    }
+    UNION
+    { # geometry – geometry
+        ?f geo:asWKT ?fSerial .
+        my:A geo:asWKT ?aSerial .
+        FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+    }</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:D</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:DExactGeom</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:E</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:EExactGeom</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_b_2_4_example_geometry_serialization_conversion_functions"><a class="anchor" href="#_b_2_4_example_geometry_serialization_conversion_functions"></a>B.2.4 Example Geometry Serialization Conversion Functions</h3>
+<div class="paragraph">
+<p><em>New Features checklist - to be removed when all examples are complete:</em></p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Geometry Serializations</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asWKT function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofaswkt">Section 8.4.1.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGML function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofasgml">Section 8.4.2.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGeoJSON function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofasgeojson">Section 8.4.3.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asKML function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofaskml">Section 8.4.4.3</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect3">
+<h4 id="_b_1_2_2_1_geofaswkt"><a class="anchor" href="#_b_1_2_2_1_geofaswkt"></a>B.1.2.2.1 <code>geof:asWKT</code></h4>
+<div class="paragraph">
+<p>For the geometry literal values in <a href="#_b_1_2_3_geometry_serializations">B.1.2.3 Geometry Serializations</a>:</p>
+</div>
+<div class="paragraph">
+<p>Application of the function <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a> to the GML, KML, GeoJSON and DGGS literals should return WKT literal and similarly for each of the other conversion methods, <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a>, <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a>, <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a> &amp; <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a>.</p>
+</div>
+<div class="paragraph">
+<p>Note that the application of <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a> requires a <code>specificDggsDatatype</code> parameter which indicates the particular DGGS literal form being converted to. In the case of <a href="#_b_1_2_3_geometry_serializations">B.1.2.3 Geometry Serializations</a>, this value would be <a href="http://www.opengis.net/def/function/geosparql/auspixDggsLiteral"><code>geof:auspixDggsLiteral</code></a>, the datatype of the AusPIX DGGS format provided by GeoSPARQL 1.1.</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_annex_c"><a class="anchor" href="#_annex_c"></a>Annex C</h3>
+
+</div>
+<div class="sect2">
+<h3 id="_informative"><a class="anchor" href="#_informative"></a>(informative)</h3>
+<div class="sect3">
+<h4 id="_c_3_mappings_from_simple_features_for_sql"><a class="anchor" href="#_c_3_mappings_from_simple_features_for_sql"></a>C.3 Mappings from Simple Features for SQL</h4>
+<div class="paragraph">
+<p>The following table maps the functions and properties from Simple Features for SQL <a href="#ISO19125-1">[ISO19125-1]</a> to GeoSPARQL.</p>
+</div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Simple Features for SQL</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoSPARQL Equivalent</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Since GeoSPARQL</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Related Property Available</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Since GeoSPARQL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.1.1 Basic Methods on Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Dimension(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/dimension">geof:dimension</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#dimension">geo:dimension</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeometryType(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Class of geometry instance</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SRID(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/getSRID">geof:getSRID</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Envelope(): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/envelope">geof:envelope</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasBoundingBox">geo:hasBoundingBox</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">AsText(): String</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/asWKT">geof:asWKT</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#asWKT">geo:asWKT</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">AsBinary(): Binary</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsEmpty(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/isEmpty">geof:isEmpty</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#isEmpty">geo:IsEmpty</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsSimple(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/isEmpty">geof:isSimple</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#isSimple">geo:IsSimple</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Boundary(): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/boundary">geof:boundary</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.1.2 Spatial Relations</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Equals(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfEquals">geof:sfEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfEquals">geo:sfEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Disjoint(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfDisjoint">geof:sfDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfDisjoint">geo:sfDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Intersects(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfIntersects">geof:sfIntersects</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfIntersects">geo:sfIntersects</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Touches(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfTouches">geof:sfTouches</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfTouches">geo:sfTouches</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Crosses(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfCrosses">geof:sfCrosses</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfCrosses">geo:sfCrosses</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Within(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfWithin">geof:sfWithin</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Contains(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfContains">geof:sfContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Overlaps(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfOverlaps">geof:sfOverlaps</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfOverlaps">geo:sfOverlaps</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Relate(anotherGeometry: Geometry, IntersectionPatternMatrix: String): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/relate">geof:relate</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.1.3 Spatial Analysis</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Buffer(distance: Double): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/buffer">geof:buffer</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConvexHull(): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/convexHull">geof:convexHull</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Intersection(anotherGeometry: Geometry): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/intersection">geof:intersection</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Union(anotherGeometry: Geometry): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/union">geof:union</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Difference(anotherGeometry: Geometry): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/difference">geof:difference</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SymDifference(anotherGeometry: Geometry): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/symDifference">geof:symDifference</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.2.1 GeometryCollection</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">NumGeometries(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/numGeometries">geof:numGeometries</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeometryN(N: Integer): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/geometryN">geof:geometryN</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.3.1 Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">X(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Y(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Z(): Double (not in the SQL spec, but a logical extension)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">M(): Double (not in the SQL spec, but a logical extension)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.5.1 Curve</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Length(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/length">geof:length</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasLength">geo:hasLength</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">StartPoint(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">EndPoint(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsClosed(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsRing(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.6.1 LineString</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">NumPoints(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">PointN(N: Integer): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.7.1 MultiCurve</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsClosed(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Length(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/length">geof:length</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasLength">geo:hasLength</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.9.1 Surface</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Area(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/area">geof:area</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasArea">geo:hasArea</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Centroid(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/centroid">geof:centroid</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasCentroid">geo:hasCentroid</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">PointOnSurface(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.10.1 Polygon</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ExteriorRing(): LineString</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">NumInteriorRing(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">InteriorRingN(N: Integer): LineString</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.11.1 MultiSurface</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Area(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/area">geof:area</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasArea">geo:hasArea</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Centroid(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/centroid">geof:centroid</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasCentroid">geo:hasCentroid</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">PointOnSurface(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_bibliography"><a class="anchor" href="#_bibliography"></a>Bibliography</h2>
+<div class="sectionbody">
+<div class="ulist bibliography">
+<ul class="bibliography">
+<li>
+<p><a id="AUSPIX"></a>[AUSPIX] Geoscience Australia, <em>AusPIX: An Australian Government implimentation of the rHEALPix DGGS in Python</em> (2020). <a href="https://github.com/GeoscienceAustralia/AusPIX_DGGS" class="bare">https://github.com/GeoscienceAustralia/AusPIX_DGGS</a></p>
+</li>
+<li>
+<p><a id="QUAL"></a>[QUAL] Cohn, Anthony G.; Brandon Bennett; John Gooday; Nicholas Mark Gotts, <em>Qualitative Spatial Representation and Reasoning with the Region Connection Calculus</em>, GeoInformatica, 1, 275–316 (1997) <a href="https://doi.org/10.1023/A:1009712514511" class="bare">https://doi.org/10.1023/A:1009712514511</a></p>
+</li>
+<li>
+<p><a id="FORMAL"></a>[FORMAL] Egenhofer, M. (1989) A Formal Definition of Binary Topological Relationships. In: Litwin, W. and Schek, H.J., Eds., Proceedings of the 3rd International Conference on Foundations of Data Organization and Algorithms (FODO), Paris, France, Lecture Notes in Computer Science, 367, (Springer-Verlag, New York, 1989) 457-472. (1989)</p>
+</li>
+<li>
+<p><a id="CATEG"></a>[CATEG] Egenhofer, Max and J. Herring <em>Categorizing Binary Topological Relations Between Regions, Lines, and Points</em>, Geographic Databases, Technical Report, Department of Surveying Engineering, University of Maine (1990)</p>
+</li>
+<li>
+<p><a id="ISO13249"></a>[ISO13249] International Organization for Standardization/International Electrotechnical Commission 13249-3, <em>ISO/IEC 13249-3: Information technology — Database languages — SQL multimedia and application packages — Part 3: Spatial</em> (2000)</p>
+</li>
+<li>
+<p><a id="ISO19105"></a>[ISO19105] International Organization for Standardization, <em>ISO 19105: Geographic information – Conformance and testing</em> (2000)</p>
+</li>
+<li>
+<p><a id="ISO19107"></a>[ISO19107] International Organization for Standardization, <em>ISO 19107: Geographic information — Spatial schema</em> (2003)</p>
+</li>
+<li>
+<p><a id="ISO19109"></a>[ISO19109] International Organization for Standardization, <em>ISO 19109: Geographic information — Rules for application schemas</em> (2005)</p>
+</li>
+<li>
+<p><a id="ISO19156"></a>[ISO19156] International Organization for Standardization, <em>ISO 19156: Geographic information — Observations and measurements</em> (2011)</p>
+</li>
+<li>
+<p><a id="LOGIC"></a>[LOGIC] Randell, D. A., Cui, Z. and Cohn, A. G.: A spatial logic based on regions and connection, Proc. 3rd Int. Conf. on Knowledge Representation and Reasoning, Morgan Kaufmann, San Mateo, pp. 165–176 (1992)</p>
+</li>
+<li>
+<p><a id="TURTLE"></a>[TURTLE] World Wide Web Consortium, <em>RDF 1.1 Turtle - Terse RDF Triple Language</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/turtle/" class="bare">https://www.w3.org/TR/turtle/</a></p>
+</li>
+<li>
+<p><a id="RDFXML"></a>[RDFXML] World Wide Web Consortium, <em>RDF 1.1 XML Syntax</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/rdf-syntax-grammar/" class="bare">https://www.w3.org/TR/rdf-syntax-grammar/</a></p>
+</li>
+<li>
+<p><a id="RDF"></a>[RDF] World Wide Web Consortium, <em>RDF 1.1 Concepts and Abstract Syntax</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/rdf11-concepts/" class="bare">https://www.w3.org/TR/rdf11-concepts/</a></p>
+</li>
+<li>
+<p><a id="RDFSEM"></a>[RDFSEM] World Wide Web Consortium, <em>RDF 1.1 Semantics</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/rdf11-mt/" class="bare">https://www.w3.org/TR/rdf11-mt/</a></p>
+</li>
+<li>
+<p><a id="RDFS"></a>[RDFS] World Wide Web Consortium, <em>RDF Schema 1.1</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/rdf-schema/" class="bare">https://www.w3.org/TR/rdf-schema/</a></p>
+</li>
+<li>
+<p><a id="RIF"></a>[RIF] World Wide Web Consortium, <em>RIF Overview (Second Edition)</em>, W3C Working Group Note (5 February 2013). <a href="https://www.w3.org/TR/rif-overview/" class="bare">https://www.w3.org/TR/rif-overview/</a></p>
+</li>
+<li>
+<p><a id="OWL2"></a>[OWL2] World Wide Web Consortium, <em>OWL 2 Web Ontology Language Document Overview (Second Edition)</em>, W3C Recommendation (11 December 2012). <a href="https://www.w3.org/TR/owl2-overview/" class="bare">https://www.w3.org/TR/owl2-overview/</a></p>
+</li>
+<li>
+<p><a id="XML"></a>[XML] World Wide Web Consortium, <em>Extensible Markup Language (XML) 1.0 (Fifth Edition)</em>, W3C Recommendation (26 November 2008). <a href="http://www.w3.org/TR/xml/" class="bare">http://www.w3.org/TR/xml/</a></p>
+</li>
+<li>
+<p><a id="XMLNS"></a>[XMLNS] World Wide Web Consortium, <em>Namespaces in XML 1.0 (Third Edition)</em>, W3C Recommendation (8 December 2009). <a href="https://www.w3.org/TR/xml-names/" class="bare">https://www.w3.org/TR/xml-names/</a></p>
+</li>
+<li>
+<p><a id="XSD1"></a>[XSD1] World Wide Web Consortium, <em>XML Schema Part 1: Structures (Second Edition)</em>, W3C Recommendation (28 October 2004). <a href="https://www.w3.org/TR/xmlschema-1/" class="bare">https://www.w3.org/TR/xmlschema-1/</a></p>
+</li>
+<li>
+<p><a id="XSD2"></a>[XSD2] World Wide Web Consortium, <em>XML Schema Part 2: Datatypes (Second Edition)</em>, W3C Recommendation (28 October 2004). <a href="https://www.w3.org/TR/xmlschema-2/" class="bare">https://www.w3.org/TR/xmlschema-2/</a></p>
+</li>
+<li>
+<p><a id="DGGSAS"></a>[DGGSAS] Open Geospatial Consortium, <em>Abstract Standard Topic 21 - Discrete Global Grid Systems - Part 1 Core Reference system and Operations and Equal Area Earth Reference System</em>, Open Geospatial Consortium Standard (2021) <a href="http://www.opengis.net/doc/AS/dggs/2.0" class="bare">http://www.opengis.net/doc/AS/dggs/2.0</a></p>
+</li>
+<li>
+<p><a id="IETF5234"></a>[IETF5234] Internet Engineering Task Force, <em>RFC 5234: Internet Standard 68: Augmented BNF for Syntax Specifications: ABNF</em>. IETF Request for Comment (2008) <a href="https://tools.ietf.org/html/std68" class="bare">https://tools.ietf.org/html/std68</a></p>
+</li>
+<li>
+<p><a id="GEOJSON"></a>[GEOJSON] Internet Engineering Task Force, <em>RFC 7946: The GeoJSON Format</em>. IETF Request for Comment (August 2016). <a href="https://tools.ietf.org/html/rfc7946" class="bare">https://tools.ietf.org/html/rfc7946</a></p>
+</li>
+<li>
+<p><a id="OGCKML"></a>[OGCKML] Open Geospatial Consortium, <em>OGC KML 2.3</em>. OGC Implementation Standard (04 August 2015). <a href="http://www.opengis.net/doc/IS/kml/2.3" class="bare">http://www.opengis.net/doc/IS/kml/2.3</a></p>
+</li>
+<li>
+<p><a id="ISO19125-1"></a>[ISO19125-1] International Organization for Standardization, <em>ISO 19125-1: Geographic information — Simple feature access — Part 1: Common architecture</em></p>
+</li>
+<li>
+<p><a id="OGC07-036"></a>[OGC07-036] Open Geospatial Consortium, <em>OGC 07-036: Geography Markup Language (GML) Encoding Standard</em>, Version 3.2.1 (27 August 2007).</p>
+</li>
+<li>
+<p><a id="IETF3987"></a>[IETF3987] Internet Engineering Task Force, <em>RFC 3987: Internationalized Resource Identifiers (IRIs)</em>. IETF Request for Comment (January 2005). <a href="https://tools.ietf.org/html/rfc3987" class="bare">https://tools.ietf.org/html/rfc3987</a></p>
+</li>
+<li>
+<p><a id="RIFCORE"></a>[RIFCORE] World Wide Web Consortium, <em>RIF Core Dialect (Second Edition)</em>, W3C Recommendation (5 February 2013) <a href="http://www.w3.org/TR/rif-core/" class="bare">http://www.w3.org/TR/rif-core/</a></p>
+</li>
+<li>
+<p><a id="SPARQL"></a>[SPARQL] World Wide Web Consortium, <em>SPARQL 1.1 Query Language</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/sparql11-query/" class="bare">https://www.w3.org/TR/sparql11-query/</a></p>
+</li>
+<li>
+<p><a id="SPARQLENT"></a>[SPARQLENT] World Wide Web Consortium, <em>SPARQL 1.1 Entailment Regimes</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/sparql11-entailment/" class="bare">https://www.w3.org/TR/sparql11-entailment/</a></p>
+</li>
+<li>
+<p><a id="SPARQLPROT"></a>[SPARQLPROT] World Wide Web Consortium, <em>SPARQL 1.1 Protocol</em>, W3C Recommendation (21 March 2013)&gt; <a href="http://www.w3.org/TR/sparql11-protocol/" class="bare">http://www.w3.org/TR/sparql11-protocol/</a></p>
+</li>
+<li>
+<p><a id="SPARQLRESX"></a>[SPARQLRESX] World Wide Web Consortium, <em>SPARQL Query Results XML Format (Second Edition)</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/rdf-sparql-XMLres/" class="bare">https://www.w3.org/TR/rdf-sparql-XMLres/</a></p>
+</li>
+<li>
+<p><a id="SPARQLRESJ"></a>[SPARQLRESJ] World Wide Web Consortium, <em>SPARQL 1.1 Query Results JSON Format</em>, W3C Recommendation (21 March 2013). <a href="http://www.w3.org/TR/sparql11-results-json/" class="bare">http://www.w3.org/TR/sparql11-results-json/</a></p>
+</li>
+<li>
+<p><a id="SHACL"></a>[SHACL] World Wide Web Consortium, <em>Shapes Constraint Language (SHACL)</em>, W3C Recommendation (20 July 2017). <a href="https://www.w3.org/TR/shacl/" class="bare">https://www.w3.org/TR/shacl/</a></p>
+</li>
+<li>
+<p><a id="PROF"></a>[PROF] World Wide Web Consortium, <em>The Profiles Vocabulary</em>, W3C Working Group Note (18 December 2019). <a href="https://www.w3.org/TR/dx-prof/" class="bare">https://www.w3.org/TR/dx-prof/</a></p>
+</li>
+<li>
+<p><a id="SKOS"></a>[SKOS] World Wide Web Consortium, <em>SKOS Simple Knowledge Organization System Reference</em>, W3C Recommendation (18 August 2009). <a href="https://www.w3.org/TR/skos-reference/" class="bare">https://www.w3.org/TR/skos-reference/</a></p>
+</li>
+<li>
+<p><a id="JSON-LD"></a>[JSON-LD] World Wide Web Consortium, <em>JSON-LD 1.1: A JSON-based Serialization for Linked Data</em>, W3C Recommendation (16 July 2020). <a href="https://www.w3.org/TR/json-ld11/" class="bare">https://www.w3.org/TR/json-ld11/</a></p>
+</li>
+<li>
+<p><a id="CHARTER"></a>[CHARTER] Open Geospatial Consortium, <em>OGC GeoSPARQL SWG Charter</em>, OGC Working Group Charter (25 August 2020). <a href="https://github.com/opengeospatial/ogc-geosparql/blob/master/charter/swg_charter.pdf" class="bare">https://github.com/opengeospatial/ogc-geosparql/blob/master/charter/swg_charter.pdf</a></p>
+</li>
+<li>
+<p><a id="DE-9IM"></a> Clementini, Eliseo; Di Felice, Paolino and van Oosterom, Peter, <em>A small set of formal topological relationships suitable for end-user interaction</em> (1993). In Abel, David; Ooi, Beng Chin (eds.). Advances in Spatial Databases: Third International Symposium, SSD '93 Singapore, June 23–25, 1993 Proceedings. Lecture Notes in Computer Science. 692/1993. Springer. pp. 277–295. doi:10.1007/3-540-56869-7_16.</p>
+</li>
+</ul>
+</div>
+<div style="page-break-after: always;"></div>
+</div>
+</div>
+</div>
+<div id="footnotes">
+<hr>
+<div class="footnote" id="_footnotedef_1">
+<a href="#_footnoteref_1">1</a>. <a href="https://en.wikipedia.org/wiki/SPARQL" class="bare">https://en.wikipedia.org/wiki/SPARQL</a>
+</div>
+<div class="footnote" id="_footnotedef_2">
+<a href="#_footnoteref_2">2</a>. <a href="https://www.w3.org/TR/sparql11-query/#extensionFunctions" class="bare">https://www.w3.org/TR/sparql11-query/#extensionFunctions</a>
+</div>
+<div class="footnote" id="_footnotedef_3">
+<a href="#_footnoteref_3">3</a>. <a href="https://www.ogc.org/def-server" class="bare">https://www.ogc.org/def-server</a>
+</div>
+<div class="footnote" id="_footnotedef_4">
+<a href="#_footnoteref_4">4</a>. <a href="http://www.w3.org/2003/01/geo/" class="bare">http://www.w3.org/2003/01/geo/</a>
+</div>
+<div class="footnote" id="_footnotedef_5">
+<a href="#_footnoteref_5">5</a>. <a href="http://purl.org/dc/terms/Location" class="bare">http://purl.org/dc/terms/Location</a>
+</div>
+<div class="footnote" id="_footnotedef_6">
+<a href="#_footnoteref_6">6</a>. <a href="https://schema.org/GeoCoordinates" class="bare">https://schema.org/GeoCoordinates</a>
+</div>
+<div class="footnote" id="_footnotedef_7">
+<a href="#_footnoteref_7">7</a>. <a href="https://schema.org/GeoShape" class="bare">https://schema.org/GeoShape</a>
+</div>
+<div class="footnote" id="_footnotedef_8">
+<a href="#_footnoteref_8">8</a>. <a href="https://www.w3.org/ns/locn" class="bare">https://www.w3.org/ns/locn</a>
+</div>
+<div class="footnote" id="_footnotedef_9">
+<a href="#_footnoteref_9">9</a>. <a href="https://www.w3.org/TR/vocab-dcat/#spatial-properties" class="bare">https://www.w3.org/TR/vocab-dcat/#spatial-properties</a>
+</div>
+<div class="footnote" id="_footnotedef_10">
+<a href="#_footnoteref_10">10</a>. <a href="https://www.w3.org/TR/sparql11-query/#expressions" class="bare">https://www.w3.org/TR/sparql11-query/#expressions</a>
+</div>
+<div class="footnote" id="_footnotedef_11">
+<a href="#_footnoteref_11">11</a>. <a href="https://www.w3.org/TR/sparql11-query/#operatorExtensibility" class="bare">https://www.w3.org/TR/sparql11-query/#operatorExtensibility</a>
+</div>
+<div class="footnote" id="_footnotedef_12">
+<a href="#_footnoteref_12">12</a>. <a href="https://www.ogc.org/def-server" class="bare">https://www.ogc.org/def-server</a>
+</div>
+<div class="footnote" id="_footnotedef_13">
+<a href="#_footnoteref_13">13</a>. <a href="http://www.qudt.org" class="bare">http://www.qudt.org</a>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2021-07-21 10:39:32 +1000
+</div>
+</div>
+</body>
+</html>

--- a/spec.html
+++ b/spec.html
@@ -1,0 +1,8066 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.10">
+<title>OGC GeoSPARQL - A Geographic Query Language for RDF Data</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+:not(pre)>code.nobreak{word-wrap:normal}
+:not(pre)>code.nowrap{white-space:nowrap}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="book">
+<div id="header">
+<h1>GeoSPARQL</h1>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<style>
+  .imageblock > .title {
+    text-align: inherit;
+  }
+</style>
+<div style="page-break-after: always;"></div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong class="big">Open Geospatial Consortium</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Submission Date: &lt;yyyy-mm-dd&gt;</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Approval Date: &lt;yyyy-mm-dd&gt;</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Publication Date: &lt;yyyy-mm-dd&gt;</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">External identifier of this OGC&#174; document: <a href="http://www.opengis.net/doc/IS/geosparql/1.1" class="bare">http://www.opengis.net/doc/IS/geosparql/1.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Internal reference number of this OGC&#174; document: YY-DOC</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Version: 1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Category: OGC&#174; Implementation Specification</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-right valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Editors: Matthew Perry, John Herring, Nicholas J. Car, Timo Homburg, Joseph Abhayaratna &amp; Simon J.D. Cox</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-none grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong class="big">OGC GeoSPARQL - A Geographic Query Language for RDF Data</strong></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Copyright notice</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Copyright &#169; 2021 Open Geospatial Consortium</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock">To obtain additional rights of use, visit <a href="http://www.opengeospatial.org/legal/" class="bare">http://www.opengeospatial.org/legal/</a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-none grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Warning</strong></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>This document is an OGC Member approved international standard. This document is available on a royalty free, non-discriminatory basis. Recipients of this document are invited to submit, with their comments, notification of any relevant patent rights of which they are aware and to provide supporting documentation.</p>
+</div>
+<table class="tableblock frame-all grid-none stripes-odd" style="width: 50%;">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Document type: OGC&#174; Standard</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Document subtype: Encoding</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Document stage: Approved for Public Release</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Document language: English</p></td>
+</tr>
+</tbody>
+</table>
+<div style="page-break-after: always;"></div>
+<div class="paragraph">
+<p>License Agreement</p>
+</div>
+<div class="paragraph">
+<p><span class="small">Permission is hereby granted by the Open Geospatial Consortium, ("Licensor"), free of charge and subject to the terms set forth below, to any person obtaining a copy of this Intellectual Property and any associated documentation, to deal in the Intellectual Property without restriction (except as set forth below), including without limitation the rights to implement, use, copy, modify, merge, publish, distribute, and/or sublicense copies of the Intellectual Property, and to permit persons to whom the Intellectual Property is furnished to do so, provided that all copyright notices on the intellectual property are retained intact and that each person to whom the Intellectual Property is furnished agrees to the terms of this Agreement.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">If you modify the Intellectual Property, all copies of the modified Intellectual Property must include, in addition to the above copyright notice, a notice that the Intellectual Property includes modifications that have not been approved or adopted by LICENSOR.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">THIS LICENSE IS A COPYRIGHT LICENSE ONLY, AND DOES NOT CONVEY ANY RIGHTS UNDER ANY PATENTS THAT MAY BE IN FORCE ANYWHERE IN THE WORLD.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">THE INTELLECTUAL PROPERTY IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE DO NOT WARRANT THAT THE FUNCTIONS CONTAINED IN THE INTELLECTUAL PROPERTY WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION OF THE INTELLECTUAL PROPERTY WILL BE UNINTERRUPTED OR ERROR FREE. ANY USE OF THE INTELLECTUAL PROPERTY SHALL BE MADE ENTIRELY AT THE USER’S OWN RISK. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ANY CONTRIBUTOR OF INTELLECTUAL PROPERTY RIGHTS TO THE INTELLECTUAL PROPERTY BE LIABLE FOR ANY CLAIM, OR ANY DIRECT, SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM ANY ALLEGED INFRINGEMENT OR ANY LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR UNDER ANY OTHER LEGAL THEORY, ARISING OUT OF OR IN CONNECTION WITH THE IMPLEMENTATION, USE, COMMERCIALIZATION OR PERFORMANCE OF THIS INTELLECTUAL PROPERTY.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">This license is effective until terminated. You may terminate it at any time by destroying the Intellectual Property together with all copies in any form. The license will also terminate if you fail to comply with any term or condition of this Agreement. Except as provided in the following sentence, no such termination of this license shall require the termination of any third party end-user sublicense to the Intellectual Property which is in force as of the date of notice of such termination. In addition, should the Intellectual Property, or the operation of the Intellectual Property, infringe, or in LICENSOR&#8217;s sole opinion be likely to infringe, any patent, copyright, trademark or other right of a third party, you agree that LICENSOR, in its sole discretion, may terminate this license without any compensation or liability to you, your licensees or any other party. You agree upon termination of any kind to destroy or cause to be destroyed the Intellectual Property together with all copies in any form, whether held by you or by any third party.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">Except as contained in this notice, the name of LICENSOR or of any other holder of a copyright in all or part of the Intellectual Property shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Intellectual Property without prior written authorization of LICENSOR or such copyright holder. LICENSOR is and shall at all times be the sole entity that may authorize you or any third party to use certification marks, trademarks or other special designations to indicate compliance with any LICENSOR standards or specifications.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">This Agreement is governed by the laws of the Commonwealth of Massachusetts. The application to this Agreement of the United Nations Convention on Contracts for the International Sale of Goods is hereby expressly excluded. In the event any provision of this Agreement shall be deemed unenforceable, void or invalid, such provision shall be modified so as to make it valid and enforceable, and as so modified the entire Agreement shall remain in full force and effect. No decision, action or inaction by LICENSOR shall be construed to be a waiver of any rights or remedies available to it.</span></p>
+</div>
+<div class="paragraph">
+<p><span class="small">None of the Intellectual Property or underlying information or technology may be downloaded or otherwise exported or reexported in violation of U.S. export laws and regulations. In addition, you are responsible for complying with any local laws in your jurisdiction which may impact your right to import, export or use the Intellectual Property, and you represent that you have complied with any regulations or registration procedures required by applicable law to make this license enforceable.</span></p>
+</div>
+<div style="page-break-after: always;"></div>
+<div id="toc" class="toc">
+<div id="toctitle" class="title">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_i_preface">i.    Preface</a></li>
+<li><a href="#_ii_submitting_organizations">ii. Submitting organizations</a>
+<ul class="sectlevel2">
+<li><a href="#_iii_submission_contact_points">iii. Submission contact points</a></li>
+</ul>
+</li>
+<li><a href="#_iv_revision_history">iv. Revision history</a>
+<ul class="sectlevel2">
+<li><a href="#_major_changes_between_versions_1_0_and_1_1">Major changes between versions 1.0 and 1.1</a></li>
+</ul>
+</li>
+<li><a href="#_v_changes_to_the_ogc_abstract_specification">v. Changes to the OGC® Abstract Specification</a></li>
+<li><a href="#_foreword">Foreword</a></li>
+<li><a href="#_introduction">Introduction</a>
+<ul class="sectlevel2">
+<li><a href="#_rdf">RDF</a></li>
+<li><a href="#_sparql">SPARQL</a></li>
+<li><a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a></li>
+</ul>
+</li>
+<li><a href="#_ogc_geosparql_a_geographic_query_language_for_rdf_data">OGC GeoSPARQL – A Geographic Query Language for RDF Data</a>
+<ul class="sectlevel1">
+<li><a href="#_scope">1. Scope</a></li>
+<li><a href="#_conformance">2. Conformance</a></li>
+<li><a href="#_normative_references">3. Normative references</a></li>
+<li><a href="#_terms_and_definitions">4. Terms and definitions</a></li>
+<li><a href="#_conventions">5. Conventions</a>
+<ul class="sectlevel2">
+<li><a href="#_symbols_and_abbreviated_terms">5.1. Symbols and abbreviated terms</a></li>
+<li><a href="#_namespaces">5.2. Namespaces</a></li>
+<li><a href="#_placeholder_iris">5.3. Placeholder IRIs</a></li>
+<li><a href="#_rdf_serializations">5.4. RDF Serializations</a></li>
+</ul>
+</li>
+<li><a href="#_core">6. Core</a>
+<ul class="sectlevel2">
+<li><a href="#_sparql_2">6.1. SPARQL</a></li>
+<li><a href="#_classes">6.2. Classes</a></li>
+<li><a href="#_standard_properties_for_geospatialobject">6.3. Standard Properties for geo:SpatialObject</a></li>
+<li><a href="#_standard_properties_for_geofeature">6.4. Standard Properties for geo:Feature</a></li>
+<li><a href="#_standard_properties_for_geospatialmeasure">6.5. Standard Properties for geo:SpatialMeasure</a></li>
+</ul>
+</li>
+<li><a href="#_topology_vocabulary_extension_relation_family">7. Topology Vocabulary Extension (relation_family)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters">7.1. Parameters</a></li>
+<li><a href="#_simple_features_relation_family_relation_familysimple_features">7.2. Simple Features Relation Family (relation_family=Simple Features)</a></li>
+<li><a href="#_egenhofer_relation_family_relation_familyegenhofer">7.3. Egenhofer Relation Family (relation_family=Egenhofer)</a></li>
+<li><a href="#_rcc8_relation_family_relation_familyrcc8">7.4. RCC8 Relation Family (relation_family=RCC8)</a></li>
+<li><a href="#_equivalent_rcc8_egenhofer_and_simple_features_topological_relations">7.5. Equivalent RCC8, Egenhofer and Simple Features Topological Relations</a></li>
+</ul>
+</li>
+<li><a href="#_geometry_extension_serialization_version">8. Geometry Extension (serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters_2">8.1. Parameters</a></li>
+<li><a href="#_geometry_class">8.2. Geometry Class</a></li>
+<li><a href="#_standard_properties_for_geogeometry">8.3. Standard Properties for geo:Geometry</a></li>
+<li><a href="#_geometry_serializations">8.4. Geometry Serializations</a></li>
+<li><a href="#_non_topological_query_functions">8.5. Non-topological Query Functions</a></li>
+</ul>
+</li>
+<li><a href="#geometry_extension">9. Geometry Topology Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters_3">9.1. Parameters</a></li>
+<li><a href="#_common_query_functions">9.2. Common Query Functions</a></li>
+<li><a href="#_simple_features_relation_family_relation_familysimple_features_2">9.3. Simple Features Relation Family (relation_family=Simple Features)</a></li>
+<li><a href="#_egenhofer_relation_family_relation_familyegenhofer_2">9.4. Egenhofer Relation Family (relation_family=Egenhofer)</a></li>
+<li><a href="#_requirements_for_rcc8_relation_family_relation_familyrcc8">9.5. Requirements for RCC8 Relation Family (relation_family=RCC8)</a></li>
+</ul>
+</li>
+<li><a href="#_rdfs_entailment_extension_relation_family_serialization_version">10. RDFS Entailment Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters_4">10.1. Parameters</a></li>
+<li><a href="#_common_requirements">10.2. Common Requirements</a></li>
+<li><a href="#_wkt_serialization_serializationwkt">10.3. WKT Serialization (serialization=WKT)</a></li>
+<li><a href="#_gml_serialization_serializationgml">10.4. GML Serialization (serialization=GML)</a></li>
+</ul>
+</li>
+<li><a href="#_query_rewrite_extension_relation_family_serialization_version">11. Query Rewrite Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_parameters_5">11.1. Parameters</a></li>
+<li><a href="#_simple_features_relation_family_relation_familysimple_features_3">11.2. Simple Features Relation Family (relation_family=Simple Features)</a></li>
+<li><a href="#_egenhofer_relation_family_relation_familyegenhofer_3">11.3. Egenhofer Relation Family (relation_family=Egenhofer)</a></li>
+<li><a href="#_rcc8_relation_family_relation_familyrcc8_2">11.4. RCC8 Relation Family (relation_family=RCC8)</a></li>
+<li><a href="#_special_considerations">11.5. Special Considerations</a></li>
+</ul>
+</li>
+<li><a href="#_future_work">12. Future Work</a></li>
+</ul>
+</li>
+<li><a href="#_annex_a_normative_abstract_test_suite">Annex A (normative) Abstract Test Suite</a>
+<ul class="sectlevel1">
+<li><a href="#_a_1_conformance_class_core">A.1 Conformance Class: <em>Core</em></a>
+<ul class="sectlevel2">
+<li><a href="#_a_1_1_confcoresparql_protocol">A.1.1 <code>/conf/core/sparql-protocol</code></a></li>
+<li><a href="#_a_1_2_confcorespatial_object_class">A.1.2 <code>/conf/core/spatial-object-class</code></a></li>
+<li><a href="#_a_1_3_confcorefeature_class">A.1.3 <code>/conf/core/feature-class</code></a></li>
+<li><a href="#_a_1_4_confcorespatial_measure_class">A.1.4 <code>/conf/core/spatial-measure-class</code></a></li>
+<li><a href="#_a_1_5_confcorespatial_object_collection_class">A.1.5 <code>/conf/core/spatial-object-collection-class</code></a></li>
+<li><a href="#_a_1_6_confcorefeature_collection_class">A.1.6 <code>/conf/core/feature-collection-class</code></a></li>
+</ul>
+</li>
+<li><a href="#_a_2_conformance_class_topology_vocabulary_extension_relation_family">A.2 Conformance Class: Topology Vocabulary Extension (relation_family)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_2_1_relation_family_simple_features">A.2.1 relation_family = Simple Features</a></li>
+<li><a href="#_a_2_2_relation_family_egenhofer">A.2.2 relation_family = Egenhofer</a></li>
+<li><a href="#_a_2_3_relation_family_rcc8">A.2.3 relation_family = RCC8</a></li>
+</ul>
+</li>
+<li><a href="#_a_3_conformance_class_geometry_extension_serialization_version">A.3 Conformance Class: Geometry Extension (serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_3_1_tests_for_all_serializations">A.3.1 Tests for all Serializations</a></li>
+<li><a href="#_a_3_2_serialization_wkt">A.3.2 serialization = WKT</a></li>
+<li><a href="#_a_3_3_serialization_gml">A.3.3 serialization = GML</a></li>
+<li><a href="#_a_3_4_serialization_geojson">A.3.4 serialization = GEOJSON</a></li>
+<li><a href="#_a_3_5_serialization_kml">A.3.5 serialization = KML</a></li>
+<li><a href="#_a_3_6_serialization_dggs">A.3.6 serialization = DGGS</a></li>
+</ul>
+</li>
+<li><a href="#_a_4_conformance_class_geometry_topology_extension_relation_family_serialization_version">A.4 Conformance Class: Geometry Topology Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_4_1_tests_for_all_relation_families">A.4.1 Tests for all relation families</a></li>
+<li><a href="#_a_4_2_relation_family_simple_features">A.4.2 relation_family = Simple Features</a></li>
+<li><a href="#_a_4_3_relation_family_egenhofer">A.4.3 relation_family = Egenhofer</a></li>
+<li><a href="#_a_4_4_relation_family_rcc8">A.4.4 relation_family = RCC8</a></li>
+</ul>
+</li>
+<li><a href="#_a_5_conformance_class_rdfs_entailment_extension_relation_family_serialization_version">A.5 Conformance Class: RDFS Entailment Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_5_1_tests_for_all_implementations">A.5.1 Tests for all implementations</a></li>
+<li><a href="#_a_5_2_serializationwkt">A.5.2 serialization=WKT</a></li>
+<li><a href="#_a_5_3_serializationgml">A.5.3 serialization=GML</a></li>
+</ul>
+</li>
+<li><a href="#_a_6_conformance_class_query_rewrite_extension_relation_family_serialization_version">A.6 Conformance Class: Query Rewrite Extension (relation_family, serialization, version)</a>
+<ul class="sectlevel2">
+<li><a href="#_a_6_1_relation_family_simple_features">A.6.1 relation_family = Simple Features</a></li>
+<li><a href="#_a_6_2_relation_family_egenhofer">A.6.2 relation_family = Egenhofer</a></li>
+<li><a href="#_a_6_3_relation_family_rcc8">A.6.3 relation_family = RCC8</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#_annex_b_informative_geosparql_examples">Annex B (informative) GeoSPARQL Examples</a>
+<ul class="sectlevel1">
+<li><a href="#_b_1_rdf_examples">B.1 RDF Examples</a>
+<ul class="sectlevel2">
+<li><a href="#_b_1_1_classes">B.1.1 Classes</a></li>
+<li><a href="#_b_1_2_properties">B.1.2 Properties</a></li>
+</ul>
+</li>
+<li><a href="#_b_2_example_sparql_queries_rules">B.2 Example SPARQL Queries &amp; Rules</a>
+<ul class="sectlevel2">
+<li><a href="#_b_2_1_example_data">B.2.1 Example Data</a></li>
+<li><a href="#_b_2_2_example_queries">B.2.2 Example Queries</a></li>
+<li><a href="#_b_2_3_example_rule_application">B.2.3 Example Rule Application</a></li>
+<li><a href="#_b_2_4_example_geometry_serialization_conversion_functions">B.2.4 Example Geometry Serialization Conversion Functions</a></li>
+<li><a href="#_annex_c">Annex C</a></li>
+<li><a href="#_informative">(informative)</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#_bibliography">Bibliography</a></li>
+</ul>
+</div>
+<div style="page-break-after: always;"></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_i_preface"><a class="anchor" href="#_i_preface"></a>i.    Preface</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The GeoSPARQL standard defines:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>a formal <em>profile</em></p>
+</li>
+<li>
+<p><strong>this specification document</strong></p>
+<div class="ulist">
+<ul>
+<li>
+<p>a core RDF/OWL ontology for geographic information representation</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a set of SPARQL extension functions</p>
+</li>
+<li>
+<p>a Functions &amp; Rules vocabulary, derived from the ontology</p>
+</li>
+<li>
+<p>a Simple Features feature types vocabulary</p>
+</li>
+<li>
+<p>a set of RIF rules, and</p>
+</li>
+<li>
+<p>SHACL shapes for RDF data validation</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>This document has the role of <em>specification</em> and authoritatively defines many of the standard&#8217;s elements, including the ontology classes and properties, SPARQL functions and function and rule vocabulary concepts. Complete descriptions of the standard&#8217;s parts and their roles are given in the Introduction in the section <a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a>.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_ii_submitting_organizations"><a class="anchor" href="#_ii_submitting_organizations"></a>ii. Submitting organizations</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The following organizations submitted this Implementation Specification to the Open Geospatial Consortium Inc.:</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p>Australian Bureau of Meteorology</p>
+</li>
+<li>
+<p>Bentley Systems, Inc.</p>
+</li>
+<li>
+<p>CSIRO</p>
+</li>
+<li>
+<p>Defence Geospatial Information Working Group (DGIWG)</p>
+</li>
+<li>
+<p>GeoConnections - Natural Resources Canada</p>
+</li>
+<li>
+<p>Interactive Instruments GmbH</p>
+</li>
+<li>
+<p>GeoScape Australia</p>
+</li>
+<li>
+<p>Mainz University Of Applied Sciences</p>
+</li>
+<li>
+<p>Oracle America</p>
+</li>
+<li>
+<p>Ordnance Survey</p>
+</li>
+<li>
+<p>Raytheon Company</p>
+</li>
+<li>
+<p>SURROUND Australia Pty Ltd.</p>
+</li>
+<li>
+<p>Traverse Technologies, Inc.</p>
+</li>
+<li>
+<p>US Geological Survey (USGS)</p>
+</li>
+</ol>
+</div>
+<div class="sect2">
+<h3 id="_iii_submission_contact_points"><a class="anchor" href="#_iii_submission_contact_points"></a>iii. Submission contact points</h3>
+<div class="paragraph">
+<p>All questions regarding this submission should be directed to the editor or the submitters:</p>
+</div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Contact</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Company</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Oracle America</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">John Herring</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Oracle America</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Nicholas J. Car</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SURROUND Australia Pty Ltd.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Timo Homburg</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Mainz University Of Applied Sciences</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Joseph Abhayaratna</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoScape Australia</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Simon J.D. Cox</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">CSIRO</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_iv_revision_history"><a class="anchor" href="#_iv_revision_history"></a>iv. Revision history</h2>
+<div class="sectionbody">
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Date</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Release</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Author</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Paragraph modified</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">27 Oct. 2009</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Clause 6</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Technical Draft</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">11 Nov. 2009</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">John R. Herring</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Creation</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">06 Jan. 2010</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">John R. Herring</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Comment responses</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">30 March 2010</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Comment responses</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">26 Oct. 2010</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision based on working group discussion</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">28 Jan. 2011</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision based on working group discussion</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">18 April 2011</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Restructure with multiple conformance classes</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">02 May 2011</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Clause 6 and Clause 8</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Move Geometry Class from core to geometryExtension</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">05 May 2011</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Update URIs</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">13 Jan. 2012</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision based on Public RFC</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">16 April 2012</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision based on adoption vote comments</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">19 July 2012</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Matthew Perry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Revision of URIs based on OGC Naming Authority recommendations</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">09 Oct. 2020</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1 Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Joseph Abhayaratna</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Establishment of the 1.1 Specification</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">10 Oct. 2020</p>
+<p class="tableblock">to</p>
+<p class="tableblock">15 March 2021</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1 Draft</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoSPARQL 1.1 SWG</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Addition of GeoSPARQL 1.1 elements</p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect2">
+<h3 id="_major_changes_between_versions_1_0_and_1_1"><a class="anchor" href="#_major_changes_between_versions_1_0_and_1_1"></a>Major changes between versions 1.0 and 1.1</h3>
+<div class="paragraph">
+<p>Version 1.1 of GeoSPARQL was released approximately 9 years after version 1.0. It contains no breaking changes to 1.0, but does contain additions: whole new profile resources, new ontology elements and new functions. The major changes are given in the tables below.</p>
+</div>
+<div class="paragraph">
+<p>These new profile resources are resources - documents - that are separate from this specification. The new <em>profile defintion</em> lists all the GeoSPARQL 1.1 resources.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New resource</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Location</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Profile definition</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/geosparql" class="bare">http://www.opengis.net/def/geosparql</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoSPARQL Rules in RIF</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/geosparql-rifrules" class="bare">http://www.opengis.net/def/geosparql-rifrules</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDF validation file</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/geosparql-shapes" class="bare">http://www.opengis.net/def/geosparql-shapes</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>These new ontology elements and new functions are normatively defined in this specification document.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Classes</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Spatial Measure class</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialmeasure">Section 6.2.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Spatial Object Collection class</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobjectcollection">Section 6.2.4</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Feature Collection class</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Class: geo:SpatialFeatureCollection">[Class: geo:SpatialFeatureCollection]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Feature Properties</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasBoundingBox</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasboundingbox">Section 6.4.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasCentroid</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohascentroid">Section 6.4.4</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasLength</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohaslength">Section 6.4.5</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasArea</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasarea">Section 6.4.7</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasVolume</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasvolume">Section 6.4.9</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Geometry Serializations</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asWKT function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofaswkt">Section 8.4.1.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGML function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofasgml">Section 8.4.2.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geoJSONLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geogeojsonliteral">Section 8.4.3.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGeoJSON</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoasgeojson">Section 8.4.3.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGeoJSON function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofasgeojson">Section 8.4.3.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">kmlLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geokmlliteral">Section 8.4.4.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asKML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoaskml">Section 8.4.4.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asKML function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofaskml">Section 8.4.4.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">dggsLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geodggsliteral">Section 8.4.5.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">auspixDggsLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geoauspixdggsliteral">Section 8.4.5.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asDGGS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoasdggs">Section 8.4.5.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asDGGS function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geo:asDGGS">[Function: geo:asDGGS]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Non-topological Query Functions</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxx">Section 8.5.19</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxY</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxy">Section 8.5.20</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxZ</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxz">Section 8.5.21</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminx">Section 8.5.22</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minY</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminy">Section 8.5.23</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minZ</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminz">Section 8.5.24</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Spatial Aggregate Functions</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">BBOX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geosaf:BBOX">[Function: geosaf:BBOX]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">BoundingCircle</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:BoundingCircle">[Function: geoaf:BoundingCircle]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Centroid</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:Centroid">[Function: geoaf:Centroid]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConcatLines</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConcatLines">[Function: geoaf:ConcatLines]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConcaveHull</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConcaveHull">[Function: geoaf:ConcaveHull]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConvexHull</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConvexHull">[Function: geoaf:ConvexHull]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Union</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:Union">[Function: geoaf:Union]</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_v_changes_to_the_ogc_abstract_specification"><a class="anchor" href="#_v_changes_to_the_ogc_abstract_specification"></a>v. Changes to the OGC® Abstract Specification</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The OGC® Abstract Specification does not require changes to accommodate this OGC® standard.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_foreword"><a class="anchor" href="#_foreword"></a>Foreword</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights. However, to date, no such rights have been claimed or identified.</p>
+</div>
+<div class="paragraph">
+<p>Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the specification set forth in this document, and to provide supporting documentation.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_introduction"><a class="anchor" href="#_introduction"></a>Introduction</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The W3C Semantic Web Activity is defining a collection of technologies that enables a “web of data” where information is easily shared and reused across applications. Some key pieces of this technology stack are the RDF (Resource Description Framework) data model <a href="#RDF">[RDF]</a>, <a href="#RDFS">[RDFS]</a>, the OWL Web Ontology Language <a href="#OWL2">[OWL2]</a> and the SPARQL protocol and RDF query language <a href="#SPARQL">[SPARQL]</a>.</p>
+</div>
+<div class="sect2">
+<h3 id="_rdf"><a class="anchor" href="#_rdf"></a>RDF</h3>
+<div class="paragraph">
+<p>RDF is, among other things, a data model built on edge-node "graphs." Each link in a graph consists of three things (with many aliases depending on the mapping from other types of data models):</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Subject (start node, instance, entity, feature)</p>
+</li>
+<li>
+<p>Predicate (verb, property, attribute, relation, member, link, reference)</p>
+</li>
+<li>
+<p>Object (value, end node, non-literal values can be used as a Subject)</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Any of the three values in a triple can be represented with a Internationalized Resource Identifier (IRI) <a href="#IETF3987">[IETF3987]</a>, which globally and uniqueliy identifies the resource referenced. IRIs are an extension to Universal Resource Identifiers (URIs) that allow for non-ASCII characters. In addition to functioning as identifiers, IRIs are usually, but not necissarily, resolvable which means a person or machine can "dereference" them (<em>click on them</em> or otherwise action them) and be taken to more information about the resource, perhaps in a web browser.</p>
+</div>
+<div class="paragraph">
+<p>Subjects and objects within an RDF triple are called nodes and can also be be represented with a blank node (a local identifier with meaning outside the graph it is defined within). Objects can further be represented with a literal value. Basic literal values in RDF are those used in XML <a href="#XSD2">[XSD2]</a> but the basic types can be extended for specialised purposes and in this specification are, for geometry data.</p>
+</div>
+<div class="paragraph">
+<p>Note that the same node may be a subject in some triples, and tan object in others.</p>
+</div>
+<div id="img-rdf" class="imageblock text-center">
+<div class="content">
+<img src="img/01.png" alt="600" width="400">
+</div>
+<div class="title">Figure 1. RDF Triple</div>
+</div>
+<div class="paragraph">
+<p>Almost all data can be presented or represented in RDF. In particular, it is an easy match to the (feature-instance-by-id, attribute, value) tuples of the General Feature Model <a href="#ISO19109">[ISO19109]</a>, and for the relational model as (table primary key, column, value).</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_sparql"><a class="anchor" href="#_sparql"></a>SPARQL</h3>
+<div class="paragraph">
+<p>From <a href="#SPARQL">[SPARQL]</a>:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+SPARQL &#8230;&#8203; is a set of specifications that provide languages and protocols to query and manipulate RDF graph content on the Web or in an RDF store.
+</blockquote>
+</div>
+<div class="paragraph">
+<p>and, from Wikipedia<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+SPARQL (pronounced "sparkle" /ˈspɑːkəl/, a recursive acronym for SPARQL Protocol and RDF Query Language) is an RDF query language - that is, a semantic query language for databases — able to retrieve and manipulate data stored in Resource Description Framework (RDF) format. It was made a standard by the RDF Data Access Working Group (DAWG) of the World Wide Web Consortium, and is recognized as one of the key technologies of the semantic web. On 15 January 2008, SPARQL 1.0 was acknowledged by W3C as an official recommendation, and SPARQL 1.1 in March, 2013.
+</blockquote>
+</div>
+<div class="paragraph">
+<p>SPARQL queries work on RDF representations of data by finding patterns that match templates in the query, in effect finding information graphs in the RDF data based on the templates and filters (constraints on nodes and edges) expressed in the query. This query template is represented in the SPARQL query by a set of parameterized “query variables” appearing in a sequence of RDF triples and filters. If the query processor finds a set of triples in the data (converted to an RDF graph in some predetermined standard manner) then the values that the “query variables” take on in those triples become a solution to the query request. The values of the variables are returned in the query result in a format based on the “SELECT” clause of the query (similar to SQL).</p>
+</div>
+<div class="paragraph">
+<p>In addition to predicates defined in this manner, the SPARQL query may contain filter functions that can be used to further constrain the query. Several mechanisms are available to extend filter functions to allow for predicates calculated directly on data values. The SPARQL specification <a href="#SPARQL">[SPARQL]</a> in section 17.6<sup class="footnote">[<a id="_footnoteref_2" class="footnote" href="#_footnotedef_2" title="View footnote.">2</a>]</sup> describes the mechanism for invocation of such a filter function.</p>
+</div>
+<div class="paragraph">
+<p>The OGC GeoSPARQL standard supports representing and querying geospatial data on the Semantic Web. GeoSPARQL defines a vocabulary for representing geospatial data in RDF, and it defines extensions to the SPARQL query language for processing geospatial data.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_geosparql_standard_structure"><a class="anchor" href="#_geosparql_standard_structure"></a>GeoSPARQL Standard structure</h3>
+<div class="paragraph">
+<p>The GeoSPARQL standard comprises multiple parts:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>a formal <em>profile</em></p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="http://www.opengis.net/def/geosparql" class="bare">http://www.opengis.net/def/geosparql</a></p>
+</li>
+<li>
+<p>defined according to the <em>Profiles Vocabulary</em> <a href="#PROF">[PROF]</a></p>
+</li>
+<li>
+<p>this relates the parts in the standard together, provides access to them, and declares dependencies on other standards</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p><strong>this specification document</strong></p>
+<div class="ulist">
+<ul>
+<li>
+<p>which defines many of the standard&#8217;s parts</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a core RDF/OWL <a href="#RDF">[RDF]</a>,<a href="#OWL2">[OWL2]</a> ontology for geographic information representation</p>
+<div class="ulist">
+<ul>
+<li>
+<p>based on the General Feature Model <a href="#ISO19109">[ISO19109]</a>, Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>, Feature Geometry <a href="#ISO19107">[ISO19107]</a> and SQL MM <a href="#ISO13249">[ISO13249]</a></p>
+</li>
+<li>
+<p>defined within the specification document and delivered in RDF also</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a Functions &amp; Rules vocabulary, derived from the ontology</p>
+<div class="ulist">
+<ul>
+<li>
+<p>presented as a <a href="#SKOS">[SKOS]</a> taxonomy</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a Simple Features feature types vocabulary</p>
+<div class="ulist">
+<ul>
+<li>
+<p>presented as a <a href="#SKOS">[SKOS]</a> taxonomy</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a set of SPARQL <a href="#SPARQL">[SPARQL]</a> extension functions</p>
+<div class="ulist">
+<ul>
+<li>
+<p>defined within the specification document</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>a set of RIF <a href="#RIFCORE">[RIFCORE]</a> rules, and</p>
+<div class="ulist">
+<ul>
+<li>
+<p>templated within the specification document</p>
+</li>
+<li>
+<p>also delivered as a RIF document also</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>SHACL <a href="#SHACL">[SHACL]</a> shapes for RDF data validation</p>
+<div class="ulist">
+<ul>
+<li>
+<p>defined within a shapes graph file</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>This specification document follows further modular design; it comprises several different components:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>a <em>core</em> component defining the top-level RDFS/OWL classes for spatial objects</p>
+</li>
+<li>
+<p>a <em>topology vocabulary</em> component defining the RDF properties for asserting and querying topological relations between spatial objects</p>
+</li>
+<li>
+<p>a <em>geometry</em> component defines RDFS data types for serializing geometry data, geometry-related RDF properties, and non-topological spatial query functions for geometry objects</p>
+</li>
+<li>
+<p>a <em>geometry topology</em> component defining topological query functions</p>
+</li>
+<li>
+<p>an <em>RDFS entailment</em> component defining mechanisms for matching implicit RDF triples that are derived based on RDF and RDFS semantics</p>
+</li>
+<li>
+<p>a <em>query rewrite</em> component defining rules for transforming a simple triple pattern that tests a topological relation between two features into an equivalent query involving concrete geometries and topological query functions</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Each of these specification components forms a <em>requirements class</em> (a set of requirements) for GeoSPARQL. Implementations can provide various levels of functionality by choosing which requirements classes to support. For example, a system based purely on qualitative spatial reasoning may support only the core and topological vocabulary components.</p>
+</div>
+<div class="paragraph">
+<p>In addition, GeoSPARQL is designed to accommodate systems based on qualitative spatial reasoning and systems based on quantitative spatial computations. Systems based on qualitative spatial reasoning, (e.g. those based on the Region Connection Calculus <a href="#QUAL">[QUAL]</a>, <a href="#LOGIC">[LOGIC]</a>) do not usually model explicit geometries, so queries in such systems will likely test for binary spatial relationships between features rather than between explicit geometries. To allow queries for spatial relations between features in quantitative systems, GeoSPARQL defines a series of query transformation rules that expand a feature-only query into a geometry-based query. With these transformation rules, queries about spatial relations between features will have the same specification in both qualitative systems and quantitative systems. The qualitative system will likely evaluate the query with a backward-chaining spatial “reasoner”, and the quantitative system can transform the query into a geometry-based query that can be evaluated with computational geometry.</p>
+</div>
+</div>
+</div>
+</div>
+<h1 id="_ogc_geosparql_a_geographic_query_language_for_rdf_data" class="sect0"><a class="anchor" href="#_ogc_geosparql_a_geographic_query_language_for_rdf_data"></a>OGC GeoSPARQL – A Geographic Query Language for RDF Data</h1>
+<div class="sect1">
+<h2 id="_scope"><a class="anchor" href="#_scope"></a>1. Scope</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This is the specification document for GeoSPARQL which, as a whole, comprises multiple parts. See the Introduction section <a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a> for details of the parts.</p>
+</div>
+<div class="paragraph">
+<p>GeoSPARQL does not define a comprehensive vocabulary for representing spatial information. It instead defines a core set of classes, properties and datatypes that can be used to construct query patterns. Many useful extensions to this vocabulary are possible, and we intend for the Semantic Web and Geographic Information System (GIS) communities to develop additional vocabulary for describing spatial information.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_conformance"><a class="anchor" href="#_conformance"></a>2. Conformance</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Conformance with this specification shall be checked using all the relevant tests specified in <em>Annex A — Abstract Test Suite</em>. The framework, concepts, and methodology for testing, and the criteria to be achieved to claim conformance are specified in <em>ISO 19105: Geographic information — Conformance and Testing</em> <a href="#ISO19105">[ISO19105]</a>.</p>
+</div>
+<div class="paragraph">
+<p>This document establishes several requirements classes and corresponding conformance classes (a conformance class is a set of tests for each requirement in a requirements class). Any GeoSPARQL implementation claiming conformance with one of the conformance classes shall pass all the tests in the associated abstract test suite.</p>
+</div>
+<div class="paragraph">
+<p>Requirements and conformance tests have IRIs that are relative to versioned namespace IRIs. Requirements and conformance test that are defined in GeoSPARQL 1.0 have IRIs relative to  <code><a href="http://www.opengis.net/spec/geosparql/1.0/" class="bare">http://www.opengis.net/spec/geosparql/1.0/</a></code>, requirements and conformance test that are added in GeoSPARQL 1.1 have IRIs relative to  <code><a href="http://www.opengis.net/spec/geosparql/1.1/" class="bare">http://www.opengis.net/spec/geosparql/1.1/</a></code>.</p>
+</div>
+<div class="paragraph">
+<p>Many conformance classes are parameterized. For parameterized conformance classes, the list of parameters is given within parenthesis.</p>
+</div>
+<table id="conformance_classes" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 1. Conformance Classes</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Conformance class</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Description</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Subclause of the abstract test suite</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Core</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines top-level spatial vocabulary components</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Topology Vocabulary Extension</p>
+<p class="tableblock">(relation_family)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines topological relation vocabulary</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.2</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Geometry Extension</p>
+<p class="tableblock">(serialization, version)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines geometry vocabulary and non- topological query functions</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.3</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Geometry Topology Extension</p>
+<p class="tableblock">(serialization, version, relation_family)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines topological query functions for geometry objects</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.4</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDFS Entailment Extension</p>
+<p class="tableblock">(serialization, version , relation_family)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines a mechanism for matching implicit RDF triples that are derived based on RDF and RDFS semantics</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.5</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Query Rewrite Extension</p>
+<p class="tableblock">(serialization, version, relation_family)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Defines query transformation rules for computing spatial relations between spatial objects based on their associated geometries</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">A.6</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Dependencies between each GeoSPARQL requirements class are shown below in Figure 2. To support a requirements class for a given set of parameter values, an implementation must support each dependent requirements class with the same set of parameter values.</p>
+</div>
+<div id="img-reqclasses" class="imageblock text-center">
+<div class="content">
+<img src="img/02.png" alt="02">
+</div>
+<div class="title">Figure 2. Requirements Class Dependency Graph</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_normative_references"><a class="anchor" href="#_normative_references"></a>3. Normative references</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The following normative documents contain provisions which, through reference in this text, constitute provisions of this document. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. However, parties to agreements based on this document are encouraged to investigate the possibility of applying the most recent editions of the normative documents indicated below. For undated references, the latest edition of the normative document referred to applies.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="#ISO19125-1">[ISO19125-1]</a>, <em>ISO 19125-1: Geographic information — Simple feature access — Part 1: Common architecture</em></p>
+</li>
+<li>
+<p><a href="#OGC07-036">[OGC07-036]</a>, <em>OGC 07-036: Geography Markup Language (GML) Encoding Standard</em>, Version 3.2.1 (27 August 2007).</p>
+</li>
+<li>
+<p><a href="#IETF3987">[IETF3987]</a>, Internet Engineering Task Force, <em>RFC 3987: Internationalized Resource Identifiers (IRIs)</em>. IETF Request for Comment (January 2005). <a href="https://tools.ietf.org/html/rfc3987" class="bare">https://tools.ietf.org/html/rfc3987</a></p>
+</li>
+<li>
+<p><a href="#RIFCORE">[RIFCORE]</a>, <em>RIF Core Dialect (Second Edition)</em>, W3C Recommendation (5 February 2013) <a href="http://www.w3.org/TR/rif-core/" class="bare">http://www.w3.org/TR/rif-core/</a></p>
+</li>
+<li>
+<p><a href="#SPARQL">[SPARQL]</a>, <em>SPARQL 1.1 Query Language</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/sparql11-query/" class="bare">https://www.w3.org/TR/sparql11-query/</a></p>
+</li>
+<li>
+<p><a href="#SPARQLENT">[SPARQLENT]</a>, <em>SPARQL 1.1 Entailment Regimes</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/sparql11-entailment/" class="bare">https://www.w3.org/TR/sparql11-entailment/</a></p>
+</li>
+<li>
+<p><a href="#SPARQLPROT">[SPARQLPROT]</a>, <em>SPARQL 1.1 Protocol</em>, W3C Recommendation (21 March 2013)&gt; <a href="http://www.w3.org/TR/sparql11-protocol/" class="bare">http://www.w3.org/TR/sparql11-protocol/</a></p>
+</li>
+<li>
+<p><a href="#SPARQLRESX">[SPARQLRESX]</a>, <em>SPARQL Query Results XML Format (Second Edition)</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/rdf-sparql-XMLres/" class="bare">https://www.w3.org/TR/rdf-sparql-XMLres/</a></p>
+</li>
+<li>
+<p><a href="#SPARQLRESJ">[SPARQLRESJ]</a>, <em>SPARQL 1.1 Query Results JSON Format</em>, W3C Recommendation (21 March 2013). <a href="http://www.w3.org/TR/sparql11-results-json/" class="bare">http://www.w3.org/TR/sparql11-results-json/</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_terms_and_definitions"><a class="anchor" href="#_terms_and_definitions"></a>4. Terms and definitions</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>For the purposes of this document, the terms and definitions given in the above references apply.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_conventions"><a class="anchor" href="#_conventions"></a>5. Conventions</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_symbols_and_abbreviated_terms"><a class="anchor" href="#_symbols_and_abbreviated_terms"></a>5.1. Symbols and abbreviated terms</h3>
+<div class="paragraph">
+<p>In this specification, the following common acronyms are used:</p>
+</div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 85.7143%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">CRS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Coordinate Reference System</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">DGGS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Discrete Global Grid System</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoJSON</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Geographic JavaScript Object Notation</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GFM</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">General Feature Model (as defined in ISO 19109)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Geography Markup Language</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">KML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Keyhole Markup Language</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">OWL</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">OWL 2 Web Ontology Language</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RCC</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Region Connection Calculus</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDF</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Resource Description Framework</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDFS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RDF Schema</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">RIF</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Rule Interchange Format</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SPARQL</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SPARQL Protocol and RDF Query Language</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SRS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Spatial Reference System</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">WKT</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Well Known Text (as defined by Simple Features or ISO 19125)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">W3C</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">World Wide Web Consortium (<a href="http://www.w3.org/" class="bare">http://www.w3.org/</a>)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">XML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Extensible Markup Language</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_namespaces"><a class="anchor" href="#_namespaces"></a>5.2. Namespaces</h3>
+<div class="paragraph">
+<p>The following IRI namespace prefixes are used throughout this document:</p>
+</div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 85.7143%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ogc:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/" class="bare">http://www.opengis.net/</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">eg:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://example.com/" class="bare">http://example.com/</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geo:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#" class="bare">http://www.opengis.net/ont/geosparql#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geof:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/" class="bare">http://www.opengis.net/def/function/geosparql/</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geor:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/" class="bare">http://www.opengis.net/def/rule/geosparql/</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">sf:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/sf#" class="bare">http://www.opengis.net/ont/sf#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">skos:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/2004/02/skos/core#" class="bare">http://www.w3.org/2004/02/skos/core#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">gml:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/gml#" class="bare">http://www.opengis.net/ont/gml#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">my:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://example.org/ApplicationSchema#" class="bare">http://example.org/ApplicationSchema#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">xsd:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/2001/XMLSchema#" class="bare">http://www.w3.org/2001/XMLSchema#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">rdf:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#" class="bare">http://www.w3.org/1999/02/22-rdf-syntax-ns#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">rdfs:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/2000/01/rdf-schema#" class="bare">http://www.w3.org/2000/01/rdf-schema#</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">owl:</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.w3.org/2002/07/owl#" class="bare">http://www.w3.org/2002/07/owl#</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_placeholder_iris"><a class="anchor" href="#_placeholder_iris"></a>5.3. Placeholder IRIs</h3>
+<div class="paragraph">
+<p>The IRI <a href="http://www.opengis.net/def/geomLiteral"><code>ogc:geomLiteral</code></a> is used in requirement specifications as a placeholder for the geometry literal serialization used in a fully-qualified conformance class, e.g. <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>&lt;http://www.opengis.net/ont/geosparql#wktLiteral&gt;</code></a>.
+The IRI <a href="http://www.opengis.net/def/asGeomLiteral"><code>ogc:asGeomLiteral</code></a> is used in requirement specifications as a placeholder for the geometry literal serialization property used in a fully-qualified conformance class, e.g. <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a>.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_rdf_serializations"><a class="anchor" href="#_rdf_serializations"></a>5.4. RDF Serializations</h3>
+<div class="paragraph">
+<p>Three RDF serializations are used in this document. Terse RDF Triple Language (turtle) <a href="#TURTLE">[TURTLE]</a> is used for RDF snippets placed within the main body of the document, and turtle, JSON-LD <a href="#JSON-LD">[JSON-LD]</a> &amp; RDF/XML <a href="#RDFXML">[RDFXML]</a> is used for the examples in <em>Annex B — GeoSPARQL Examples</em>.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_core"><a class="anchor" href="#_core"></a>6. Core</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <strong>core</strong> requirements class, with IRI <code>/req/core</code>, which has a single corresponding conformance class, <strong>core</strong>, with IRI <code>/conf/core</code>. This requirements class defines a set of classes and properties for representing geospatial data. The resulting vocabulary can be used to construct SPARQL graph patterns for querying appropriately modeled geospatial data. RDFS and OWL vocabulary have both been used so that the vocabulary can be understood by systems that support only RDFS entailment and by systems that support OWL-based reasoning.</p>
+</div>
+<div class="sect2">
+<h3 id="_sparql_2"><a class="anchor" href="#_sparql_2"></a>6.1. SPARQL</h3>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 1</strong> Implementations shall support the SPARQL Query Language for RDF <a href="#SPARQL">[SPARQL]</a>, the SPARQL Protocol <a href="#SPARQLPROT">[SPARQLPROT]</a> and the SPARQL Query Results XML <a href="#SPARQLRESX">[SPARQLRESX]</a> and JSON <a href="#SPARQLRESJ">[SPARQLRESJ]</a> Formats.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/core/sparql-protocol"><code>http://www.opengis.net/spec/geosparql/1.0/req/core/sparql-protocol</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_classes"><a class="anchor" href="#_classes"></a>6.2. Classes</h3>
+<div class="paragraph">
+<p>Three main classes are defined: <a href="#_class_geospatialobject">Spatial Object</a>, <a href="#_class_geofeature">Feature</a>, and <a href="#_class_geospatialmeasure">Spatial Measure</a>. The class <a href="#_class_geofeature">Feature</a> is equivalent to the UML class <code>Feature</code> defined in <a href="#ISO19109">[ISO19109]</a>.</p>
+</div>
+<div class="paragraph">
+<p>Two container classes are defined: <a href="#_class_geospatialobjectcollection">Spatial Object Collection</a> and <a href="#_class_geofeaturecollection">Feature Collection</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="_class_geospatialobject"><a class="anchor" href="#_class_geospatialobject"></a>6.2.1. Class: geo:SpatialObject</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#SpatialObject">geo:SpatialObject</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:SpatialObject
+    a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Spatial Object"@en ;
+    skos:definition "The class Spatial Object represents everything that can
+                    have a spatial representation. It is superclass of feature
+                    and geometry"@en .</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 2</strong> Implementations shall allow the RDFS class <a href="#_class_geospatialobject">Spatial Object</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/core/spatial-object-class"><code>http://www.opengis.net/spec/geosparql/1.0/req/core/spatial-object-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>Example:</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:SpatialObject ;
+     skos:prefLabel "Object X";
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_class_geofeature"><a class="anchor" href="#_class_geofeature"></a>6.2.2. Class: geo:Feature</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#Feature">geo:Feature</a> is equivalent to the class <code>GFI_Feature</code> <a href="#ISO19156">[ISO19156]</a> and is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:Feature
+    a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Feature"@en ;
+    rdfs:subClassOf geo:SpatialObject ;
+    owl:disjointWith geo:Geometry ;
+    skos:definition "This class represents the top-level feature type. This
+                    class is equivalent to GFI_Feature defined in ISO 19156,
+                    and it is superclass of all feature types."@en .</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 3</strong> Implementations shall allow the RDFS class <a href="#_class_geofeature">Feature</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/core/feature-class"><code>http://www.opengis.net/spec/geosparql/1.0/req/core/feature-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_class_geospatialmeasure"><a class="anchor" href="#_class_geospatialmeasure"></a>6.2.3. Class: geo:SpatialMeasure</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#SpatialMeasure">geo:SpatialMeasure</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:SpatialMeasure
+    a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Spatial Measure"@en ;
+    skos:definition "This class represents a measurement of some dimension
+                    of a feature's spatial presence."@en .</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+Properties for Spatial Measure may need to indicate a use a unit of measure. When they do, OGC recommended units of measure vocabularies should be used. See the OGC Definitions Server<sup class="footnote">[<a id="_footnoteref_3" class="footnote" href="#_footnotedef_3" title="View footnote.">3</a>]</sup>.
+</td>
+</tr>
+</table>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 4</strong> Implementations shall allow the RDFS class <a href="#_class_geospatialmeasure">Spatial Measure</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-measure-class"><code>http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-measure-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_class_geospatialobjectcollection"><a class="anchor" href="#_class_geospatialobjectcollection"></a>6.2.4. Class: geo:SpatialObjectCollection</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#SpatialObjectCollection">geo:SpatialObjectCollection</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:SpatialObjectCollection
+  a owl:Class ;
+  rdfs:isDefinedBy geo: ;
+  skos:prefLabel "Collection of spatial objects" ;
+  skos:definition "The class Spatial Object Collection represents any collection of things that can
+                  have a spatial representation. It is superclass of Feature Collection
+                  and Geometry Collection."@en ;
+  rdfs:subClassOf rdfs:Container ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom geo:SpatialObject ;
+      owl:onProperty rdfs:member ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 5</strong> Implementations shall allow the RDFS class <a href="#_class_geospatialobjectcollection">Spatial Object Collection</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-object-collection-class"><code>http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-object-collection-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_class_geofeaturecollection"><a class="anchor" href="#_class_geofeaturecollection"></a>6.2.5. Class: geo:FeatureCollection</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#FeatureCollection">geo:FeatureCollection</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:FeatureCollection
+  a owl:Class ;
+  rdfs:isDefinedBy geo: ;
+  skos:prefLabel "Collection of geospatial features" ;
+  skos:definition "The class Feature Collection represents
+                  any collection of individual Features."@en ;
+  rdfs:subClassOf geo:SpatialObjectCollection ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom :Feature ;
+      owl:onProperty rdfs:member ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 6</strong> Implementations shall allow the RDFS class <a href="#_class_geofeaturecollection">Feature Collection</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/core/feature-collection-class"><code>http://www.opengis.net/spec/geosparql/1.1/req/core/feature-collection-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_standard_properties_for_geospatialobject"><a class="anchor" href="#_standard_properties_for_geospatialobject"></a>6.3. Standard Properties for geo:SpatialObject</h3>
+<div class="paragraph">
+<p><em>To be defined</em></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_standard_properties_for_geofeature"><a class="anchor" href="#_standard_properties_for_geofeature"></a>6.4. Standard Properties for geo:Feature</h3>
+<div class="paragraph">
+<p>Properties are defined for associating geometries with features.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 7</strong> Implementations shall allow the properties <a href="#_property_geohasgeometry">has geometry</a>,
+<a href="#_property_geohasdefaultgeometry">has default geometry</a>, <a href="#_property_geohaslength">has length</a>, <a href="#_property_geohasarea">has area</a>, <a href="#_property_geohasvolume">has volume</a> <a href="#_property_geohascentroid">has centroid</a>, <a href="#_property_geohasboundingbox">has bounding box</a> and <a href="#_property_geohasspatialresolution">has spatial resolution</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect3">
+<h4 id="_property_geohasgeometry"><a class="anchor" href="#_property_geohasgeometry"></a>6.4.1. Property: geo:hasGeometry</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasGeometry"><code>geo:hasGeometry</code></a> is used to link a feature with a geometry that represents its spatial extent. A given feature may have many associated geometries.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasGeometry
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has Geometry"@en ;
+    skos:definition "A spatial representation for a given feature."@en ;
+    rdfs:domain geo:Feature;
+    rdfs:range geo:Geometry .</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasdefaultgeometry"><a class="anchor" href="#_property_geohasdefaultgeometry"></a>6.4.2. Property: geo:hasDefaultGeometry</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasDefaultGeometry"><code>geo:hasDefaultGeometry</code></a> is used to link a feature with its default geometry. The default geometry is the geometry that should be used for spatial calculations in the absence of a request for a specific geometry (e.g. in the case of query rewrite).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasDefaultGeometry
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has Default Geometry"@en ;
+    skos:definition "The default geometry to be used in spatial calculations,
+                    usually the most detailed geometry."@en ;
+    rdfs:subPropertyOf geo:hasGeometry;
+    rdfs:domain geo:Feature;
+    rdfs:range geo:Geometry .</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>GeoSPARQL does not restrict the cardinality of the <a href="#_property_geohasdefaultgeometry">has default geometry</a> property. It is thus possible for a feature to have more than one distinct default geometry or to have no default geometry. This situation does not result in a query processing error; SPARQL graph pattern matching simply proceeds as normal. Certain queries may, however, give logically inconsistent results. For example, if a feature <code>my:f1</code> has two asserted default geometries, and those two geometries are disjoint polygons, the query below could return a non-zero count on a system supporting the GeoSPARQL Query Rewrite Extension (rule <a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint"><code>geor:sfDisjoint</code></a>).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+
+SELECT (COUNT(*) AS ?cnt)
+WHERE { :f1 geo:sfDisjoint :f1 }</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Such cases are application-specific data modeling errors and are therefore outside of the scope of the GeoSPARQL specification., however it is recommended that multiple geometries indicated with <a href="#_property_geohasdefaultgeometry">has default geometry</a> should be differentiated by <code>Geometry</code> class properties, perhaps relating to precision, SRS etc.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasboundingbox"><a class="anchor" href="#_property_geohasboundingbox"></a>6.4.3. Property: geo:hasBoundingBox</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasBoundingBox"><code>geo:hasBoundingBox</code></a> is used to link a feature with a simplified geometry-representation corresponding to the envelope of its geometry. Bounding-boxes are typically uses in indexing and discovery.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasBoundingBox
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:subPropertyOf geo:hasGeometry;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has bounding box"@en ;
+    skos:definition "The minimum or smallest bounding or enclosing box of a given feature."@en ;
+    skos:scopeNote "The target is a geometry that defines a rectilinear region whose edges are
+                    aligned with the axes of the coordinate reference system, which exactly
+                    contains the geometry or feature e.g. sf:Envelope"@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:Geometry .</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>GeoSPARQL does not restrict the cardinality of the <a href="#_property_geohasboundingbox">has bounding box</a> property. A feature may be associated with more than one bounding-box, for example in different coordinate reference systems.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohascentroid"><a class="anchor" href="#_property_geohascentroid"></a>6.4.4. Property: geo:hasCentroid</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasCentroid"><code>geo:hasCentroid</code></a> is used to link a feature with a point geometry corresponding with the centroid of its geometry. The centroid is typically used to show location on a low-resolution image, and for some indexing and discovery functions.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasCentroid
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:subPropertyOf geo:hasGeometry;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has centroid"@en ;
+    skos:definition "The arithmetic mean position of all the geometry points
+                    of a given feature."@en ;
+    skos:scopeNote "The target geometry shall describe a point, e.g. sf:Point"@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:Geometry .</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>GeoSPARQL does not restrict the cardinality of the <a href="#_property_geohascentroid">has centroid</a> property. A feature may be associated with more than one centroid, for example computed using different rules or in different coordinate reference systems.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohaslength"><a class="anchor" href="#_property_geohaslength"></a>6.4.5. Property: geo:hasLength</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasLength"><code>geo:hasLength</code></a> is used to indicate the length of a <a href="#_class_geofeature">Feature</a>. In the case of a one-dimensional <a href="#_class_geofeature">Feature</a>, it is the simple length. In the case of a two-dimensional <a href="#_class_geofeature">Feature</a>, it is interpreted to mean the perimeter length. The range of the property is <a href="#_class_geospatialmeasure">Spatial Measure</a>, which encodes the length value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasLength
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has length"@en ;
+    skos:definition "The length of a Feature, expressed as a Spatial Measure."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:SpatialMeasure .</code></pre>
+</div>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+A consistency check can be applied to geometries indicating both this property and the <a href="#_property_geodimension">dimension</a> property: if supplied, the <a href="#_property_geodimension">dimension</a> property&#8217;s range value must be the literal integer  1 or 2. The following SPARQL query will return <code>true</code> if applied to a graph where is not always the case for all geometries:
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">    PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+    ASK
+    WHERE {
+        ?g geo:hasLength ?l ;
+           geo:dimension ?d .
+
+        FILTER (?d &gt; 2)
+    }</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetriclength"><a class="anchor" href="#_property_geohasmetriclength"></a>6.4.6. Property: geo:hasMetricLength</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricLength"><code>geo:hasMetricLength</code></a> is similar to <a href="#_property_geohaslength">has length</a>, but is easier to specify and use because the unit is always meter (the standard length unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricLength
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has length in meters"@en ;
+    skos:definition "The length of a Feature in meters."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range xsd:double .</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasarea"><a class="anchor" href="#_property_geohasarea"></a>6.4.7. Property: geo:hasArea</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasArea"><code>geo:hasArea</code></a> is used to indicate the area of a <a href="#_class_geofeature">Feature</a>. The range of the property is <a href="#_class_geospatialmeasure">Spatial Measure</a>, which encodes the area value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasArea
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has area"@en ;
+    skos:definition "The two-dimensional area of a Feature, expressed as a Spatial Measure."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:SpatialMeasure .</code></pre>
+</div>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+A consistency check can be applied to geometries indicating both this property and the <a href="#_property_geodimension">dimension</a> property: if supplied, the <a href="#_property_geodimension">dimension</a> property&#8217;s range value must be the literal integer 2. The following SPARQL query will return <code>true</code> if applied to a graph where is not always the case for all geometries:
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">    PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+    ASK
+    WHERE {
+        ?g geo:hasArea ?a ;
+           geo:dimension ?d .
+
+        FILTER (?d != 2)
+    }</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetricarea"><a class="anchor" href="#_property_geohasmetricarea"></a>6.4.8. Property: geo:hasMetricArea</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricArea"><code>geo:hasMetricArea</code></a> is similar to <a href="#_property_geohasarea">has area</a>, but is easier to specify and use because the unit is always square meter (the standard area unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricArea
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has area in square meters"@en ;
+    skos:definition "The area of a Feature in square meters."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range xsd:double .</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasvolume"><a class="anchor" href="#_property_geohasvolume"></a>6.4.9. Property: geo:hasVolume</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasVolume"><code>geo:hasVolume</code></a> is used to indicate the volume of a <a href="#_class_geofeature">Feature</a>. The range of the property is <a href="#_class_geospatialmeasure">Spatial Measure</a>, which encodes the volume value expressed as a scalar quantity which also includes the units of measure, and potentially uncertainty and other properties.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasVolume
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has volume"@en ;
+    skos:definition "The volume of a Feature, expressed as a Spatial Measure"@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range geo:SpatialMeasure ;
+.</code></pre>
+</div>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+A consistency check can be applied to geometries indicating both this property and the <a href="#_property_geodimension">dimension</a> property: if supplied, the <a href="#_property_geodimension">dimension</a> property&#8217;s range value must be the literal integer 3. The following SPARQL query will return <code>true</code> if applied to a graph where is not always the case for all geometries:
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">    PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+    ASK
+    WHERE {
+        ?g geo:hasVolume ?a ;
+           geo:dimension ?d .
+
+        FILTER (?d != 3)
+    }</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetricvolume"><a class="anchor" href="#_property_geohasmetricvolume"></a>6.4.10. Property: geo:hasMetricVolume</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricVolume"><code>geo:hasMetricVolume</code></a> is similar to <a href="#_property_geohasvolume">has volume</a>, but is easier to specify and use because the unit is always cubic meter (the standard volume unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricVolume
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has volume in cubic meters"@en ;
+    skos:definition "The volume of a Feature in cubic meters."@en ;
+    rdfs:domain geo:Feature ;
+    rdfs:range xsd:double .</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_standard_properties_for_geospatialmeasure"><a class="anchor" href="#_standard_properties_for_geospatialmeasure"></a>6.5. Standard Properties for geo:SpatialMeasure</h3>
+<div class="paragraph">
+<p><em>To be defined</em></p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_topology_vocabulary_extension_relation_family"><a class="anchor" href="#_topology_vocabulary_extension_relation_family"></a>7. Topology Vocabulary Extension (relation_family)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>Topology Vocabulary Extension (relation_family)</em> parameterized requirements class, with IRI <code>/req/topology-vocab-extension</code>, which has a single corresponding conformance class <em>Topology Vocabulary Extension (relation_family)</em>, with IRI <code>/conf/topology-vocab-extension</code>. This requirements class defines a vocabulary for asserting and querying topological relations between spatial objects. The class is parameterized so that different families of topological relations may be used, e.g. RCC8, Egenhofer. These relations are generalized so that they may connect features as well as geometries.</p>
+</div>
+<div class="paragraph">
+<p>A Dimensionally Extended 9-Intersection Model (DE-9IM) pattern, which specifies the spatial dimension of the intersections of the interiors, boundaries and exteriors of two geometric objects, is used to describe each spatial relation. Possible pattern values are <code>-1 (empty)</code>, <code>0, 1, 2, T (true) = {0, 1, 2}</code>, <code>F (false) = {-1}</code>, <code>* (don’t care) = {-1, 0, 1, 2}</code>. In the following descriptions, the notation <code>X/Y</code> is used denote applying a spatial relation to geometry types <code>X</code> and <code>Y</code> (i.e., <code>x</code> <em>relation</em> <code>y</code> where <code>x</code> is of type <code>X</code> and <code>y</code> is of type <code>Y</code>). The symbol <code>P</code> is used for 0- dimensional geometries (e.g. points). The symbol <code>L</code> is used for 1-dimensional geometries (e.g. lines), and the symbol <code>A</code> is used for 2-dimensional geometries (e.g. polygons). Consult the Simple Features specification <a href="#ISO19125-1">[ISO19125-1]</a> for a more detailed description of DE-9IM intersection patterns.</p>
+</div>
+<div class="sect2">
+<h3 id="_parameters"><a class="anchor" href="#_parameters"></a>7.1. Parameters</h3>
+<div class="paragraph">
+<p>The following parameter is defined for the <em>Topology Vocabulary Extension</em> requirements class.</p>
+</div>
+<div class="paragraph">
+<p><strong>relation_family</strong>: Specifies the set of topological spatial relations to support.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_simple_features_relation_family_relation_familysimple_features"><a class="anchor" href="#_simple_features_relation_family_relation_familysimple_features"></a>7.2. Simple Features Relation Family (relation_family=Simple Features)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the <em>Simple Features</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 8</strong> Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#sfEquals"><code>geo:sfEquals</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfDisjoint"><code>geo:sfDisjoint</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfIntersects"><code>geo:sfIntersects</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfTouches"><code>geo:sfTouches</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfCrosses"><code>geo:sfCrosses</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfWithin"><code>geo:sfWithin</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfContains"><code>geo:sfContains</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfOverlaps"><code>geo:sfOverlaps</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations"><code>http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Topological relations in the <em>Simple Features</em> family are summarized in <a href="#sf_relations">Table 2</a>. Multi-row intersection patterns should be interpreted as a logical <code>OR</code> of each row.</p>
+</div>
+<table id="sf_relations" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 2. Simple Features Topological Relations</caption>
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation Name</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation IRI</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Domain/Range</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Applies To Geometry Types</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfEquals"><code>geo:sfEquals</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disjoint</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfDisjoint"><code>geo:sfDisjoint</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FF**FF****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">intersects</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfIntersects"><code>geo:sfIntersects</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T******** *T******* ***T***** ****T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">touches</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfTouches"><code>geo:sfTouches</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All except P/P</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">within</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfWithin"><code>geo:sfWithin</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*F**F***)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">contains</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfContains"><code>geo:sfContains</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*****FF*)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">overlaps</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfOverlaps"><code>geo:sfOverlaps</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A, P/P, L/L</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**) for A/A, P/P</code>; <code>(1*T***T**) for L/L</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">crosses</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfCrosses"><code>geo:sfCrosses</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>P/L, P/A, L/A, L/L</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**) for P/L, P/A,
+L/A</code>; <code>(0********) for L/L</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_egenhofer_relation_family_relation_familyegenhofer"><a class="anchor" href="#_egenhofer_relation_family_relation_familyegenhofer"></a>7.3. Egenhofer Relation Family (relation_family=Egenhofer)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the 9-intersection model for binary topological relations (<em>Egenhofer</em>) relation family. Consult references <a href="#FORMAL">[FORMAL]</a> and <a href="#CATEG">[CATEG]</a> for a more detailed discussion of <em>Egenhofer</em> relations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 9</strong> Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#ehEquals"><code>geo:ehEquals</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehDisjoint"><code>geo:ehDisjoint</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehMeet"><code>geo:ehMeet</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehOverlap"><code>geo:ehOverlap</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehCovers"><code>geo:ehCovers</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehCoveredBy"><code>geo:ehCoveredBy</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehInside"><code>geo:ehInside</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehContains"><code>geo:ehContains</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations"><code>http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Topological relations in the <em>Egenhofer</em> family are summarized in <a href="#genhofer_relations">Table 3</a>. Multi-row intersection patterns should be interpreted as a logical <code>OR</code> of each row.</p>
+</div>
+<table id="genhofer_relations" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 3. Egenhofer Topological Relations</caption>
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation Name</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation IRI</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Domain/Range</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Applies To Geometry Types</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehEquals"><code>geo:ehEquals</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disjoint</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehDisjoint"><code>geo:ehDisjoint</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FF*FF****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">meet</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehMeet"><code>geo:ehMeet</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All except P/P</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">overlap</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehOverlap"><code>geo:ehOverlap</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>All</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">covers</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehCovers"><code>geo:ehCovers</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A, A/L, L/L</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*TFT*FF*)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">covered by</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehCoveredBy"><code>geo:ehCoveredBy</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A, L/A, L/L</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFF*TFT**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">inside</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehInside"><code>geo:ehInside</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFF*FFT**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">contains</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehContains"><code>geo:ehContains</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">All</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*TFF*FF*)</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_rcc8_relation_family_relation_familyrcc8"><a class="anchor" href="#_rcc8_relation_family_relation_familyrcc8"></a>7.4. RCC8 Relation Family (relation_family=RCC8)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the region connection calculus basic 8 (<em>RCC8</em>) relation family. Consult references <a href="#QUAL">[QUAL]</a> and <a href="#LOGIC">[LOGIC]</a> for a more detailed discussion of <em>RCC8</em> relations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 10</strong> Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#rcc8eq"><code>geo:rcc8eq</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8dc"><code>geo:rcc8dc</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8ec"><code>geo:rcc8ec</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8po"><code>geo:rcc8po</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tppi"><code>geo:rcc8tppi</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tpp"><code>geo:rcc8tpp</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8ntpp"><code>geo:rcc8ntpp</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8ntppi"><code>geo:rcc8ntppi</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations"><code>http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Topological relations in the <em>RCC8</em> family are summarized in <a href="#rcc8_relations">Table 4</a>.</p>
+</div>
+<table id="rcc8_relations" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 4. RCC8 Topological Relations</caption>
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation Name</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Relation IRI</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Domain/Range</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Applies To Geometry Types</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8eq"><code>geo:rcc8eq</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disconnected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8dc"><code>geo:rcc8dc</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FFTFFTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">externally connected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ec"><code>geo:rcc8ec</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FFTFTTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">partially overlapping</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8po"><code>geo:rcc8po</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTTTTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">tangential proper part inverse</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8tppi"><code>geo:rcc8tppi</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTFTTFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">tangential proper part</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8tpp"><code>geo:rcc8tpp</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFTTFTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">non-tangential proper part</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ntpp"><code>geo:rcc8ntpp</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFTFFTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">non-tangential proper part inverse</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ntppi"><code>geo:rcc8ntppi</code></a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialobject">Spatial Object</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>A/A</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTFFTFFT)</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_equivalent_rcc8_egenhofer_and_simple_features_topological_relations"><a class="anchor" href="#_equivalent_rcc8_egenhofer_and_simple_features_topological_relations"></a>7.5. Equivalent RCC8, Egenhofer and Simple Features Topological Relations</h3>
+<div class="paragraph">
+<p><a href="#relation_equivalences">Table 5</a> summarizes the equivalences between <em>Egenhofer</em>, <em>RCC8</em> and <em>Simple Features</em> spatial relations for closed, non-empty regions. The symbol <code>+</code> denotes logical <code>OR</code>, and the symbol <code>¬</code> denotes negation.</p>
+</div>
+<table id="relation_equivalences" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 5. Equivalent Simple Features, RCC8 and Egenhofer relations</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Simple Features</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">RCC8</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Egenhofer</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">equals</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disjoint</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disconnected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">disjoint</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">intersects</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>¬</code> disconnected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>¬</code> disjoint</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">touches</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">externally connected</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">meet</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">within</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">non-tangential proper part <code>+</code> tangential proper part</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">inside <code>+</code> coveredBy</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">contains</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">non-tangential proper part inverse <code>+</code> tangential proper part inverse</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">contains <code>+</code> covers</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">overlaps</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">partially overlapping</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">overlap</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_geometry_extension_serialization_version"><a class="anchor" href="#_geometry_extension_serialization_version"></a>8. Geometry Extension (serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>Geometry Extension (serialization, version)</em> parameterized requirements class, with IRI <code>/req/geometry-extension</code>, which has a single corresponding conformance class <em>Geometry Extension (serialization, version)</em>, with IRI <code>/conf/geometry-extension</code>. This requirements class defines a vocabulary for asserting and querying information about geometry data, and it defines query functions for operating on geometry data.</p>
+</div>
+<div class="paragraph">
+<p>As part of the vocabulary, an RDFS datatype is defined for encoding detailed geometry information as a literal value. A literal representation of a geometry is needed so that geometric values may be treated as a single unit. Such a representation allows geometries to be passed to external functions for computations and to be returned from a query.</p>
+</div>
+<div class="paragraph">
+<p>Other schemes for encoding simple geometry data in RDF have been implemented. The W3C Basic Geo vocabulary<sup class="footnote">[<a id="_footnoteref_4" class="footnote" href="#_footnotedef_4" title="View footnote.">4</a>]</sup> was an early (2003) RDF vocabulary for "representing lat(itude), long(itude) and other information about spatially-located things, using WGS84 as a reference datum" and many widely used Semantic Web vocabularies contain some spatial data support. For example, <em>Dublin Core Terms</em> provides a <em>Location</em> class<sup class="footnote">[<a id="_footnoteref_5" class="footnote" href="#_footnotedef_5" title="View footnote.">5</a>]</sup> for "A spatial region or named place." and <em>schema.org</em> provides a number of spatial object and geometry classes, such as <code>GeoCoordinates</code> <sup class="footnote">[<a id="_footnoteref_6" class="footnote" href="#_footnotedef_6" title="View footnote.">6</a>]</sup> and <code>GeoShape</code> <sup class="footnote">[<a id="_footnoteref_7" class="footnote" href="#_footnotedef_7" title="View footnote.">7</a>]</sup>.</p>
+</div>
+<div class="paragraph">
+<p>Many vocabularies, such as these two, provide little specific support for detailed geometries and only support the WGS84 Coordinate Reference System (CSR).</p>
+</div>
+<div class="paragraph">
+<p>Since 2012 and the first version of GeoSPARQL, many ontologies have imported GeoSPARQL, for example, the <em>ISA Programme Location Core Vocabulary</em> <sup class="footnote">[<a id="_footnoteref_8" class="footnote" href="#_footnotedef_8" title="View footnote.">8</a>]</sup> whose usage notes provide examples containing GeoSPARQL literals and the use of GeoSPARQL&#8217;s "geometry class". The W3C&#8217;s more recent <em>Data Catalog Vocabulary, Version 2</em> (DCAT2) standard<sup class="footnote">[<a id="_footnoteref_9" class="footnote" href="#_footnotedef_9" title="View footnote.">9</a>]</sup> similarly contains usage notes for <code>geometry</code>, <code>bbox</code> and other properties that suggest the use of GeoSPARQL literals.</p>
+</div>
+<div class="paragraph">
+<p>Some of the properties defined in these vocabularies, such as DCAT2&#8217;s <code>spatialResolution</code> have motivated the inclusion of new properties in this version of GeoSPARQL. In this case the equivalent property is <a href="#_property_geohasspatialresolution">has spatial resolution</a>. The GeoSPARQL 1.1 Standards Working Group charter <a href="#CHARTER">[CHARTER]</a> contains references to a number of vocabularies/ontologies that were influential in the generation of this verison of GeoSPARQL.</p>
+</div>
+<div class="sect2">
+<h3 id="_parameters_2"><a class="anchor" href="#_parameters_2"></a>8.1. Parameters</h3>
+<div class="paragraph">
+<p>The following parameters are defined for the <em>Geometry Extension</em> requirements class.</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">serialization</dt>
+<dd>
+<p>Specifies the serialization standard to use when generating geometry literals and also the supported geometry types.</p>
+</dd>
+</dl>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+a serialization strongly affects the geometry conceptualization. The WKT serialization aligns the geometry types with <em>ISO 19125 Simple Features</em> <a href="#ISO19125-1">[ISO19125-1]</a>, and the GML serialization aligns the geometry types with <em>ISO 19107 Spatial Schema</em> <a href="#ISO19107">[ISO19107]</a>.
+</td>
+</tr>
+</table>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">version</dt>
+<dd>
+<p>Specifies the version of the serialization format used.</p>
+</dd>
+</dl>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_geometry_class"><a class="anchor" href="#_geometry_class"></a>8.2. Geometry Class</h3>
+<div class="paragraph">
+<p>A single root geometry class is defined: <a href="#_class_geogeometry">Geometry</a>. In addition, properties are defined for describing geometry data and for associating geometries with features.</p>
+</div>
+<div class="paragraph">
+<p>One container class is defined: <a href="#_class_geogeometrycollection">Geometry Collection</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="_class_geogeometry"><a class="anchor" href="#_class_geogeometry"></a>8.2.1. Class: geo:Geometry</h4>
+<div class="paragraph">
+<p>The class <a href="http://www.opengis.net/ont/geosparql#Geometry"><code>geo:Geometry</code></a> is equivalent to <code>GM_Object</code> <a href="#ISO19107">[ISO19107]</a> and is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:Geometry
+    a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Geometry"@en ;
+    rdfs:subClassOf geo:SpatialObject ;
+    owl:disjointWith geo:Feature;
+    skos:definition "The class represents the top-level geometry type. This class
+                    is equivalent to the UML class GM_Object defined in ISO 19107,
+                    and it is superclass of all geometry types."@en ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 11</strong> Implementations shall allow the RDFS class <a href="#_class_geogeometry">Geometry</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-class"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_class_geogeometrycollection"><a class="anchor" href="#_class_geogeometrycollection"></a>8.2.2. Class: geo:GeometryCollection</h4>
+<div class="paragraph">
+<p>The class <a href="#_class_geogeometrycollection">Geometry Collection</a> is defined by the following:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:GeometryCollection
+  a owl:Class ;
+  rdfs:isDefinedBy geo: ;
+  skos:prefLabel "Collection of geometry entities"@en ;
+  skos:definition "The class Geometry Collection represents any collection of Geometry entities."@en ;
+  rdfs:subClassOf geo:SpatialObjectCollection ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom geo:Geometry ;
+      owl:onProperty rdfs:member ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 12</strong> Implementations shall allow the RDFS class <a href="#_class_geogeometrycollection">Geometry Collection</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/core/geometry-collection-class"><code>http://www.opengis.net/spec/geosparql/1.1/req/core/geometry-collection-class</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_standard_properties_for_geogeometry"><a class="anchor" href="#_standard_properties_for_geogeometry"></a>8.3. Standard Properties for geo:Geometry</h3>
+<div class="paragraph">
+<p>Properties are defined for describing geometry metadata.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 13</strong> Implementations shall allow the properties <a href="#_property_geodimension">dimension</a>, <a href="#_property_geocoordinatedimension">coordinate dimension</a>, <a href="#_property_geospatialdimension">spatial dimension</a>, <a href="#_property_geoisempty">is empty</a>, <a href="#_property_geoissimple">is simple</a>, <a href="#_property_geohasserialization">has serialization</a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-properties"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-properties</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect3">
+<h4 id="_property_geodimension"><a class="anchor" href="#_property_geodimension"></a>8.3.1. Property: geo:dimension</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#dimension"><code>geo:dimension</code></a> is used to link the a geometry object to its topological dimension, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this will return the largest topological dimension of the contained objects.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:dimension
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "dimension"@en ;
+    skos:definition "The topological dimension of this geometric object, which
+                    must be less than or equal to the coordinate dimension. In
+                    non-homogeneous collections, this is the largest
+                    topological dimension of the contained objects."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:integer ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geocoordinatedimension"><a class="anchor" href="#_property_geocoordinatedimension"></a>8.3.2. Property: geo:coordinateDimension</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#coordinateDimension"><code>geo:coordinateDimension</code></a> is defined to link a geometry object to the dimension of direct positions (coordinate tuples) used in the geometry&#8217;s definition.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:coordinateDimension
+    a rdf:Property, owl:DatatypeProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "coordinate dimension"@en ;
+    skos:definition "The number of measurements or axes needed to describe the
+                    position of this geometry in a coordinate system."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:integer ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geospatialdimension"><a class="anchor" href="#_property_geospatialdimension"></a>8.3.3. Property: geo:spatialDimension</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#spatialDimension"><code>geo:spatialDimension</code></a> is defined to link a geometry object to the dimension of the spatial portion of the direct positions (coordinate tuples) used in its serializations. If the direct positions do not carry a measure coordinate, this will be equal to the coordinate dimension.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:spatialDimension
+    a rdf:Property, owl:DatatypeProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "spatial dimension"@en ;
+    skos:definition "The number of measurements or axes needed to describe the
+                    spatial position of this geometry in a coordinate system."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:integer ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasspatialresolution"><a class="anchor" href="#_property_geohasspatialresolution"></a>8.3.4. Property: geo:hasSpatialResolution</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasSpatialResolution"><code>geo:hasSpatialResolution</code></a> is defined to indicate spatial resolution of the elements within a Geometry. Spatial resolution specifies the level of detail of a Geometry. It the smallest dinstinghuishable distance between adjacent coordinate sets. Therefore this property is not applicable to a point Geometry, because it consists of a single coordinate set.</p>
+</div>
+<div class="paragraph">
+<p>Since this property is defined for a <a href="#_class_geogeometry">Geometry</a>, all literal representations of that Geometry instance must have the same spatial resolution.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasSpatialResolution
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has spatial resolution"@en ;
+    skos:definition "The spatial resolution of a Geometry"@en ;
+    rdfs:domain geo:Geometry ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetricspatialresolution"><a class="anchor" href="#_property_geohasmetricspatialresolution"></a>8.3.5. Property: geo:hasMetricSpatialResolution</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution"><code>geo:hasMetricSpatialResolution</code></a> is similar to <a href="#_property_geohasspatialresolution">has spatial resolution</a>, specifies that the unit of resolution distance is always meter (the standard distance unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricSpatialResolution
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has spatial resolution in meters"@en ;
+    skos:definition "The spatial resolution of a Geometry in meters."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:double ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasspatialaccuracy"><a class="anchor" href="#_property_geohasspatialaccuracy"></a>8.3.6. Property: geo:hasSpatialAccuracy</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasSpatialAccuracy"><code>geo:hasSpatialAccuracy</code></a> is applicable when a Geometry is used to represent a Feature. It is expressed as a distance that indicates the truthfullness of the positions (coordinates) that define the Geometry. In this case accuracy defines a zone surrounding each coordinate within wich the real positions are known to be. The accuracy value defines this zone as a distance from the coordinate(s) in all directions (e.g. a line, a circle or a sphere, depending on spatial dimension).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasSpatialAccuracy
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has spatial accuracy"@en ;
+    skos:definition "The positional accuracy of the coordinates of a Geometry."@en ;
+    rdfs:domain geo:Geometry ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasmetricspatialaccuracy"><a class="anchor" href="#_property_geohasmetricspatialaccuracy"></a>8.3.7. Property: geo:hasMetricSpatialAccuracy</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy"><code>geo:hasMetricSpatialAccuracy</code></a> is similar to <a href="#_property_geohasspatialaccuracy">has spatial accuracy</a>, but it is easier to specify and use because the unit of distance is always meter (the standard distance unit of the International System of Units).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasMetricSpatialAccuracy
+    a rdf:Property, owl:ObjectProperty;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has spatial accuracy in meters"@en ;
+    skos:definition "The positional accuracy of the coordinates of a Geometry in meters."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:double ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geoisempty"><a class="anchor" href="#_property_geoisempty"></a>8.3.8. Property: geo:isEmpty</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#isEmpty"><code>geo:isEmpty</code></a> will indicate a Boolean object set to <code>true</code> if and only if the geometry contains no information.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:isEmpty
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "is empty"@en ;
+    skos:definition "(true) if this geometric object is the empty Geometry. If
+                    true, then this geometric object represents the empty point
+                    set for the coordinate space."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:boolean ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geoissimple"><a class="anchor" href="#_property_geoissimple"></a>8.3.9. Property: geo:isSimple</h4>
+<div class="paragraph">
+<p>The proeprty <a href="http://www.opengis.net/ont/geosparql#isSimple"><code>geo:isSimple</code></a> will indicate a Boolean object set to <code>true</code>, only if the geometry contains no self-intersections, with the possible exception of its boundary.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:isSimple
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "is simple"@en ;
+    skos:definition "(true) if this geometric object has no anomalous geometric
+                    points, such as self intersection or self tangency."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range xsd:boolean ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_property_geohasserialization"><a class="anchor" href="#_property_geohasserialization"></a>8.3.10. Property: geo:hasSerialization</h4>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#hasSerialization"><code>geo:hasSerialization</code></a> is defined to connect a geometry with its text-based serialization (e.g., its WKT serialization).</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:hasSerialization
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "has serialization"@en ;
+    skos:definition "Connects a geometry object with its text-based serialization."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range rdfs:Literal ;
+.</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+this property is the generic property used to connect a geometry with its serialization. GeoSPARQL also contains a number of sub properties of this one for connecting serializations of common types with geometries, for example <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> which can be used for GeoJSON <a href="#GEOJSON">[GEOJSON]</a> literals.
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_geometry_serializations"><a class="anchor" href="#_geometry_serializations"></a>8.4. Geometry Serializations</h3>
+<div class="paragraph">
+<p>This section establishes the requirements for representing geometry data in RDF based on different systems.</p>
+</div>
+<div class="sect3">
+<h4 id="_well_known_text_serializationwkt"><a class="anchor" href="#_well_known_text_serializationwkt"></a>8.4.1. Well-Known Text (serialization=WKT)</h4>
+<div class="paragraph">
+<p>This section establishes the requirements for representing geometry data in RDF based on Well-Known Text (WKT) as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>. It defines one RDFS Datatype: <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>http://www.opengis.net/ont/geosparql#wktLiteral</code></a> and one property, <a href="#_function_geofaswkt">as WKT</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geowktliteral"><a class="anchor" href="#_rdfs_datatype_geowktliteral"></a>8.4.1.1. RDFS Datatype: geo:wktLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> is used to contain the Well-Known Text (WKT) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:wktLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Well-known Text literal"@en ;
+    skos:definition "A Well-known Text serialization of a geometry object."@en ;
+.</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 14</strong> All RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> shall consist of an optional IRI identifying the coordinate reference system and a required Well Known Text (WKT) description of a geometric value. Valid <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiterals</code></a> are formed by either a WKT string as defined in <a href="#ISO13249">[ISO13249]</a> or by concatenating a valid absolute IRI, as defined in <a href="#IETF3987">[IETF3987]</a>, enclose in angled brackets (<code>&lt;</code> &amp; <code>&gt;</code>) followed by a single space (Unicode U+0020 character) as a separator, and a WKT string as defined in <a href="#ISO13249">[ISO13249]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The following <em>ABNF</em> <a href="#IETF5234">[IETF5234]</a> syntax specification formally defines this literal:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>wktLiteral ::= opt-iri-and-space geometric-data
+
+opt-iri-and-space = "&lt;" IRI "&gt;" LWSP / ""</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The token <code>opt-iri-and-space</code> may be either an IRI and space or nothing (<code>""</code>), the token <code>IRI</code> (Internationalized Resource Identifier) is essentially a web address and is defined in <a href="#IETF3987">[IETF3987]</a> and the token <code>LWSP</code>, is one or more white space characters, as defined in <a href="#IETF5234">[IETF5234]</a>. <code>geometric-data</code> is the Well-Known Text representation of the geometry, defined in <a href="#ISO13249">[ISO13249]</a>.</p>
+</div>
+<div class="paragraph">
+<p>In the absence of a leading spatial reference system IRI, the following spatial reference system IRI will be assumed: <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><code>&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</code></a>. This IRI denotes WGS 84 longitude-latitude.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 15</strong> The IRI <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><code>&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</code></a> shall be assumed as the spatial reference system for <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> instances that do not specify an explicit spatial reference system IRI.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-default-srs"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-default-srs</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The OGC maintains a set of SRS IRIs under the <code>http://www.opengis.net/def/crs/</code> namespace and IRIs from this set are recommended for use, however others may also be used, as long as they are valid IRIs.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 16</strong> Coordinate tuples within <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> shall be interpreted using the axis order defined in the spatial reference system used.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-axis-order"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-axis-order</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"Point(-83.38 33.95)"^^&lt;http://www.opengis.net/ont/geosparql#wktLiteral&gt;</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>A second example below encodes the same point as encoded in the example above but using a SRS identified by <a href="http://www.opengis.net/def/SRS/EPSG/0/4326"><code>http://www.opengis.net/def/SRS/EPSG/0/4326</code></a>: a WGS 84 geodetic latitude-longitude spatial reference system (note that this spatial reference system defines a different axis order):</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; Point(33.95 -83.38)"^^&lt;http://www.opengis.net/ont/geosparql#wktLiteral&gt;</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 17</strong> An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> shall be interpreted as an empty geometry.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoaswkt"><a class="anchor" href="#_property_geoaswkt"></a>8.4.1.2. Property: geo:asWKT</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> is defined to link a geometry with its WKT serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 18</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-wkt-literal"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-wkt-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> is used to link a geometric element with its WKT serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asWKT
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as WKT"@en ;
+    skos:definition "The WKT serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:wktLiteral ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofaswkt"><a class="anchor" href="#_function_geofaswkt"></a>8.4.1.3. Function: geof:asWKT</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asWKT (geom: ogc:geomLiteral): geo:wktLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a> converts <code>geom</code> to an equivalent WKT representation preserving the coordinate reference system.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 19</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asWKT-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asWKT-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_geography_markup_language_serializationgml"><a class="anchor" href="#_geography_markup_language_serializationgml"></a>8.4.2. Geography Markup Language (serialization=GML)</h4>
+<div class="paragraph">
+<p>This section establishes requirements for representing geometry data in RDF based on GML as defined by Geography Markup Language Encoding Standard <a href="#OGC07-036">[OGC07-036]</a>. It defines one RDFS Datatype:
+<a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>http://www.opengis.net/ont/geosparql#gmlLiteral</code></a> and one property, <a href="#_function_geofasgml">as GML</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geogmlliteral"><a class="anchor" href="#_rdfs_datatype_geogmlliteral"></a>8.4.2.1. RDFS Datatype: geo:gmlLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> is used to contain the Geography Markup Language (GML) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:gmlLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "GML literal"@en ;
+    skos:definition "The datatype of GML literal values"@en ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> instances are formed by encoding geometry information as a valid element from the GML schema that implements a subtype of <code>GM_Object</code>. For example, in GML 3.2.1 this is every element directly or indirectly in the substitution group of the element <code>{http://www.opengis.net/ont/gml/3.2}AbstractGeometry</code>. In GML 3.1.1 and GML 2.1.2 this is every element directly or indirectly in the substitution group of the element <code>{http://www.opengis.net/ont/gml}_Geometry</code>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 20</strong> All <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> instances shall consist of a valid element from the GML schema that implements a subtype of <code>GM_Object</code> as defined in <a href="#OGC07-036">[OGC07-036]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> below encodes a point geometry in the WGS 84 geodetic longitude-latitude spatial reference system using GML version 3.2:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"""
+&lt;gml:Point
+        srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"
+        xmlns:gml=\"http://www.opengis.net/ont/gml\"&gt;
+    &lt;gml:pos&gt;-83.38 33.95&lt;/gml:pos&gt;
+&lt;/gml:Point&gt;
+"""^^&lt;http://www.opengis.net/ont/geosparql#gmlLiteral&gt;</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 21</strong> An empty <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> shall be interpreted as an empty geometry.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 22</strong> Implementations shall document supported GML profiles.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-profile"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-profile</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoasgml"><a class="anchor" href="#_property_geoasgml"></a>8.4.2.2. Property: geo:asGML</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> is defined to link a geometry with its GML serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 23</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-gml-literal"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-gml-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> is used to link a geometric element with its GML serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asGML
+    a rdf:Property ;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as GML"@en ;
+    skos:definition "The GML serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:gmlLiteral ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofasgml"><a class="anchor" href="#_function_geofasgml"></a>8.4.2.3. Function: geof:asGML</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asGML (geom: ogc:geomLiteral, gmlProfile: xsd:string): geo:gmlLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a> converts <code>geom</code> to an equivalent GML representation defined by a gmlProfile version string preserving the coordinate reference system.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 24</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asGML-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asGML-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_geojson_serializationgeojson"><a class="anchor" href="#_geojson_serializationgeojson"></a>8.4.3. GeoJSON (serialization=GEOJSON)</h4>
+<div class="paragraph">
+<p>This section establishes requirements for representing geometry data in RDF based on GeoJSON as defined by <a href="#GeoJSON">[GeoJSON]</a>. It defines one RDFS Datatype:
+<a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>http://www.opengis.net/ont/geosparql#geoJSONLiteral</code></a> and one property, <a href="#_function_geofasgeojson">as GeoJSON</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geogeojsonliteral"><a class="anchor" href="#_rdfs_datatype_geogeojsonliteral"></a>8.4.3.1. RDFS Datatype: geo:geoJSONLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:geoJSONLiteral</code></a> is used to contain the Geo JavaScript Object Notation (GeoJSON) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:geoJSONLiteral a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "GeoJSON Literal"@en ;
+    skos:definition "A GeoJSON serialization of a geometry object."@en .</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> instances are formed by encoding geometry information as a Geometry object as defined in the GeoJSON specification <a href="#GEOJSON">[GEOJSON]</a>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 25</strong> All <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> instances shall consist of the Geometry objects as defined in the GeoJSON specification <a href="#GEOJSON">[GEOJSON]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 26</strong> RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> do not contain a SRS definition. All literals of this type shall, according to the GeoJSON specification, be encoded only in, and be assumed to use, the WGS84 geodetic longitude-latitude spatial reference system (<a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><code>http://www.opengis.net/def/crs/OGC/1.3/CRS84</code></a>).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-srs"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-srs</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"""
+{"type": "Point", "coordinates": [-83.38,33.95]}
+"""^^&lt;http://www.opengis.net/ont/geosparql#geoJSONLiteral&gt;</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 27</strong> An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> shall be interpreted as an empty geometry, i.e. <code>{"geometry": null}</code> in GeoJSON .</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoasgeojson"><a class="anchor" href="#_property_geoasgeojson"></a>8.4.3.2. Property: geo:asGeoJSON</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> is defined to link a geometry with its GeoJSON serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 28</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-geojson-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-geojson-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> is used to link a geometric element with its GeoJSON serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asGeoJSON
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as GeoJSON"@en ;
+    skos:definition "The GeoJSON serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:geoJSONLiteral ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofasgeojson"><a class="anchor" href="#_function_geofasgeojson"></a>8.4.3.3. Function: geof:asGeoJSON</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asGeoJSON (geom: ogc:geomLiteral): geo:geoJSONLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a> converts <code>geom</code> to an equivalent GeoJSON representation. Coordinates are converted to the CRS84 coordinate system, the only valid coordinate system to be used in a GeoJSON literal.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 29</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asGeoJSON-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asGeoJSON-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_keyhole_markup_language_serializationkml"><a class="anchor" href="#_keyhole_markup_language_serializationkml"></a>8.4.4. Keyhole Markup Language (serialization=KML)</h4>
+<div class="paragraph">
+<p>This section establishes requirements for representing geometry data in RDF based on KML as defined by <a href="#OGCKML">[OGCKML]</a>. It defines one RDFS Datatype:
+<a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>http://www.opengis.net/ont/geosparql#kmlLiteral</code></a> and one property, <a href="#_function_geofaskml">as KML</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geokmlliteral"><a class="anchor" href="#_rdfs_datatype_geokmlliteral"></a>8.4.4.1. RDFS Datatype: geo:kmlLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> is used to contain the Keyhole Markup Language (KML) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:kmlLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "KML Literal"@en ;
+    skos:definition "A KML serialization of a geometry object."@en ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> instances are formed by encoding geometry information as a Geometry object as defined in the KML specification <a href="#OGCKML">[OGCKML]</a>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 30</strong> All <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> instances shall consist of the Geometry objects as defined in the KML specification <a href="#OGCKML">[OGCKML]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 31</strong> RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> do not contain a SRS definition. All literals of this type shall according to the KML specification only be encoded in and assumed to use the WGS84 geodetic longitude-latitude spatial reference system (<a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84"><code>http://www.opengis.net/def/crs/OGC/1.3/CRS84</code></a>).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-srs"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-srs</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> below encodes a point geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"""
+&lt;Point xmlns=\"http://www.opengis.net/kml/2.2\"&gt;
+    &lt;coordinates&gt;-83.38,33.95&lt;/coordinates&gt;
+&lt;/Point&gt;
+"""^^&lt;http://www.opengis.net/ont/geosparql#kmlLiteral&gt;</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 32</strong> An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> shall be interpreted as an empty geometry .</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoaskml"><a class="anchor" href="#_property_geoaskml"></a>8.4.4.2. Property: geo:asKML</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a> is defined to link a geometry with its KML serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 33</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-kml-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-kml-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a> is used to link a geometric element with its KML serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asKML
+    a rdf:Property, owl:DatatypeProperty;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as KML"@en ;
+    skos:definition "The KML serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:kmlLiteral ;
+.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofaskml"><a class="anchor" href="#_function_geofaskml"></a>8.4.4.3. Function: geof:asKML</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asKML (geom: ogc:geomLiteral): geo:kmlLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a> converts <code>geom</code> to an equivalent KML representation. Coordinates are converted to the CRS84 coordinate system, the only valid coordinate system to be used in a KML literal.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 34</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asKML-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asKML-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_discrete_global_grid_system_serializationdggs"><a class="anchor" href="#_discrete_global_grid_system_serializationdggs"></a>8.4.5. Discrete Global Grid System (serialization=DGGS)</h4>
+<div class="paragraph">
+<p>This section establishes the requirements for representing Discrete Global Grid System (DGGS) geometry data as RDF literals. The form of representation is specific to individual DGGS implementations: known DGGSes are not compatible or even very similar.</p>
+</div>
+<div class="paragraph">
+<p>Here are defined two RDFS Datatypes:
+<a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>http://www.opengis.net/ont/geosparql#dggsLiteral</code></a> &amp; <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>http://www.opengis.net/ont/geosparql#auspixDggsLiteral</code></a> and one property, <a href="#_function_geofasdggs">as DGGS</a>.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+The two datatypes defined here are for an abstract DGGS implementation (<a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a>) and a specific one, AusPIX <a href="#AUSPIX">[AUSPIX]</a> (<a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a>). The purposes of including both of these are to indicate the conceptual position of DGGS literals in this specification - the abstract form acts as a parent of all other potential, specific, DGGS datatypes - and to exemplify a specific system implementation which allows for real examples of use.
+</td>
+</tr>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geodggsliteral"><a class="anchor" href="#_rdfs_datatype_geodggsliteral"></a>8.4.5.1. RDFS Datatype: geo:dggsLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a> is used to contain the Discrete Global Grid System (DGGS) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:dggsLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "DGGS Literal"@en ;
+    skos:definition "A textual serialization of a Discrete Global Grid System (DGGS) geometry object."@en
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a> instances are formed by encoding geometry information according to specific DGGS implementation. The specific implementation should be indicated by use of a subclass of the <code>geo:dggsLiteral</code> datatype.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 35</strong> All RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a> shall consist of a DGGS geometry serialization formulated according to a specific DGGS.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 36</strong> An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a>, or one of its data subtypes, shall be interpreted as an empty <code>geo:Geometry</code>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal-empty"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal-empty</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_rdfs_datatype_geoauspixdggsliteral"><a class="anchor" href="#_rdfs_datatype_geoauspixdggsliteral"></a>8.4.5.2. RDFS Datatype: geo:auspixDggsLiteral</h5>
+<div class="paragraph">
+<p>The datatype <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a> is used to contain the AusPIX Discrete Global Grid System (DGGS) serialization of a geometry.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:auspixDggsLiteral
+    a rdfs:Datatype ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "AusPIX DGGS Literal"@en ;
+    skos:definition "A textual serialization of an AusPIX Discrete Global Grid System (DGGS) geometry object."@en ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Valid <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a> instances are formed by encoding geometry information according to the AusPIX DGGS implementation <a href="#AUSPIX">[AUSPIX]</a>.</p>
+</div>
+<div class="paragraph">
+<p>The example <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a> below encodes a point geometry according to the <em>AusPIX</em> DGGS. The DGGS geometry type is indicated with the token <code>CellList</code> and the list of values, a single cell, is enclosed in parenthesis. The cell value of <em>R3234</em> is analogous to either a <code>Point</code> or simple <code>Polygon</code> in WKT geometries, so a single coordinate pair or a list of them:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">"CellList (R3234)"^^&lt;http://www.opengis.net/ont/geosparql#auspixDggsLiteral&gt;</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+What <code>R3234</code> means is not handled by GeoSPARQL but by the AusPIX DGGS specification <a href="#AUSPIX">[AUSPIX]</a>, just as GeoPSARQL does not delve into the internals of other geometry formats such as WKT or GeoJSON.
+</td>
+</tr>
+</table>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 37</strong> All RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a> shall consist of a DGGS geometry serialization formulated according to the AusPIX DGGS.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/auspix-dggs-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/auspix-dggs-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_property_geoasdggs"><a class="anchor" href="#_property_geoasdggs"></a>8.4.5.3. Property: geo:asDGGS</h5>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> is defined to link a geometry with its DGGS serialization.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 38</strong> Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> to be used in SPARQL graph patterns.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-dggs-literal"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-dggs-literal</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>The property <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> is used to link a Geometry instance with its serialization.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">geo:asDGGS
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:subPropertyOf geo:hasSerialization ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "as DGGS"@en ;
+    skos:definition "A DGGS Well-Known Text serialization of a geometry."@en ;
+    rdfs:domain geo:Geometry ;
+    rdfs:range geo:dggsLiteral ;
+.</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+It is expected that this property will be used to indicate specific DGGS data types, such as <a href="http://www.opengis.net/ont/geosparql#auspixDggsLiteral"><code>geo:auspixDggsLiteral</code></a>, descibed above, as opposed to the generic <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a>.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_function_geofasdggs"><a class="anchor" href="#_function_geofasdggs"></a>8.4.5.4. Function: geof:asDGGS</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:asDGGS (geom: ogc:geomLiteral, specificDggsDatatype: xsd:anyURI): geo:DggsLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a> converts <code>geom</code> to an equivalent DGGS representation, formulated according to the specific DGGS literal indicated using the <code>specificDggsDatatype</code> parameter.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 39</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asDGGS-function"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/asDGGS-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_non_topological_query_functions"><a class="anchor" href="#_non_topological_query_functions"></a>8.5. Non-topological Query Functions</h3>
+<div class="paragraph">
+<p>This clause defines SPARQL functions for performing non-topological spatial operations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 40</strong> Implementations shall support <a href="#_function_geofdistance">distance</a>, <a href="#_function_geofbuffer">buffer</a>, <a href="#_function_geofconvexhull">convex hull</a>, <a href="#_function_geofintersection">intersection</a>, <a href="#_function_geofunion">union</a>,
+<a href="#_function_geofisempty">is empty</a>, <a href="#_function_geofissimple">is simple</a>,
+<a href="#_function_geofarea">area</a>, <a href="#_function_geoflength">length</a>,
+<a href="#_function_geofnumgeometries">num geometries</a>,
+<a href="#_function_geofgeometryn">geometry n</a>, <a href="#_function_geoftransform">transform</a>,
+<a href="#_function_geofdimension">dimension</a>, <a href="#_function_geofdifference">difference</a>, <a href="#_function_geofsymdifference">sym difference</a>, <a href="#_function_geofenvelope">envelope</a>, <a href="#_function_geofboundary">boundary</a> as SPARQL extension functions, consistent with the definitions of their corresponding functions in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a> (<code>distance</code>, <code>buffer</code>, <code>convexHull</code>, <code>intersection</code>, <code>union</code>, <code>isEmpty</code>, <code>isSimple</code>, <code>area</code>, <code>length</code>, <code>numGeometries</code>, <code>geometryN</code>, <code>transform</code>, <code>dimension</code>, <code>difference</code>, <code>symDifference</code>, <code>envelope</code> and <code>boundary</code> respectively) and other attached definitions.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>An invocation of any of the following functions with invalid arguments produces an error. An invalid argument includes any of the following:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>An argument of an unexpected type</p>
+</li>
+<li>
+<p>An invalid geometry literal value</p>
+</li>
+<li>
+<p>A geometry literal from a spatial reference system that is incompatible with the spatial reference system used for calculations</p>
+</li>
+<li>
+<p>An invalid units IRI</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>For further discussion of the effects of errors during FILTER evaluation, consult Section 17<sup class="footnote">[<a id="_footnoteref_10" class="footnote" href="#_footnotedef_10" title="View footnote.">10</a>]</sup> of the SPARQL specification <a href="#SPARQL">[SPARQL]</a>.</p>
+</div>
+<div class="paragraph">
+<p>Note that returning values instead of raising an error serves as an extension mechanism of SPARQL.</p>
+</div>
+<div class="paragraph">
+<p>From Section 17.3.1<sup class="footnote">[<a id="_footnoteref_11" class="footnote" href="#_footnotedef_11" title="View footnote.">11</a>]</sup> of the SPARQL specification <a href="#SPARQL">[SPARQL]</a>:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+SPARQL language extensions may provide additional associations between operators and operator functions; &#8230;&#8203; No additional operator may yield a result that replaces any result other &#8230;&#8203; . The consequence of this rule is that SPARQL <code>FILTER</code> s will produce at least the same intermediate bindings after applying a <code>FILTER</code> as an unextended implementation.
+</blockquote>
+</div>
+<div class="paragraph">
+<p>This extension mechanism enables GeoSPARQL implementations to simultaneously support multiple geometry serializations. For example, a system that supports <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> serializations may also support <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> serializations and consequently would not raise an error if it encounters multiple geometry datatypes while processing a given query.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+Several non-topological query functions use a unit of measure IRI. The OGC has recommended units of measure vocabularies for use, see the OGC Definitions Server<sup class="footnote">[<a id="_footnoteref_12" class="footnote" href="#_footnotedef_12" title="View footnote.">12</a>]</sup>.
+</td>
+</tr>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_function_geofdistance"><a class="anchor" href="#_function_geofdistance"></a>8.5.1. Function: geof:distance</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:distance (geom1: ogc:geomLiteral,
+               geom2: ogc:geomLiteral,
+               units: xsd:anyURI): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the shortest distance between any two Points in the two geometric objects. Calculations are in spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofbuffer"><a class="anchor" href="#_function_geofbuffer"></a>8.5.2. Function: geof:buffer</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:buffer (geom: ogc:geomLiteral,
+             radius: xsd:double,
+             units: xsd:anyURI): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns a geometric object that represents all Points whose distance from <code>geom1</code> is less than or equal to the <code>radius</code> measured in <code>units</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofconvexhull"><a class="anchor" href="#_function_geofconvexhull"></a>8.5.3. Function: geof:convexHull</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:convexHull (geom1: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns a geometric object that represents all Points in the convex hull of <code>geom1</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofisempty"><a class="anchor" href="#_function_geofisempty"></a>8.5.4. Function: geof:isEmpty</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:isEmpty (geom1: ogc:geomLiteral): xsd:boolean</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns true if <code>geom1</code> is an empty geometry, i.e. contains no coordinates.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofissimple"><a class="anchor" href="#_function_geofissimple"></a>8.5.5. Function: geof:isSimple</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:isSimple (geom1: ogc:geomLiteral): xsd:boolean</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns true if <code>geom1</code> is a simple geometry, i.e. has no anomalous geometric points, such as self intersection or self tangency.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofarea"><a class="anchor" href="#_function_geofarea"></a>8.5.6. Function: geof:area</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:area (geom1: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the area of <code>geom1</code> in squaremeters.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geoflength"><a class="anchor" href="#_function_geoflength"></a>8.5.7. Function: geof:length</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:length (geom1: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the length of <code>geom1</code> in meters.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofdimension"><a class="anchor" href="#_function_geofdimension"></a>8.5.8. Function: geof:dimension</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:dimension (geom1: ogc:geomLiteral): xsd:integer</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the dimension of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofnumgeometries"><a class="anchor" href="#_function_geofnumgeometries"></a>8.5.9. Function: geof:numGeometries</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:numGeometries (geom1: ogc:geomLiteral): xsd:integer</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the number of geometries of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofgeometryn"><a class="anchor" href="#_function_geofgeometryn"></a>8.5.10. Function: geof:geometryN</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:geometryN (geom1: ogc:geomLiteral): xsd:integer</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the nth geometry of <code>geom1</code> if it is a GeometryCollection .</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geoftransform"><a class="anchor" href="#_function_geoftransform"></a>8.5.11. Function: geof:transform</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:transform (geom: ogc:geomLiteral, srsIRI: xsd:anyURI): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><a href="http://www.opengis.net/def/function/geosparql/transform">geof:transform</a> converts <code>geom</code> to a spatial reference system defined by srsIRI. The function raises an error if a transformation is not mathematically possible.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+We recommend that implementers use the same literal type as a result of this function that is passed as a parameter to this function.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofintersection"><a class="anchor" href="#_function_geofintersection"></a>8.5.12. Function: geof:intersection</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:intersection (geom1: ogc:geomLiteral,
+                   geom2: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns a geometric object that represents all Points in the intersection of <code>geom1</code> with <code>geom2</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofunion"><a class="anchor" href="#_function_geofunion"></a>8.5.13. Function: geof:union</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:union (geom1: ogc:geomLiteral,
+            geom2: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns a geometric object that represents all Points in the union of <code>geom1</code> with <code>geom2</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofdifference"><a class="anchor" href="#_function_geofdifference"></a>8.5.14. Function: geof:difference</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:difference (geom1: ogc:geomLiteral,
+                 geom2: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns a geometric object that represents all Points in the set difference of <code>geom1</code> with <code>geom2</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofsymdifference"><a class="anchor" href="#_function_geofsymdifference"></a>8.5.15. Function: geof:symDifference</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:symDifference (geom1: ogc:geomLiteral,
+                    geom2: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns a geometric object that represents all Points in the set symmetric difference of <code>geom1</code> with <code>geom2</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofenvelope"><a class="anchor" href="#_function_geofenvelope"></a>8.5.16. Function: geof:envelope</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:envelope (geom1: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns the minimum bounding box of <code>geom1</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofboundary"><a class="anchor" href="#_function_geofboundary"></a>8.5.17. Function: geof:boundary</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:boundary (geom1: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This function returns the closure of the boundary of <code>geom1</code>. Calculations are in the spatial reference system of <code>geom1</code>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 41</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/getSRID"><code>geof:getSRID</code></a> as a SPARQL extension function.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/srid-function"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/srid-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_function_geofgetsrid"><a class="anchor" href="#_function_geofgetsrid"></a>8.5.18. Function: geof:getSRID</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:getSRID (geom: ogc:geomLiteral): xsd:anyURI</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns the spatial reference system IRI for <code>geom</code>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 42</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/concaveHull"><code>geof:concaveHull</code></a>, <a href="http://www.opengis.net/def/function/geosparql/boundingCircle"><code>geof:boundingCircle</code></a>, <a href="http://www.opengis.net/def/function/geosparql/union2"><code>geof:union2</code></a>, <a href="http://www.opengis.net/def/function/geosparql/concatLines"><code>geof:concatLines</code></a>, <a href="http://www.opengis.net/def/function/geosparql/concatLines"><code>geof:centroid</code></a>, <a href="http://www.opengis.net/def/function/geosparql/minX"><code>geof:maxX</code></a>,
+<a href="http://www.opengis.net/def/function/geosparql/maxY"><code>geof:maxY</code></a>, <a href="http://www.opengis.net/def/function/geosparql/maxZ"><code>geof:maxZ</code></a>,  <a href="http://www.opengis.net/def/function/geosparql/minX"><code>geof:minX</code></a>, <a href="http://www.opengis.net/def/function/geosparql/minY"><code>geof:minY</code></a> and <a href="http://www.opengis.net/def/function/geosparql/minZ"><code>geof:minZ</code></a> as a SPARQL extension functions.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions"><code>http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_function_geofmaxx"><a class="anchor" href="#_function_geofmaxx"></a>8.5.19. Function: geof:maxX</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:maxX (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/maxX"><code>geof:maxX</code></a> returns the maximum X coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofmaxy"><a class="anchor" href="#_function_geofmaxy"></a>8.5.20. Function: geof:maxY</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:maxY (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/maxY"><code>geof:maxY</code></a> returns the maximum Y coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofmaxz"><a class="anchor" href="#_function_geofmaxz"></a>8.5.21. Function: geof:maxZ</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:maxZ (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/maxZ"><code>geof:maxZ</code></a> returns the maximum Z coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofminx"><a class="anchor" href="#_function_geofminx"></a>8.5.22. Function: geof:minX</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:minX (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/minX"><code>geof:minX</code></a> returns the minimum X coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofminy"><a class="anchor" href="#_function_geofminy"></a>8.5.23. Function: geof:minY</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:minY (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/minY"><code>geof:minY</code></a> returns the minimum Y coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofminz"><a class="anchor" href="#_function_geofminz"></a>8.5.24. Function: geof:minZ</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:minZ (geom: ogc:geomLiteral): xsd:double</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/minZ"><code>geof:minZ</code></a> returns the minimum Z coordinate for <code>geom</code>.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofboundingcircle"><a class="anchor" href="#_function_geofboundingcircle"></a>8.5.25. Function: geof:boundingCircle</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:boundingCircle (geom: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/boundingCircle"><code>geof:boundingCircle</code></a> calculates a minimum bounding circle of the set of given geometries.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofcentroid"><a class="anchor" href="#_function_geofcentroid"></a>8.5.26. Function: geof:centroid</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:centroid (geom: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/centroid"><code>geof:centroid</code></a> valculates the centroid of the set of given geometries.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofconcatlines"><a class="anchor" href="#_function_geofconcatlines"></a>8.5.27. Function: geof:concatLines</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:concatLines (geom: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/concatLines"><code>geof:concatLines</code></a>  Concatenates a set of LineStrings.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofconcavehull"><a class="anchor" href="#_function_geofconcavehull"></a>8.5.28. Function: geof:concaveHull</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:concaveHull (geom: ogc:geomLiteral, targetPercent: xsd:double): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/concaveHull"><code>geof:concaveHull</code></a> calculates the concave hull of the set of given geometries.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_function_geofunion2"><a class="anchor" href="#_function_geofunion2"></a>8.5.29. Function: geof:union2</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:union2 (geom: ogc:geomLiteral): ogc:geomLiteral</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The function <a href="http://www.opengis.net/def/function/geosparql/union2"><code>geof:union2</code></a> calculates the union of the set of given geometries.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="geometry_extension"><a class="anchor" href="#geometry_extension"></a>9. Geometry Topology Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>Geometry Topology Extension (relation_family, serialization, version)</em> parameterized requirements class, with IRI <code>/req/geometry-topology-extension</code>, which defines a collection of topological query functions that operate on geometry literals. This class is parameterized to give implementations flexibility in the topological relation families and geometry serializations that they choose to support. This requirements class has a single corresponding conformance class <em>Geometry Topology Extension (relation_family, serialization, version)</em>, with IRI <code>/conf/geometry-topology-extension</code>.</p>
+</div>
+<div class="paragraph">
+<p>The Dimensionally Extended Nine Intersection Model (DE-9IM) <a href="#DE-9IM">[DE-9IM]</a> has been used to define the relation tested by the query functions introduced in this section. Each query function is associated with a defining DE-9IM intersection pattern. Possible pattern values are:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>-1</code> (empty)</p>
+</li>
+<li>
+<p><code>0</code>, <code>1</code>, <code>2</code>, <code>T</code> (true) = <code>{0, 1, 2}</code></p>
+</li>
+<li>
+<p><code>F</code> (false) = <code>{-1}</code></p>
+</li>
+<li>
+<p><code>*</code> (don’t care) = <code>{-1, 0, 1, 2}</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>In the following descriptions, the notation <code>X/Y</code> is used denote applying a spatial relation to geometry types <code>X</code> and <code>Y</code> (i.e., <code>x</code> <em>relation</em> <code>y</code> where <code>x</code> is of type <code>X</code> and <code>y</code> is of type <code>Y</code>). The symbol <code>P</code> is used for 0-dimensional geometries (e.g. points). The symbol <code>L</code> is used for 1- dimensional geometries (e.g. lines), and the symbol <code>A</code> is used for 2-dimensional geometries (e.g. polygons). Consult the Simple Features specification <a href="#ISO19125-1">[ISO19125-1]</a> for a more detailed description of DE-9IM intersection patterns.</p>
+</div>
+<div class="sect2">
+<h3 id="_parameters_3"><a class="anchor" href="#_parameters_3"></a>9.1. Parameters</h3>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>relation_family</strong>: Specifies the set of topological spatial relations to support.</p>
+</li>
+<li>
+<p><strong>serialization</strong>: Specifies the serialization standard to use for geometry literals.</p>
+</li>
+<li>
+<p><strong>version</strong>: Specifies the version of the serialization format used.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_common_query_functions"><a class="anchor" href="#_common_query_functions"></a>9.2. Common Query Functions</h3>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 43</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/relate"><code>geof:relate</code></a> as a SPARQL extension function, consistent with the relate operator defined in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/relate-query-function"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/relate-query-function</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>geof:relate (geom1: ogc:geomLiteral,
+             geom2: ogc:geomLiteral,
+             pattern-matrix: xsd:string): xsd:boolean</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Returns <code>true</code> if the spatial relationship between <code>geom1</code> and <code>geom2</code> corresponds to one with acceptable values for the specified pattern-matrix. Otherwise, this function returns <code>false</code>. <code>pattern-matrix</code> represents a DE-9IM intersection pattern consisting of <code>T</code> (true) and <code>F</code> (false) values. The spatial reference system for <code>geom1</code> is used for spatial calculations.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_simple_features_relation_family_relation_familysimple_features_2"><a class="anchor" href="#_simple_features_relation_family_relation_familysimple_features_2"></a>9.3. Simple Features Relation Family (relation_family=Simple Features)</h3>
+<div class="paragraph">
+<p>This clause establishes requirements for the <em>Simple Features</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 44</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/sfEquals"><code>geof:sfEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfDisjoint"><code>geof:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfIntersects"><code>geof:sfIntersects</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfTouches"><code>geof:sfTouches</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfCrosses"><code>geof:sfCrosses</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfWithin"><code>geof:sfWithin</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfContains"><code>geof:sfContains</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfOverlaps"><code>geof:sfOverlaps</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/sf-query-functions"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/sf-query-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Boolean query functions defined for the Simple Features relation family, along with their associated DE-9IM intersection patterns, are shown in <a href="#simple_features_query_functions">Table 6</a> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (<code>geom1</code> and <code>geom2</code>) of the geometry literal <em>serialization</em> type <em>specified</em> by serialization and version. Each function returns an <a href="http://www.w3.org/2001/XMLSchema#boolean"><code>xsd:boolean</code></a> value of <code>true</code> if the specified relation exists between <code>geom1</code> and <code>geom2</code> and returns false otherwise. In each case, the spatial reference system of <code>geom1</code> is used for spatial calculations.</p>
+</div>
+<table id="simple_features_query_functions" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 6. Simple Features Query Functions</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Query Function</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Defining DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfEquals(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfDisjoint(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FF*FF****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfIntersects(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfTouches(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfCrosses(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**) for P/L, P/A, L/A; (0*T***T**) for L/L</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfWithin(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*F**F***)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfContains(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*****FF*)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:sfOverlaps(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**) for A/A, P/P; (1*T***T**) for L/L</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_egenhofer_relation_family_relation_familyegenhofer_2"><a class="anchor" href="#_egenhofer_relation_family_relation_familyegenhofer_2"></a>9.4. Egenhofer Relation Family (relation_family=Egenhofer)</h3>
+<div class="paragraph">
+<p>This clause establishes requirements for the <em>Egenhofer</em> relation family. Consult references <a href="#FORMAL">[FORMAL]</a> and <a href="#CATEG">[CATEG]</a> for a more detailed discussion of <em>Egenhofer</em> relations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 45</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/ehEquals"><code>geof:ehEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehDisjoint"><code>geof:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehMeet"><code>geof:ehMeet</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehOverlap"><code>geof:ehOverlap</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCovers"><code>geof:ehCovers</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCoveredBy"><code>geof:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehInside"><code>geof:ehInside</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehContains"><code>geof:ehContains</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/eh-query-functions"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/eh-query-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Boolean query functions defined for the <em>Egenhofer</em> relation family, along with their associated DE-9IM intersection patterns, are shown in <a href="#egenhofer_query_functions">Table 7</a> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (<code>geom1</code> and <code>geom2</code>) of the geometry literal serialization type specified by <em>serialization</em> and <em>version</em>. Each function returns an <a href="http://www.w3.org/2001/XMLSchema#boolean"><code>xsd:boolean</code></a> value of <code>true</code> if the specified relation exists between <code>geom1</code> and <code>geom2</code> and returns <code>false</code> otherwise. In each case, the spatial reference system of geom1 is used for spatial calculations.</p>
+</div>
+<table id="egenhofer_query_functions" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 7. Egenhofer Query Functions</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Query Function</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Defining DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehEquals(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehDisjoint(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FF*FF****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehMeet(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FT******* F**T***** F***T****)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehOverlap(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*T***T**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehCovers(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*TFT*FF*)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehCoveredBy(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFF*TFT**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehInside(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFF*FFT**)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:ehContains(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(T*TFF*FF*)</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_requirements_for_rcc8_relation_family_relation_familyrcc8"><a class="anchor" href="#_requirements_for_rcc8_relation_family_relation_familyrcc8"></a>9.5. Requirements for RCC8 Relation Family (relation_family=RCC8)</h3>
+<div class="paragraph">
+<p>This clause establishes requirements for the <em>RCC8</em> relation family. Consult references <a href="#QUAL">[QUAL]</a> and <a href="#LOGIC">[LOGIC]</a> for a more detailed discussion of <em>RCC8</em> relations.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 46</strong> Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/rcc8eq"><code>geof:rcc8eq</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8dc"><code>geof:rcc8dc</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ec"><code>geof:rcc8ec</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8po"><code>geof:rcc8po</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tppi"><code>geof:rcc8tppi</a></code>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tpp"><code>geof:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntpp"><code>geof:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntppi"><code>geof:rcc8ntppi</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/rcc8-query-functions"><code>http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/rcc8-query-functions</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Boolean query functions defined for the <em>RCC8</em> relation family, along with their associated DE-9IM intersection patterns, are shown in <a href="#rcc8_query_functions">Table 8</a> below. Each function accepts two arguments (<code>geom1</code> and <code>geom2</code>) of the geometry literal serialization type specified by <em>serialization</em> and <em>version</em>. Each function returns an <a href="http://www.w3.org/2001/XMLSchema#boolean"><code>xsd:boolean</code></a> value of <code>true</code> if the specified relation exists between <code>geom1</code> and <code>geom2</code> and returns <code>false</code> otherwise. In each case, the spatial reference system of geom1 is used for spatial calculations.</p>
+</div>
+<table id="rcc8_query_functions" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 8. RCC8 Query Functions</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Query Function</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Defining DE-9IM Intersection Pattern</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8eq(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFFTFFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8dc(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FFTFFTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8ec(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(FFTFTTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8po(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTTTTTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8tppi(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTFTTFFT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8tpp(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFTTFTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8ntpp(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TFFTFFTTT)</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code><code>geof:rcc8ntppi(geom1: ogc:geomLiteral,
+                geom2: ogc:geomLiteral): xsd:boolean</code></code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>(TTTFFTFFT)</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_rdfs_entailment_extension_relation_family_serialization_version"><a class="anchor" href="#_rdfs_entailment_extension_relation_family_serialization_version"></a>10. RDFS Entailment Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>RDFS Entailment Extension (relation_family, serialization, version)</em> parameterized requirements class, with IRI <code>/req/rdfs-entailment-extension</code>, which defines a mechanism for matching implicitly-derived RDF triples in GeoSPARQL queries. This class is parameterized to give implementations flexibility in the topological relation families and geometry types that they choose to support. This requirements class has a single corresponding conformance class <em>RDFS Entailment Extension (relation_family, serialization, version)</em>, <code>with IRI /conf/rdfs-entailment-extension</code>.</p>
+</div>
+<div class="sect2">
+<h3 id="_parameters_4"><a class="anchor" href="#_parameters_4"></a>10.1. Parameters</h3>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>relation_family</strong>: Specifies the set of topological spatial relations to support.</p>
+</li>
+<li>
+<p><strong>serialization</strong>: Specifies the serialization standard to use for geometry literals.</p>
+</li>
+<li>
+<p><strong>version</strong>: Specifies the version of the serialization format used.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_common_requirements"><a class="anchor" href="#_common_requirements"></a>10.2. Common Requirements</h3>
+<div class="paragraph">
+<p>The basic mechanism for supporting RDFS entailment has been defined by the W3C SPARQL 1.1 RDFS Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a>.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 47</strong> Basic graph pattern matching shall use the semantics defined by the RDFS Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/bgp-rdfs-ent"><code>http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/bgp-rdfs-ent</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_wkt_serialization_serializationwkt"><a class="anchor" href="#_wkt_serialization_serializationwkt"></a>10.3. WKT Serialization (serialization=WKT)</h3>
+<div class="paragraph">
+<p>This section establishes the requirements for representing geometry data in RDF based on WKT as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="_geometry_class_hierarchy"><a class="anchor" href="#_geometry_class_hierarchy"></a>10.3.1. Geometry Class Hierarchy</h4>
+<div class="paragraph">
+<p>The Simple Features specification presents a geometry class hierarchy. It is straightforward to represent this class hierarchy in RDFS and OWL by constructing IRIs for geometry classes using the following pattern: <code>http://www.opengis.net/ont/sf#{geometry class}</code> and by asserting appropriate <a href="http://www.w3.org/2000/01/rdf-schema#subClassOf"><code>rdfs:subClassOf</code></a> statements.</p>
+</div>
+<div class="paragraph">
+<p>The example RDF snippet below encodes the Polygon class from Simple Features 1.0.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">sf:Polygon a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Polygon"@en ;
+    rdfs:subClassOf sf:Surface ;
+    skos:definition "A planar surface defined by 1 exterior boundary and 0 or
+                    more interior boundaries"@en .</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 48</strong> Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/wkt-geometry-types"><code>http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/wkt-geometry-types</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_gml_serialization_serializationgml"><a class="anchor" href="#_gml_serialization_serializationgml"></a>10.4. GML Serialization (serialization=GML)</h3>
+<div class="paragraph">
+<p>This section establishes requirements for representing geometry data in RDF based on GML as defined by Geography Markup Language Encoding Standard <a href="#OGC07-036">[OGC07-036]</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="_geometry_class_hierarchy_2"><a class="anchor" href="#_geometry_class_hierarchy_2"></a>10.4.1. Geometry Class Hierarchy</h4>
+<div class="paragraph">
+<p>An RDF/OWL class hierarchy can be generated from the GML schema that implements <code>GM_Object</code> by constructing IRIs for geometry classes using the following pattern: <code>http://www.opengis.net/ont/gml#{GML Element}</code> and by asserting appropriate <a href="http://www.w3.org/2000/01/rdf-schema#subClassOf"><code>rdfs:subClassOf</code></a> statements.</p>
+</div>
+<div class="paragraph">
+<p>The example RDF snippet below encodes the Polygon class from GML 3.2.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">gml:Polygon a rdfs:Class, owl:Class ;
+    rdfs:isDefinedBy geo: ;
+    skos:prefLabel "Polygon"@en ;
+    rdfs:subClassOf gml:SurfacePatch ;
+    skos:definition "A planar surface defined by 1 exterior boundary and 0 or
+                    more interior boundaries."@en .</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 49</strong> Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the GML schema that implements <code>GM_Object</code> using the specified <em>version</em> of GML <a href="#OGC07-036">[OGC07-036]</a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/gml-geometry-types"><code>http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment-extension/gml-geometry-types</code></a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_query_rewrite_extension_relation_family_serialization_version"><a class="anchor" href="#_query_rewrite_extension_relation_family_serialization_version"></a>11. Query Rewrite Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This clause establishes the <em>Query Rewrite Extension (relation_family, serialization, version)</em> parameterized requirements class, with IRI <code>/req/query-rewrite-extension</code>, which has a single corresponding conformance class <em>Query Rewrite Extension (relation_family, serialization, version)</em>, with IRI <code>/conf/query-rewrite-extension</code>. This requirements class defines a set of RIF rules <a href="#RIF">[RIF]</a> that use topological extension functions defined in Clause 9 to establish the existence of direct topological predicates defined in Clause 7. One possible implementation strategy is to transform a given query by expanding a triple pattern involving a direct spatial predicate into a series of triple patterns and an invocation of the corresponding extension function as specified in the RIF rule.</p>
+</div>
+<div class="paragraph">
+<p>The following rule specified using the RIF Core Dialect <a href="#RIFCORE">[RIFCORE]</a> is used as a template to describe rules in the remainder of this clause. <a href="http://www.opengis.net/def/relation"><code>ogc:relation</code></a> is used as a placeholder for the spatial relation IRIs defined in Clause 7, and <a href="http://www.opengis.net/def/function"><code>ogc:function</code></a> is used as a placeholder for the spatial functions defined in <a href="#geometry_extension">Clause 9</a>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-rif" data-lang="rif">Forall ?f1 ?f2 ?g1 ?g2 ?g1Serial ?g2Serial
+    (?f1[ogc:relation-&gt;?f2] :-
+        Or(
+            And
+                # feature – feature rule
+                (?f1[geo:hasDefaultGeometry-&gt;?g1]
+                 ?f2[geo:hasDefaultGeometry-&gt;?g2]
+                 ?g1[ogc:asGeomLiteral-&gt;?g1Serial]
+                 ?g2[ogc:asGeomLiteral-&gt;?g2Serial]
+                 External(ogc:function (?g1Serial,?g2Serial)))
+            And
+                # feature – geometry rule
+                (?f1[geo:hasDefaultGeometry-&gt;?g1]
+                 ?g1[ogc:asGeomLiteral-&gt;?g1Serial]
+                 ?f2[ogc:asGeomLiteral-&gt;?g2Serial]
+                 External(ogc:function (?g1Serial,?g2Serial)))
+            And
+                # geometry - feature rule
+                (?f2[geo:hasDefaultGeometry-&gt;?g2]
+                 ?f1[ogc:asGeomLiteral-&gt;?g1Serial]
+                 ?g2[ogc:asGeomLiteral-&gt;?g2Serial]
+                 External(ogc:function (?g1Serial,?g2Serial)))
+            And
+                # geometry - geometry rule
+                (?f1[ogc:asGeomLiteral-&gt;?g1Serial]
+                 ?f2[ogc:asGeomLiteral-&gt;?g2Serial]
+                 External(ogc:function (?g1Serial,?g2Serial)))
+    )
+)</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+The GeoSPARQL 1.1 Standard contains a RIF rules artefact expanded for all function generated from this template and Python software for re-issuing the expanded artefact. See <a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a>.
+</td>
+</tr>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_parameters_5"><a class="anchor" href="#_parameters_5"></a>11.1. Parameters</h3>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>relation_family</strong>: Specifies the set of topological spatial relations to support.</p>
+</li>
+<li>
+<p><strong>serialization</strong>: Specifies the serialization standard to use for geometry literals.</p>
+</li>
+<li>
+<p><strong>version</strong>: Specifies the version of the serialization format used.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_simple_features_relation_family_relation_familysimple_features_3"><a class="anchor" href="#_simple_features_relation_family_relation_familysimple_features_3"></a>11.2. Simple Features Relation Family (relation_family=Simple Features)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the <em>Simple Features</em> relation family. <a href="#sf_query_transformation_rules">Table 9</a> specifies the function and property substitutions for each rule in the <em>Simple Features</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 50</strong> Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/sfEquals"><code>geor:sfEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint"><code>geor:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfIntersects"><code>geor:sfIntersects</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfTouches"><code>geor:sfTouches</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfCrosses"><code>geor:sfCrosses</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfWithin"><code>geor:sfWithin</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfContains"><code>geor:sfContains</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfOverlaps"><code>geor:sfOverlaps</code></a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/sf-query-rewrite"><code>http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/sf-query-rewrite</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table id="sf_query_transformation_rules" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 9. Simple Features Query Transformation Rules</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Rule</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:relation</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfEquals">geor:sfEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfEquals">geo:sfEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfEquals">geof:sfEquals</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint">geor:sfDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfDisjoint">geo:sfDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfDisjoint">geof:sfDisjoint</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfIntersects">geor:sfIntersects</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfIntersects">geo:sfIntersects</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfIntersects">geof:sfIntersects</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfTouches">geor:sfTouches</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfTouches">geo:sfTouches</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfTouches">geof:sfTouches</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfCrosses">geor:sfCrosses</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfCrosses">geo:sfCrosses</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfCrosses">geof:sfCrosses</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfWithin">geor:sfWithin</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfWithin">geof:sfWithin</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfContains">geor:sfContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfContains">geof:sfContains</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/sfOverlaps">geor:sfOverlaps</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfOverlaps">geo:sfOverlaps</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfOverlaps">geof:sfOverlaps</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_egenhofer_relation_family_relation_familyegenhofer_3"><a class="anchor" href="#_egenhofer_relation_family_relation_familyegenhofer_3"></a>11.3. Egenhofer Relation Family (relation_family=Egenhofer)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the <em>Egenhofer</em> relation family. <a href="#eh_query_transformation_rules">Table 10</a> specifies the function and property substitutions for each rule in the <em>Egenhofer</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 51</strong> Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/ehEquals"><code>geor:ehEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehDisjoint"><code>geor:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehMeet"><code>geor:ehMeet</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehOverlap"><code>geor:ehOverlap</code></a>,
+<a href="http://www.opengis.net/def/rule/geosparql/ehCovers"><code>geor:ehCovers</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCoveredBy"><code>geor:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehInside"><code>geor:ehInside</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehContains"><code>geor:ehContains</code></a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/eh-query-rewrite"><code>http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/eh-query-rewrite</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table id="eh_query_transformation_rules" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 10. Egenhofer Query Transformation Rules</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Rule</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:relation</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehEquals">geor:ehEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehEquals">geo:ehEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehEquals">geof:ehEquals</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehDisjoint">geor:ehDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehDisjoint">geo:ehDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehDisjoint">geof:ehDisjoint</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehMeet">geor:ehMeet</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehMeet">geo:ehMeet</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehMeet">geof:ehMeet</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehOverlap">geor:ehOverlap</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehOverlap">geo:ehOverlap</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehOverlap">geof:ehOverlap</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehCovers">geor:ehCovers</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehCovers">geo:ehCovers</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehCovers">geof:ehCovers</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehCoveredBy">geor:ehCoveredBy</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehCoveredBy">geo:ehCoveredBy</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehCoveredBy">geof:ehCoveredBy</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehInside">geor:ehInside</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehInside">geo:ehInside</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehInside">geof:ehInside</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/ehContains">geor:ehContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#ehContains">geo:ehContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/ehContains">geof:ehContains</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_rcc8_relation_family_relation_familyrcc8_2"><a class="anchor" href="#_rcc8_relation_family_relation_familyrcc8_2"></a>11.4. RCC8 Relation Family (relation_family=RCC8)</h3>
+<div class="paragraph">
+<p>This clause defines requirements for the <em>RCC8</em> relation family. <a href="#rcc8_query_transformation_rules">Table 11</a> specifies the function and property substitutions for each rule in the <em>RCC8</em> relation family.</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><strong>Req 52</strong> Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/rcc8eq"><code>geor:rcc8eq</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8dc"><code>geor:rcc8dc</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ec"><code>geor:rcc8ec</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8po"><code>geor:rcc8po</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tppi"><code>geor:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tpp"><code>geor:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntpp"><code>geor:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntppi"><code>geor:rcc8ntppi</code></a>.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/rcc8-query-rewrite"><code>http://www.opengis.net/spec/geosparql/1.0/req/query-rewrite-extension/rcc8-query-rewrite</code></a></p></td>
+</tr>
+</tbody>
+</table>
+<table id="rcc8_query_transformation_rules" class="tableblock frame-all grid-all stripes-odd stretch">
+<caption class="title">Table 11. RCC8 Query Transformation Rules</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Rule</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:relation</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">ogc:function</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8eq">geor:rcc8eq</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8eq">geo:rcc8eq</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8eq">geof:rcc8eq</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8dc">geor:rcc8dc</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8dc">geo:rcc8dc</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8dc">geof:rcc8dc</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8ec">geor:rcc8ec</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ec">geo:rcc8ec</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8ec">geof:rcc8ec</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8po">geor:rcc8po</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8po">geo:rcc8po</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8po">geof:rcc8po</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8tppi">geor:rcc8tppi</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8tppi">geo:rcc8tppi</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8tppi">geof:rcc8tppi</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8tpp">geor:rcc8tpp</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8tpp">geo:rcc8tpp</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8tpp">geof:rcc8tpp</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8ntpp">geor:rcc8ntpp</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ntpp">geo:rcc8ntpp</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8ntpp">geof:rcc8ntpp</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/rule/geosparql/rcc8ntppi">geor:rcc8ntppi</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#rcc8ntppi">geo:rcc8ntppi</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/rcc8ntppi">geof:rcc8ntppi</a></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_special_considerations"><a class="anchor" href="#_special_considerations"></a>11.5. Special Considerations</h3>
+<div class="paragraph">
+<p>The applicability of GeoSPARQL rules in certain circumstances has intentionally been left undefined.</p>
+</div>
+<div class="paragraph">
+<p>The first situation arises for triple patterns with unbound predicates. Consider the query pattern below:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>{ my:feature1 ?p my:feature2 }</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>When using a query transformation strategy, this triple pattern could invoke none of the GeoSPARQL rules or all of the rules. Implementations are free to support either of these alternatives.</p>
+</div>
+<div class="paragraph">
+<p>The second situation arises when supporting GeoSPARQL rules in the presence of RDFS Entailment. The existence of a topological relation (possibly derived from a GeoSPARQL rule) can entail other RDF triples. For example, if <a href="http://www.opengis.net/ont/geosparql#sfOverlaps"><code>geo:sfOverlaps</code></a> has been defined as an <a href="http://www.w3.org/2000/01/rdf-schema#subPropertyOf"><code>rdfs:subPropertyOf</code></a> the property <code>my:overlaps</code>, and the RDF triple <code>my:feature1 <a href="http://www.opengis.net/ont/geosparql#sfOverlaps">geo:sfOverlaps</a> my:feature2</code> has been derived from a GeoSPARQL rule, then the RDF triple <code>my:feature1 my:overlaps my:feature2</code> can be entailed. Implementations may support such entailments but are not required to.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_future_work"><a class="anchor" href="#_future_work"></a>12. Future Work</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Many future extensions of this standard are possible and, since the release of GeoSPARQL 1.0, many extensions have been made.</p>
+</div>
+<div class="paragraph">
+<p>The GeoSPARQL 1.1 release tried to incorporate many additions requested of the GeoSPARQL 1.0 Standard, including options the use of other serializations of geometry data (e.g. KML, GeoJSON, DGGS) and the addition of handling spatial scalar measurements.</p>
+</div>
+<div class="paragraph">
+<p>Plans for future GeoSPARQL releases have been mooted but won&#8217;t be articulated here, instead they will be discussed and decided apon by the OGC GeoSPARQL Standards Working Group and related groups. Readers of this document are encouraged to see out those groups' lists of issues and standards change requests rather than looking for ideas here that will surely age badly.</p>
+</div>
+</div>
+</div>
+<h1 id="_annex_a_normative_abstract_test_suite" class="sect0"><a class="anchor" href="#_annex_a_normative_abstract_test_suite"></a>Annex A (normative) Abstract Test Suite</h1>
+<div class="sect1">
+<h2 id="_a_1_conformance_class_core"><a class="anchor" href="#_a_1_conformance_class_core"></a>A.1 Conformance Class: <em>Core</em></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/core</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_1_1_confcoresparql_protocol"><a class="anchor" href="#_a_1_1_confcoresparql_protocol"></a>A.1.1 <code>/conf/core/sparql-protocol</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/sparql-protocol</code></p>
+</div>
+<div class="paragraph">
+<p>Implementations shall support the SPARQL Query Language for RDF <a href="#SPARQL">[SPARQL]</a>, the SPARQL Protocol for RDF <a href="#SPARQLPROT">[SPARQLPROT]</a> and the SPARQL Query Results XML Format <a href="#SPARQLRESX">[SPARQLRESX]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that the implementation accepts SPARQL queries and returns the correct results in the correct format, according to the SPARQL Query Language for RDF, the SPARQL Protocol for RDF and SPARQL Query Results XML Format W3C specifications.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_sparql_2">Section 6.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_2_confcorespatial_object_class"><a class="anchor" href="#_a_1_2_confcorespatial_object_class"></a>A.1.2 <code>/conf/core/spatial-object-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/spatial-object-class</code></p>
+</div>
+<div class="paragraph">
+<p>Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#SpatialObject">geo:SpatialObject</a> to be used in SPARQL graph
+patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#SpatialObject">geo:SpatialObject</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geospatialobject">Section 6.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_3_confcorefeature_class"><a class="anchor" href="#_a_1_3_confcorefeature_class"></a>A.1.3 <code>/conf/core/feature-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/feature-class</code>
+Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#Feature">geo:Feature</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: verify that queries involving <a href="http://www.opengis.net/ont/geosparql#Feature">geo:Feature</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geofeature">Section 6.2.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_4_confcorespatial_measure_class"><a class="anchor" href="#_a_1_4_confcorespatial_measure_class"></a>A.1.4 <code>/conf/core/spatial-measure-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/spatial-measure-class</code>
+Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#SpatialMeasure">geo:SpatialMeasure</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#SpatialMeasure">geo:SpatialMeasure</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geospatialmeasure">Section 6.2.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_5_confcorespatial_object_collection_class"><a class="anchor" href="#_a_1_5_confcorespatial_object_collection_class"></a>A.1.5 <code>/conf/core/spatial-object-collection-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/spatial-object-collection-class</code></p>
+</div>
+<div class="paragraph">
+<p>Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#SpatialObjectCollection">geo:SpatialObjectCollection</a> to be used in SPARQL graph
+patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: verify that queries involving <a href="http://www.opengis.net/ont/geosparql#SpatialObjectCollection">geo:SpatialObjectCollection</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geospatialobjectcollection">Section 6.2.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_1_6_confcorefeature_collection_class"><a class="anchor" href="#_a_1_6_confcorefeature_collection_class"></a>A.1.6 <code>/conf/core/feature-collection-class</code></h3>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/core/feature-collection-class</code></p>
+</div>
+<div class="paragraph">
+<p>Implementations shall allow the RDFS class <a href="http://www.opengis.net/ont/geosparql#FeatureCollection">geo:FeatureCollection</a> to be used in SPARQL graph
+patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: verify that queries involving <a href="http://www.opengis.net/ont/geosparql#FeatureCollection">geo:FeatureCollection</a> return the correct result on a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geofeaturecollection">Section 6.2.5</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_2_conformance_class_topology_vocabulary_extension_relation_family"><a class="anchor" href="#_a_2_conformance_class_topology_vocabulary_extension_relation_family"></a>A.2 Conformance Class: Topology Vocabulary Extension (relation_family)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/topology-vocab-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_2_1_relation_family_simple_features"><a class="anchor" href="#_a_2_1_relation_family_simple_features"></a>A.2.1 relation_family = Simple Features</h3>
+<div class="sect3">
+<h4 id="_a_2_1_1_conftopology_vocab_extensionsf_spatial_relations"><a class="anchor" href="#_a_2_1_1_conftopology_vocab_extensionsf_spatial_relations"></a>A.2.1.1 <code>/conf/topology-vocab-extension/sf-spatial-relations</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/topology-vocab-extension/sf-spatial-relations</code>
+Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#sfEquals"><code>geo:sfEquals</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfDisjoint"><code>geo:sfDisjoint</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfIntersects"><code>geo:sfIntersects</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfTouches"><code>geo:sfTouches</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfCrosses"><code>geo:sfCrosses</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfWithin"><code>geo:sfWithin</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfContains"><code>geo:sfContains</code></a>, <a href="http://www.opengis.net/ont/geosparql#sfOverlaps"><code>geo:sfOverlaps</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_simple_features_relation_family_relation_familysimple_features">Section 7.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_2_2_relation_family_egenhofer"><a class="anchor" href="#_a_2_2_relation_family_egenhofer"></a>A.2.2 relation_family = Egenhofer</h3>
+<div class="sect3">
+<h4 id="_a_2_2_1_conftopology_vocab_extensioneh_spatial_relations"><a class="anchor" href="#_a_2_2_1_conftopology_vocab_extensioneh_spatial_relations"></a>A.2.2.1 <code>/conf/topology-vocab-extension/eh-spatial-relations</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/topology-vocab-extension/eh-spatial-relations</code>
+Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#ehEquals"><code>geo:ehEquals</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehDisjoint"><code>geo:ehDisjoint</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehMeet"><code>geo:ehMeet</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehOverlap"><code>geo:ehOverlap</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehCovers"><code>geo:ehCovers</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehCoveredBy"><code>geo:ehCoveredBy</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehInside"> <code>geo:ehInside</code></a>, <a href="http://www.opengis.net/ont/geosparql#ehContains"><code>geo:ehContains</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_egenhofer_relation_family_relation_familyegenhofer">Section 7.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_2_3_relation_family_rcc8"><a class="anchor" href="#_a_2_3_relation_family_rcc8"></a>A.2.3 relation_family = RCC8</h3>
+<div class="sect3">
+<h4 id="_a_2_3_1_conftopology_vocab_extensionrcc8_spatial_relations"><a class="anchor" href="#_a_2_3_1_conftopology_vocab_extensionrcc8_spatial_relations"></a>A.2.3.1 <code>/conf/topology-vocab-extension/rcc8-spatial-relations</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/topology-vocab-extension/rcc8-spatial-relations</code>
+Implementations shall allow the properties <a href="http://www.opengis.net/ont/geosparql#rcc8eq"><code>geo:rcc8eq</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8dc"><code>geo:rcc8dc</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8ec"><code>geo:rcc8ec</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8po"><code>geo:rcc8po</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tppi"><code>geo:rcc8tppi</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tpp"><code>geo:rcc8tpp</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tpp"><code>geo:rcc8ntpp</code></a>, <a href="http://www.opengis.net/ont/geosparql#rcc8tppi"><code>geo:rcc8ntppi</code></a> to be used in SPARQL graph patterns</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rcc8_relation_family_relation_familyrcc8">Section 7.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_3_conformance_class_geometry_extension_serialization_version"><a class="anchor" href="#_a_3_conformance_class_geometry_extension_serialization_version"></a>A.3 Conformance Class: Geometry Extension (serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/geometry-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_3_1_tests_for_all_serializations"><a class="anchor" href="#_a_3_1_tests_for_all_serializations"></a>A.3.1 Tests for all Serializations</h3>
+<div class="sect3">
+<h4 id="_a_3_1_1_confgeometry_extensiongeometry_class"><a class="anchor" href="#_a_3_1_1_confgeometry_extensiongeometry_class"></a>A.3.1.1 <code>/conf/geometry-extension/geometry-class</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-class</code>
+Implementations shall allow the RDFS class <a href="#_class_geogeometry">Geometry</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="#_class_geogeometry">Geometry</a> return the correct result on a test dataset</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geogeometry">Section 8.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_6_confgeometry_extensiongeometry_collection_class"><a class="anchor" href="#_a_3_1_6_confgeometry_extensiongeometry_collection_class"></a>A.3.1.6 <code>/conf/geometry-extension/geometry-collection-class</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-collection-class</code>
+Implementations shall allow the RDFS class <a href="#_class_geogeometrycollection">Geometry Collection</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: verify that queries involving <a href="#_class_geogeometrycollection">Geometry Collection</a> return the correct result on a test dataset</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_class_geogeometrycollection">Section 8.2.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_2_confgeometry_extensionfeature_properties"><a class="anchor" href="#_a_3_1_2_confgeometry_extensionfeature_properties"></a>A.3.1.2 <code>/conf/geometry-extension/feature-properties</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/feature-properties</code>
+Implementations shall allow the properties <a href="#_property_geohasgeometry">has geometry</a> and <a href="#_property_geohasdefaultgeometry">has default geometry</a>,
+<a href="#_property_geohaslength">has length</a>,
+<a href="#_property_geohasarea">has area</a>,
+<a href="http://www.opengis.net/ont/geosparql#hasCentroid"><code>geo:hasVolume</code></a>
+<a href="#_property_geohasboundingbox">has bounding box</a>
+<a href="#_property_geohascentroid">has centroid</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_standard_properties_for_geofeature">Section 6.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_3_confgeometry_extensiongeometry_properties"><a class="anchor" href="#_a_3_1_3_confgeometry_extensiongeometry_properties"></a>A.3.1.3 <code>/conf/geometry-extension/geometry-properties</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-properties</code>
+Implementations shall allow the properties <a href="#_property_geodimension">dimension</a>, <a href="#_property_geocoordinatedimension">coordinate dimension</a>, <a href="#_property_geospatialdimension">spatial dimension</a>,  <a href="#_property_geoisempty">is empty</a>,  <a href="#_property_geoissimple">is simple</a>,  <a href="#_property_geohasserialization">has serialization</a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these properties return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_standard_properties_for_geogeometry">Section 8.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_4_confgeometry_extensionquery_functions"><a class="anchor" href="#_a_3_1_4_confgeometry_extensionquery_functions"></a>A.3.1.4 <code>/conf/geometry-extension/query-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/query-functions</code>
+Implementations shall support <a href="#_function_geofdistance">distance</a>, <a href="#_function_geofbuffer">buffer</a>, <a href="#_function_geofconvexhull">convex hull</a>, <a href="#_function_geofintersection">intersection</a>, <a href="#_function_geofunion">union</a>, <a href="#_function_geofdifference">difference</a>, <a href="#_function_geofsymdifference">sym difference</a>, <a href="#_function_geofenvelope">envelope</a> and <a href="#_function_geofboundary">boundary</a> as SPARQL extension functions, consistent with the definitions of the corresponding functions (distance, buffer, convexHull, intersection, difference, symDifference, envelope and boundary respectively) in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: <a href="#_function_geofdistance">distance</a>, <a href="#_function_geofbuffer">buffer</a>, <a href="#_function_geofconvexhull">convex hull</a>, <a href="#_function_geofintersection">intersection</a>, <a href="#_function_geofunion">union</a>, <a href="#_function_geofdifference">difference</a>, <a href="#_function_geofsymdifference">sym difference</a>, <a href="#_function_geofenvelope">envelope</a> and <a href="#_function_geofboundary">boundary</a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_non_topological_query_functions">Section 8.5</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_5_confgeometry_extensionsrid_function"><a class="anchor" href="#_a_3_1_5_confgeometry_extensionsrid_function"></a>A.3.1.5 <code>/conf/geometry-extension/srid-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/srid-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/getSRID"><code>geof:getSRID</code></a> as a SPARQL extension function.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a SPARQL query involving the <a href="http://www.opengis.net/def/function/geosparql/getSRID"><code>geof:getSRID</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_geofgetsrid">Section 8.5.18</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_1_5_confgeometry_extensionsa_functions"><a class="anchor" href="#_a_3_1_5_confgeometry_extensionsa_functions"></a>A.3.1.5 <code>/conf/geometry-extension/sa-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/-functions</code>
+Implementations shall support geof:concaveHull, geof:boundingCircle, geof:union2, geof:concatLines, geof:centroid, geof:maxX, geof:maxY, geof:maxZ, geof:minX, geof:minY and geof:minZ as a SPARQL extension functions.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving these functions return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_safuncs">[_function_safuncs]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_2_serialization_wkt"><a class="anchor" href="#_a_3_2_serialization_wkt"></a>A.3.2 serialization = WKT</h3>
+<div class="sect3">
+<h4 id="_a_3_2_1_confgeometry_extensionwkt_literal"><a class="anchor" href="#_a_3_2_1_confgeometry_extensionwkt_literal"></a>A.3.2.1 <code>/conf/geometry-extension/wkt-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/wkt-literal</code>
+All <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> instances shall consist of an optional IRI identifying the Spatial Reference System (SRS) followed by Simple Features Well Known Text (WKT) describing a geometric value. Valid <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> instances are formed by concatenating a valid, absolute IRI as defined in <a href="#IETF3987">[IETF3987]</a>, one or more spaces (Unicode U+0020 character) as a separator, and a WKT string as defined in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving  <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geowktliteral">Section 8.4.1.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_2_confgeometry_extensionwkt_literal_default_srs"><a class="anchor" href="#_a_3_2_2_confgeometry_extensionwkt_literal_default_srs"></a>A.3.2.2 <code>/conf/geometry-extension/wkt-literal-default-srs</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/wkt-literal-default-srs</code>
+The IRI <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84">&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</a> shall be assumed as the SRS for  <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiterals</code></a> that do not specify an explicit SRS IRI.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving  <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> values without an explicit encoded SRS IRI return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geowktliteral">Section 8.4.1.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_3_confgeometry_extensionwkt_axis_order"><a class="anchor" href="#_a_3_2_3_confgeometry_extensionwkt_axis_order"></a>A.3.2.3 <code>/conf/geometry-extension/wkt-axis-order</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/wkt-axis-order</code>
+Coordinate tuples within <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiterals</code></a> shall be interpreted using the axis order defined in the SRS used.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving  <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geowktliteral">Section 8.4.1.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_4_confgeometry_extensionwkt_literal_empty"><a class="anchor" href="#_a_3_2_4_confgeometry_extensionwkt_literal_empty"></a>A.3.2.4 <code>/conf/geometry-extension/wkt-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/wkt-literal-empty</code>
+An empty RDFS Literal of type <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code>geo:wktLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geowktliteral">Section 8.4.1.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_5_confgeometry_extensiongeometry_as_wkt_literal"><a class="anchor" href="#_a_3_2_5_confgeometry_extensiongeometry_as_wkt_literal"></a>A.3.2.5 <code>/conf/geometry-extension/geometry-as-wkt-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-wkt-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoaswkt">Section 8.4.1.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_2_6_reqgeometry_extensionaswkt_function"><a class="anchor" href="#_a_3_2_6_reqgeometry_extensionaswkt_function"></a>A.3.2.6 <code>/req/geometry-extension/asWKT-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asWKT-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_aswkt">[_function_aswkt]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_3_serialization_gml"><a class="anchor" href="#_a_3_3_serialization_gml"></a>A.3.3 serialization = GML</h3>
+<div class="sect3">
+<h4 id="_a_3_3_1_confgeometry_extensiongml_literal"><a class="anchor" href="#_a_3_3_1_confgeometry_extensiongml_literal"></a>A.3.3.1 <code>/conf/geometry-extension/gml-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/gml-literal</code>
+All <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> instances shall consist of a valid element from the GML schema that implements a subtype of GM_Object as defined in [OGC 07-036].</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogmlliteral">Section 8.4.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_3_2_confgeometry_extensiongml_literal_empty"><a class="anchor" href="#_a_3_3_2_confgeometry_extensiongml_literal_empty"></a>A.3.3.2 <code>/conf/geometry-extension/gml-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/gml-literal-empty</code>
+An empty <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#gmlLiteral"><code>geo:gmlLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogmlliteral">Section 8.4.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_3_3_confgeometry_extensiongml_profile"><a class="anchor" href="#_a_3_3_3_confgeometry_extensiongml_profile"></a>A.3.3.3 <code>/conf/geometry-extension/gml-profile</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/gml-profile</code>
+Implementations shall document supported GML profiles.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Examine the implementation’s documentation to verify that the supported GML profiles are documented.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogmlliteral">Section 8.4.2.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Documentation</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_3_4_confgeometry_extensiongeometry_as_gml_literal"><a class="anchor" href="#_a_3_3_4_confgeometry_extensiongeometry_as_gml_literal"></a>A.3.3.4 <code>/conf/geometry-extension/geometry-as-gml-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-gml-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asGML"><code>geo:asGML</code></a> property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoasgml">Section 8.4.2.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_3_5_reqgeometry_extensionasgml_function"><a class="anchor" href="#_a_3_3_5_reqgeometry_extensionasgml_function"></a>A.3.3.5 <code>/req/geometry-extension/asGML-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asGML-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_asgml">[_function_asgml]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_4_serialization_geojson"><a class="anchor" href="#_a_3_4_serialization_geojson"></a>A.3.4 serialization = GEOJSON</h3>
+<div class="sect3">
+<h4 id="_a_3_4_1_reqgeometry_extensiongeojson_literal"><a class="anchor" href="#_a_3_4_1_reqgeometry_extensiongeojson_literal"></a>A.3.4.1 <code>/req/geometry-extension/geojson-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geojson-literal</code>
+All <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> instances shall consist of valid JSON that conforms to the GeoJSON specification <a href="#GEOJSON">[GEOJSON]</a></p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoasgml">Section 8.4.2.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_4_2_reqgeometry_extensiongeojson_literal_srs"><a class="anchor" href="#_a_3_4_2_reqgeometry_extensiongeojson_literal_srs"></a>A.3.4.2 <code>/req/geometry-extension/geojson-literal-srs</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geojson-literal-default-srs</code>
+The IRI <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84">&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</a> shall be assumed as the SRS for <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> instances that do not specify an explicit SRS IRI.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> values without an explicit encoded SRS IRI return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogeojsonliteral">Section 8.4.3.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_4_3_reqgeometry_extensiongeojson_literal_empty"><a class="anchor" href="#_a_3_4_3_reqgeometry_extensiongeojson_literal_empty"></a>A.3.4.3 <code>/req/geometry-extension/geojson-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geojson-literal-empty</code>
+An empty <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#geoJSONLiteral"><code>geo:geoJSONLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geogeojsonliteral">Section 8.4.3.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_4_4_reqgeometry_extensiongeometry_as_geojson_literal"><a class="anchor" href="#_a_3_4_4_reqgeometry_extensiongeometry_as_geojson_literal"></a>A.3.4.4 <code>/req/geometry-extension/geometry-as-geojson-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-geojson-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asGeoJSON"><code>geo:asGeoJSON</code></a> property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoasgeojson">Section 8.4.3.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_4_5_reqgeometry_extensionasgeojson_function"><a class="anchor" href="#_a_3_4_5_reqgeometry_extensionasgeojson_function"></a>A.3.4.5 <code>/req/geometry-extension/asGeoJSON-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asGeoJSON-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_asgeojson">[_function_asgeojson]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_5_serialization_kml"><a class="anchor" href="#_a_3_5_serialization_kml"></a>A.3.5 serialization = KML</h3>
+<div class="sect3">
+<h4 id="_a_3_5_1_reqgeometry_extensionkml_literal"><a class="anchor" href="#_a_3_5_1_reqgeometry_extensionkml_literal"></a>A.3.5.1 <code>/req/geometry-extension/kml-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/kml-literal</code>
+All <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> instances shall consist of a valid element from the KML schema that implements a <code>kml:AbstractObjectGroup</code> as defined in <a href="#OGCKML">[OGCKML]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geomklliteral">[_rdfs_datatype_geomklliteral]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_5_2_reqgeometry_extensionkml_literal_srs"><a class="anchor" href="#_a_3_5_2_reqgeometry_extensionkml_literal_srs"></a>A.3.5.2 <code>/req/geometry-extension/kml-literal-srs</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/kml-literal-default-srs</code>
+The IRI <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84">&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;</a> shall be assumed as the SRS for <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiterals</code></a> that do not specify an explicit SRS IRI.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a>  values without an explicit encoded SRS IRI return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geomklliteral">[_rdfs_datatype_geomklliteral]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_5_3_reqgeometry_extensionkml_literal_empty"><a class="anchor" href="#_a_3_5_3_reqgeometry_extensionkml_literal_empty"></a>A.3.5.3 <code>/req/geometry-extension/kml-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/kml-literal-empty</code>
+An empty <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#kmlLiteral"><code>geo:kmlLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rdfs_datatype_geomklliteral">[_rdfs_datatype_geomklliteral]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_5_4_reqgeometry_extensiongeometry_as_kml_literal"><a class="anchor" href="#_a_3_5_4_reqgeometry_extensiongeometry_as_kml_literal"></a>A.3.5.4 <code>/req/geometry-extension/geometry-as-kml-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-kml-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asKML"><code>geo:asKML</code></a>  property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoaskml">Section 8.4.4.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_5_5_reqgeometry_extensionaskml_function"><a class="anchor" href="#_a_3_5_5_reqgeometry_extensionaskml_function"></a>A.3.5.5 <code>/req/geometry-extension/asKML-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asKML-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_askml">[_function_askml]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_3_6_serialization_dggs"><a class="anchor" href="#_a_3_6_serialization_dggs"></a>A.3.6 serialization = DGGS</h3>
+<div class="sect3">
+<h4 id="_a_3_6_1_reqgeometry_extensiondggs_literal"><a class="anchor" href="#_a_3_6_1_reqgeometry_extensiondggs_literal"></a>A.3.6.1 <code>/req/geometry-extension/dggs-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/dggs-literal</code>
+All RDFS Literals of type <a href="http://www.opengis.net/ont/geosparql#dggsLiteral"><code>geo:dggsLiteral</code></a> shall consist of a DGGS geometry serialization formulated according to a specific DGGS literal type identified by a datatype specializing this generic datatype.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries do not use use this datatype but instead use specializations of it.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_dggs_serialization_serializationdggs">[_dggs_serialization_serializationdggs]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_6_2_reqgeometry_extensiondggs_literal_empty"><a class="anchor" href="#_a_3_6_2_reqgeometry_extensiondggs_literal_empty"></a>A.3.6.2 <code>/req/geometry-extension/dggs-literal-empty</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/dggs-literal-empty</code>
+An empty <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:dggsLiteral</code></a> shall be interpreted as an empty geometry.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving empty <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:dggsLiteral</code></a> values return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_dggs_serialization_serializationdggs">[_dggs_serialization_serializationdggs]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_6_3_reqgeometry_extensiongeometry_as_dggs_literal"><a class="anchor" href="#_a_3_6_3_reqgeometry_extensiongeometry_as_dggs_literal"></a>A.3.6.3 <code>/req/geometry-extension/geometry-as-dggs-literal</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/geometry-as-dggs-literal</code>
+Implementations shall allow the RDF property <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> to be used in SPARQL graph patterns.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the <a href="http://www.opengis.net/ont/geosparql#asDGGS"><code>geo:asDGGS</code></a> property return the correct result for a test dataset.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_property_geoasdggs">Section 8.4.5.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_a_3_6_4_reqgeometry_extensionasdggs_function"><a class="anchor" href="#_a_3_6_4_reqgeometry_extensionasdggs_function"></a>A.3.6.4 <code>/req/geometry-extension/asDGGS-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-extension/asDGGS-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a>, as a SPARQL extension function</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_function_asdggs">[_function_asdggs]</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_4_conformance_class_geometry_topology_extension_relation_family_serialization_version"><a class="anchor" href="#_a_4_conformance_class_geometry_topology_extension_relation_family_serialization_version"></a>A.4 Conformance Class: Geometry Topology Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/geometry-topology-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_4_1_tests_for_all_relation_families"><a class="anchor" href="#_a_4_1_tests_for_all_relation_families"></a>A.4.1 Tests for all relation families</h3>
+<div class="sect3">
+<h4 id="_a_4_1_1_confgeometry_topology_extensionrelate_query_function"><a class="anchor" href="#_a_4_1_1_confgeometry_topology_extensionrelate_query_function"></a>A.4.1.1 <code>/conf/geometry-topology-extension/relate-query-function</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-topology-extension/relate-query-function</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/relate"><code>geof:relate</code></a> as a SPARQL extension function, consistent with the relate operator defined in Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving the <a href="http://www.opengis.net/def/function/geosparql/relate"><code>geof:relate</code></a> function returns the correct result for a test dataset when using the specified serialization and version.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_common_query_functions">Section 9.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_4_2_relation_family_simple_features"><a class="anchor" href="#_a_4_2_relation_family_simple_features"></a>A.4.2 relation_family = Simple Features</h3>
+<div class="sect3">
+<h4 id="_a_4_2_1_confgeometry_topology_extensionsf_query_functions"><a class="anchor" href="#_a_4_2_1_confgeometry_topology_extensionsf_query_functions"></a>A.4.2.1 <code>/conf/geometry-topology-extension/sf-query-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-topology-extension/sf-query-functions</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/sfEquals"><code>geof:sfEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfDisjoint"><code>geof:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/efIntersects"><code>geof:sfIntersects</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfTouches"><code>geof:sfTouches</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfCrosses"><code>geof:sfCrosses</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfWithin"><code>geof:sfWithin</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfContains"><code>geof:sfContains</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfOverlaps"><code>geof:sfOverlaps</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/function/geosparql/sfEquals"><code>geof:sfEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfDisjoint"><code>geof:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/efIntersects"><code>geof:sfIntersects</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfTouches"><code>geof:sfTouches</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfCrosses"><code>geof:sfCrosses</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfWithin"><code>geof:sfWithin</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfContains"><code>geof:sfContains</code></a>, <a href="http://www.opengis.net/def/function/geosparql/sfOverlaps"><code>geof:sfOverlaps</code></a> .</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_simple_features_relation_family_relation_familysimple_features">Section 7.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_4_3_relation_family_egenhofer"><a class="anchor" href="#_a_4_3_relation_family_egenhofer"></a>A.4.3 relation_family = Egenhofer</h3>
+<div class="sect3">
+<h4 id="_a_4_3_1_confgeometry_topology_extensioneh_query_functions"><a class="anchor" href="#_a_4_3_1_confgeometry_topology_extensioneh_query_functions"></a>A.4.3.1 <code>/conf/geometry-topology-extension/eh-query-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-topology-extension/eh-query-functions</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/ehEquals"><code>geof:ehEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehDisjoint"><code>geof:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehMeet"><code>geof:ehMeet</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehOverlap"><code>geof:ehOverlap</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCovers"><code>geof:ehCovers</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCoveredBy"><code>geof:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehInside"><code>geof:ehInside</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehContains"><code>geof:ehContains</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features [ISO 19125- 1].</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/function/geosparql/ehEquals"><code>geof:ehEquals</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehDisjoint"><code>geof:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehMeet"><code>geof:ehMeet</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehOverlap"><code>geof:ehOverlap</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCovers"><code>geof:ehCovers</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehCoveredBy"><code>geof:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehInside"><code>geof:ehInside</code></a>, <a href="http://www.opengis.net/def/function/geosparql/ehContains"><code>geof:ehContains</code></a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_egenhofer_relation_family_relation_familyegenhofer">Section 7.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_4_4_relation_family_rcc8"><a class="anchor" href="#_a_4_4_relation_family_rcc8"></a>A.4.4 relation_family = RCC8</h3>
+<div class="sect3">
+<h4 id="_a_4_4_1_confgeometry_topology_extensionrcc8_query_functions"><a class="anchor" href="#_a_4_4_1_confgeometry_topology_extensionrcc8_query_functions"></a>A.4.4.1 <code>/conf/geometry-topology-extension/rcc8-query-functions</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/geometry-topology-extension/rcc8-query-functions</code>
+Implementations shall support <a href="http://www.opengis.net/def/function/geosparql/rcc8eq"><code>geof:rcc8eq</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8dc"><code>geof:rcc8dc</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ec"><code>geof:rcc8ec</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8po"><code>geof:rcc8po</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tppi"><code>geof:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tpp"><code>geof:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntpp"><code>geof:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntppi"><code>geof:rcc8ntppi</code></a> as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/function/geosparql/rcc8eq"><code>geof:rcc8eq</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8dc"><code>geof:rcc8dc</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ec"><code>geof:rcc8ec</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8po"><code>geof:rcc8po</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tppi"><code>geof:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8tpp"><code>geof:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntpp"><code>geof:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/function/geosparql/rcc8ntppi"><code>geof:rcc8ntppi</code></a> .</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rcc8_relation_family_relation_familyrcc8">Section 7.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_5_conformance_class_rdfs_entailment_extension_relation_family_serialization_version"><a class="anchor" href="#_a_5_conformance_class_rdfs_entailment_extension_relation_family_serialization_version"></a>A.5 Conformance Class: RDFS Entailment Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/rdfs-entailment-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_5_1_tests_for_all_implementations"><a class="anchor" href="#_a_5_1_tests_for_all_implementations"></a>A.5.1 Tests for all implementations</h3>
+<div class="sect3">
+<h4 id="_a_5_1_1_confrdfsentailmentextensionbgp_rdfs_ent"><a class="anchor" href="#_a_5_1_1_confrdfsentailmentextensionbgp_rdfs_ent"></a>A.5.1.1 <code>/conf/rdfsentailmentextension/bgp-rdfs-ent</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/rdfs-entailment-extension/bgp-rdfs-ent</code>
+Basic graph pattern matching shall use the semantics defined by the RDFS Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving entailed RDF triples returns the correct result for a test dataset using the specified serialization, version and relation_family.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_common_requirements">Section 10.2</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_5_2_serializationwkt"><a class="anchor" href="#_a_5_2_serializationwkt"></a>A.5.2 serialization=WKT</h3>
+<div class="sect3">
+<h4 id="_a_5_2_1_confrdfs_entailment_extensionwkt_geometry_types"><a class="anchor" href="#_a_5_2_1_confrdfs_entailment_extensionwkt_geometry_types"></a>A.5.2.1 <code>/conf/rdfs-entailment-extension/wkt-geometry-types</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/rdfs-entailment-extension/wkt-geometry-types</code>
+Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of Simple Features <a href="#ISO19125-1">[ISO19125-1]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving WKT Geometry types returns the correct result for a test dataset using the specified version of Simple Features.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_geometry_class_hierarchy">Section 10.3.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_5_3_serializationgml"><a class="anchor" href="#_a_5_3_serializationgml"></a>A.5.3 serialization=GML</h3>
+<div class="sect3">
+<h4 id="_a_5_3_1_confrdfs_entailment_extensiongml_geometry_types"><a class="anchor" href="#_a_5_3_1_confrdfs_entailment_extensiongml_geometry_types"></a>A.5.3.1 <code>/conf/rdfs-entailment-extension/gml-geometry-types</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/rdfs-entailment-extension/gml-geometry-types</code>
+Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the GML schema that implements GM_Object using the specified version of GML <a href="#OGC07-036">[OGC07-036]</a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that a set of SPARQL queries involving GML Geometry types returns the correct result for a test dataset using the specified version of GML.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_geometry_class_hierarchy_2">Section 10.4.1</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_a_6_conformance_class_query_rewrite_extension_relation_family_serialization_version"><a class="anchor" href="#_a_6_conformance_class_query_rewrite_extension_relation_family_serialization_version"></a>A.6 Conformance Class: Query Rewrite Extension (relation_family, serialization, version)</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><strong>Conformance Class IRI</strong>: <code>/conf/query-rewrite-extension</code></p>
+</div>
+<div class="sect2">
+<h3 id="_a_6_1_relation_family_simple_features"><a class="anchor" href="#_a_6_1_relation_family_simple_features"></a>A.6.1 relation_family = Simple Features</h3>
+<div class="sect3">
+<h4 id="_a_6_1_1_confquery_rewrite_extensionsf_query_rewrite"><a class="anchor" href="#_a_6_1_1_confquery_rewrite_extensionsf_query_rewrite"></a>A.6.1.1 <code>/conf/query-rewrite-extension/sf-query-rewrite</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/query-rewrite-extension/sf-query-rewrite</code>
+Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/sfEquals"><code>geor:sfEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint"><code>geor:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfIntersects"><code>geor:sfIntersects</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfTouches"><code>geor:sfTouches</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfCrosses"><code>geor:sfCrosses</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfWithin"><code>geor:sfWithin</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfContains"><code>geor:sfContains</code></a> and <a href="http://www.opengis.net/def/rule/geosparql/sfOverlaps"><code>geor:sfOverlaps</code></a>..</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/rule/geosparql/sfEquals"><code>geor:sfEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfDisjoint"><code>geor:sfDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfIntersects"><code>geor:sfIntersects</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfTouches"><code>geor:sfTouches</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfCrosses"><code>geor:sfCrosses</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfWithin"><code>geor:sfWithin</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/sfContains"><code>geor:sfContains</code></a> and <a href="http://www.opengis.net/def/rule/geosparql/sfOverlaps"><code>geor:sfOverlaps</code></a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_simple_features_relation_family_relation_familysimple_features_2">Section 9.3</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_6_2_relation_family_egenhofer"><a class="anchor" href="#_a_6_2_relation_family_egenhofer"></a>A.6.2 relation_family = Egenhofer</h3>
+<div class="sect3">
+<h4 id="_a_6_2_1_confquery_rewrite_extensioneh_query_rewrite"><a class="anchor" href="#_a_6_2_1_confquery_rewrite_extensioneh_query_rewrite"></a>A.6.2.1 <code>/conf/query-rewrite-extension/eh-query-rewrite</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/query-rewrite-extension/eh-query-rewrite</code>
+Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/ehEquals"><code>geor:ehEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehDisjoint"><code>geor:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehMeet"><code>geor:ehMeet</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehOverlap"><code>geor:ehOverlap</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCovers"><code>geor:ehCovers</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCoveredBy"><code>geor:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehInside"><code>geor:ehInside</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehContains"><code>geor:ehContains</code></a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/rule/geosparql/ehEquals"><code>geor:ehEquals</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehDisjoint"><code>geor:ehDisjoint</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehMeet"><code>geor:ehMeet</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehOverlap"><code>geor:ehOverlap</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCovers"><code>geor:ehCovers</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehCoveredBy"><code>geor:ehCoveredBy</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehInside"><code>geor:ehInside</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/ehContains"><code>geor:ehContains</code></a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_egenhofer_relation_family_relation_familyegenhofer_2">Section 9.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_a_6_3_relation_family_rcc8"><a class="anchor" href="#_a_6_3_relation_family_rcc8"></a>A.6.3 relation_family = RCC8</h3>
+<div class="sect3">
+<h4 id="_a_6_3_1_confquery_rewrite_extensionrcc8_query_rewrite"><a class="anchor" href="#_a_6_3_1_confquery_rewrite_extensionrcc8_query_rewrite"></a>A.6.3.1 <code>/conf/query-rewrite-extension/rcc8-query-rewrite</code></h4>
+<div class="paragraph">
+<p><strong>Requirement</strong>: <code>/req/query-rewrite-extension/rcc8-query-rewrite</code>
+Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime <a href="#SPARQLENT">[SPARQLENT]</a> for the RIF rules <a href="#RIFCORE">[RIFCORE]</a> <a href="http://www.opengis.net/def/rule/geosparql/rcc8eq"><code>geor:rcc8eq</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8dc"><code>geor:rcc8dc</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ec"><code>geor:rcc8ec</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8po"><code>geor:rcc8po</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tppi"><code>geor:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tpp"><code>geor:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntpp"><code>geor:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntppi"><code>geor:rcc8ntppi</code></a>.</p>
+</div>
+<div class="olist loweralpha">
+<ol class="loweralpha" type="a">
+<li>
+<p><strong>Test purpose</strong>: Check conformance with this requirement</p>
+</li>
+<li>
+<p><strong>Test method</strong>: Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: <a href="http://www.opengis.net/def/rule/geosparql/rcc8eq"><code>geor:rcc8eq</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8dc"><code>geor:rcc8dc</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ec"><code>geor:rcc8ec</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8po"><code>geor:rcc8po</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tppi"><code>geor:rcc8tppi</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8tpp"><code>geor:rcc8tpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntpp"><code>geor:rcc8ntpp</code></a>, <a href="http://www.opengis.net/def/rule/geosparql/rcc8ntppi"><code>geor:rcc8ntppi</code></a>.</p>
+</li>
+<li>
+<p><strong>Reference</strong>: <a href="#_rcc8_relation_family_relation_familyrcc8_2">Section 11.4</a></p>
+</li>
+<li>
+<p><strong>Test Type</strong>: Capabilities</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h1 id="_annex_b_informative_geosparql_examples" class="sect0"><a class="anchor" href="#_annex_b_informative_geosparql_examples"></a>Annex B (informative) GeoSPARQL Examples</h1>
+<div class="openblock partintro">
+<div class="content">
+This Annex provides examples of the GeoSPARQL ontology and functions. In addition to these, extended examples are provided seperately by the GeoSPARQL 1.1 profile, see the <a href="#_geosparql_standard_structure">GeoSPARQL Standard structure</a> for the link to those examples.
+</div>
+</div>
+<div class="sect1">
+<h2 id="_b_1_rdf_examples"><a class="anchor" href="#_b_1_rdf_examples"></a>B.1 RDF Examples</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This Section illustrates GeoSPARQL ontology modelling with extended examples.</p>
+</div>
+<div class="paragraph">
+<p><em>New Features checklist - to be removed when all examples are complete:</em></p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Classes</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Spatial Measure class</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_class_geospatialmeasure">Section 6.2.3</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect2">
+<h3 id="_b_1_1_classes"><a class="anchor" href="#_b_1_1_classes"></a>B.1.1 Classes</h3>
+<div class="sect3">
+<h4 id="_b_1_1_1_spatialobject"><a class="anchor" href="#_b_1_1_1_spatialobject"></a>B 1.1.1 <code>SpatialObject</code></h4>
+<div class="paragraph">
+<p>The <code>SpatialObject</code> class is defined in <a href="#_class_geospatialobject">Spatial Object</a>.</p>
+</div>
+<div class="paragraph">
+<p>Basic use (as per the example in the class definition)</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:SpatialObject ;
+    skos:prefLabel "Object X";
+.</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+It is unlikely that users of GeoSPARQL will create many instances of <a href="#_class_geospatialobject">Spatial Object</a> as its two more concrete subclasses, <a href="#_class_geofeature">Feature</a> &amp; <a href="#_class_geogeometry">Geometry</a>, are more directly relatable to real-world phenomena and use.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_1_2_feature"><a class="anchor" href="#_b_1_1_2_feature"></a>B 1.1.2 <code>Feature</code></h4>
+<div class="paragraph">
+<p>The <code>Feature</code> class is defined in <a href="#_class_geofeature">Section 6.2.2</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_1_basic_use"><a class="anchor" href="#_b_1_1_2_1_basic_use"></a>B 1.1.2.1 Basic use</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Feature</code> is declared and given a preferred label.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_2_a_feature_related_to_a_geometry"><a class="anchor" href="#_b_1_1_2_2_a_feature_related_to_a_geometry"></a>B 1.1.2.2 A <code>Feature</code> related to a <code>Geometry</code></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Feature</code> is declared, given a preferred label and a geometry for that <code>Feature</code> is indicated with the use of <a href="#_property_geohasgeometry">has geometry</a>. The <code>Geometry</code> indicated is described using a <em>Well-Known Text</em> literal value, indicated by the property <a href="http://www.opengis.net/ont/geosparql#asWKT"><code>geo:asWKT</code></a> and the literal type <code>geo:wktLiteral</code>.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_3_feature_with_both_geometry_and_spatialmeasure_instances_indicated"><a class="anchor" href="#_b_1_1_2_3_feature_with_both_geometry_and_spatialmeasure_instances_indicated"></a>B 1.1.2.3 <code>Feature</code> with both <code>Geometry</code> and <code>SpatialMeasure</code> instances indicated</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+        geo:hasGeometry [
+            geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasArea [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 8.7 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Feature</code> and a <code>Geometry</code> are described as per the previous example but an additional <code>SpatialMeasure</code> for the <code>Feature</code> is indicated with the use of the property <a href="#_property_geohasarea">has area</a>. This property indicates a <code>SpatialMeasure</code> instance which conveys its value using the <em>Quantities, Units, Dimensions and Types (QUDT)</em> ontology<sup class="footnote">[<a id="_footnoteref_13" class="footnote" href="#_footnotedef_13" title="View footnote.">13</a>]</sup></p>
+</div>
+<div class="paragraph">
+<p>Note that in this example, the use of QUDT and its <a href="http://qudt.org/schema/qudt#numericValue"><code>qudt:numericValue</code></a> &amp; <a href="http://qudt.org/schema/qudt#numericValue"><code>qudt:unit</code></a> is just one of many possible ways to convey a <code>SpatialMeasure</code> instance&#8217;s value.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_4_feature_with_metric_area"><a class="anchor" href="#_b_1_1_2_4_feature_with_metric_area"></a>B 1.1.2.4 <code>Feature</code> with metric area</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+        geo:hasGeometry [
+            geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasMetricArea "8.7E4"^^xsd:double;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This example encodes the same data as the example above (B 1.1.2.3), but it uses the simpler metric expression of area.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_5_feature_with_two_different_geometry_instances_indicated"><a class="anchor" href="#_b_1_1_2_5_feature_with_two_different_geometry_instances_indicated"></a>B 1.1.2.5 <code>Feature</code> with two different <code>Geometry</code> instances indicated</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        rdfs:label "Official boundary" ;
+        rdfs:comment "Official boundary from the Department of Xxx" ;
+        geo:asWKT "MULTIPOLYGON (((149.06016596 -35.23610602, 149.060620714 -35.236043434, ... , 149.06016596 -35.23610602)))"^^geo:wktLiteral ;
+    ] ,
+    [
+        rdfs:label "Unofficial boundary" ;
+        rdfs:comment "Unofficial boundary as actually used by everyone" ;
+        geo:asWKT "MULTIPOLYGON (((149.06016597 -35.23610603, 149.060620715 -35.236043435, ... , 149.06016597 -35.23610603)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>In this example, <code>Feature X</code> has two different <code>Geometry</code> instances indicated with their different explained in annotation properties. No ontology properties are used to indicate a difference in these <code>Geometry</code> thus machine use of this <code>Feature</code> woud not be easily able to differentiate them.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_6_feature_with_two_different_geometry_instances_with_different_property_values"><a class="anchor" href="#_b_1_1_2_6_feature_with_two_different_geometry_instances_with_different_property_values"></a>B 1.1.2.6 <code>Feature</code> with two different <code>Geometry</code> instances with different property values</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:hasSpatialResolution [
+            qudt:numericValue 100 ;
+            qudt:unit &lt;http://qudt.org/vocab/unit/M&gt; ;  # metre
+        ] ;
+        geo:asWKT "MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+    ] ,
+    [
+        geo:hasSpatialResolution [
+            qudt:numericValue 5 ;
+            qudt:unit &lt;http://qudt.org/vocab/unit/M&gt; ;  # metre
+        ] ;
+        geo:asWKT "MULTIPOLYGON (((149.06016597 -35.23610603, 149.060620715 -35.236043435, ... , 149.06016597 -35.23610603)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>In this example, <code>Feature X</code> has two different <code>Geometry</code> instances indicated with different spatial resolutions. This use of the <a href="#_property_geohasspatialresolution">has spatial resolution</a> property follows Example <a href="#_b_1_1_2_3_feature_with_both_geometry_and_spatialmeasure_instances_indicated">B 1.1.2.3 <code>Feature</code> with both <code>Geometry</code> and <code>SpatialMeasure</code> instances indicated</a> with its use of QUDT for unit &amp; value.</p>
+</div>
+<div class="paragraph">
+<p>Machine use of this <code>Feature</code> would be able to differentiate the two <code>Geometry</code> instnaces based on this use of <a href="#_property_geohasspatialresolution">has spatial resolution</a>.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_7_feature_with_two_different_geometry_instances_using_metric_spatial_resolution"><a class="anchor" href="#_b_1_1_2_7_feature_with_two_different_geometry_instances_using_metric_spatial_resolution"></a>B 1.1.2.7 <code>Feature</code> with two different <code>Geometry</code> instances using metric spatial resolution</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:hasMetricSpatialResolution "100"^^xsd:double ;
+        geo:asWKT "MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+    ] ,
+    [
+        geo:hasMetricSpatialResolution "5"^^xsd:double ;
+        geo:asWKT "MULTIPOLYGON (((149.06016597 -35.23610603, 149.060620715 -35.236043435, ... , 149.06016597 -35.23610603)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This example encodes the same data as the example above (B 1.1.2.7), but uses the simpler metric property to indicate spatial resolution.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b_1_1_2_8_feature_with_two_different_types_of_geometry_instances"><a class="anchor" href="#_b_1_1_2_8_feature_with_two_different_types_of_geometry_instances"></a>B 1.1.2.8 <code>Feature</code> with two different types of <code>Geometry</code> instances</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:asWKT "POLYGON ((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasCentroid [
+        geo:asWKT "POINT (149.06017784 -35.23612321)"^^geo:WktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Feature</code> instance has two geometries, one indicated with the general property <code>hasGeometry</code> and a second indicated with the specialised property <code>hasCentroid</code> which suggests the role that the indicated geometry plays. Note that while <code>hasGeometry</code> may indicate any type of <code>Geometry</code>, <code>hasCentroid</code> should only be used to indicate a point geometry. It may be informally inferred that the polygonal geometry is the <code>Feature</code> instance&#8217;s boundary.</p>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_1_3_geometry"><a class="anchor" href="#_b_1_1_3_geometry"></a>B.1.1.3 <code>Geometry</code></h4>
+<div class="paragraph">
+<p>The <code>Geometry</code> class is defined in <a href="#_class_geogeometry">Section 8.2.1</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_b1_1_3_1_basic_use"><a class="anchor" href="#_b1_1_3_1_basic_use"></a>B1.1.3.1 Basic Use</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:y a geo:Geometry ;
+    skos:prefLabel "Geometry Y";
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a <code>Geometry</code> is declared and given a preferred label.</p>
+</div>
+<div class="paragraph">
+<p>From GeoSPARQL 1.0 use, the most commonly observed use of a <code>Geometry</code> is in relation to a <code>Feature</code> as per the example in <a href="#_b_1_1_2_2_a_feature_related_to_a_geometry">B 1.1.2.2 A <code>Feature</code> related to a <code>Geometry</code></a> and often the <code>Geometry</code> is indirectly declared by the use of <code>hasGeometry</code> on the <code>Feature</code> instance indicating a Blank Node, however it is entirely possible to declare <code>Geometry</code> instances without any <code>Feature</code> instances. The next basic example declares a <code>Geometry</code> instance with an demonstration absolute URI and data.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">&lt;https://example.com/geometry/y&gt;
+    a geo:Geometry ;
+    skos:prefLabel "Geometry Y";
+    geo:asWKT "MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here the <code>Geometry</code> instance has data in WKT form and, since no CRS is declared, WGS84 is the assumed, default, CRS.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b1_1_3_2_a_geometry_with_multiple_serializations"><a class="anchor" href="#_b1_1_3_2_a_geometry_with_multiple_serializations"></a>B1.1.3.2 A <code>Geometry</code> with multiple serializations</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:Feature ;
+    skos:prefLabel "Feature X";
+    geo:hasGeometry [
+        geo:asWKT "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+        geo:asDGGS "&lt;https://w3id.org/dggs/aspix&gt; CELLLIST ((R1234 R1235 R1236 ... R1256))"^^geo:auspixDggsLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Here a single <code>Geometry</code>, linked to a <code>Feature</code> instance, is expressed using two different serializations: Well-known Text and the AusPIX DGGS.</p>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_1_4_spatialmeasure"><a class="anchor" href="#_b_1_1_4_spatialmeasure"></a>B 1.1.4 <code>SpatialMeasure</code></h4>
+<div class="paragraph">
+<p>The <code>SpatialMeasure</code> class is defined in <a href="#_class_geospatialmeasure">Section 6.2.3</a>.</p>
+</div>
+<div class="sect4">
+<h5 id="_b1_1_4_1_basic_use"><a class="anchor" href="#_b1_1_4_1_basic_use"></a>B1.1.4.1 Basic Use</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:z
+    a geo:SpatialMeasure ;
+    skos:prefLabel "Area Z" ;
+    qudt:numericValue 8.7 ;
+    qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This example defines an instance of <code>SpatialMeasure</code> and supplies it with a preferred label, a numeric value and a unit of measure.</p>
+</div>
+<div class="paragraph">
+<p><code>SpatialMeasure</code> instances may be declared in isolation like this - without reference to a <code>Feature</code> instance, just as Geometry instances may be - and future use of GeoSPARQL may see such declarations used widely however, at the time of writing GeoSPARQL 1.1, anticipated use of <code>SpatialMeasure</code> is with reference to a <code>Feature</code> instance: the <em>thing</em> for which the spatial measure is defined. The next example give use in relation to a <code>Feature</code> instance.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x
+    a geo:Feature ;
+    skos:prefLabel "Feature X" ;
+    geo:hasArea [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 8.7 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare
+    ] ;</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>In this example, the <code>SpatialMeasure</code> instance has no label - only a numeric value and a unit of measure - but it is declared to be the area for "Feature X".</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_b1_1_4_1_multiple_measures"><a class="anchor" href="#_b1_1_4_1_multiple_measures"></a>B1.1.4.1 Multiple measures</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix qudt: &lt;http://qudt.org/schema/qudt/&gt; .
+
+eg:x
+    a geo:Feature ;
+    skos:prefLabel "Lake X" ;
+    eg:hasFeatureCategory &lt;http://example.com/cat/lake&gt; ;
+    geo:hasArea [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 8.7 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare
+    ] ;
+    geo:hasVolume [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 624432 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/M3&gt; ;  # cubic metre
+    ]</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This example shows a <code>Feature</code> instance with area and volume declared. A categorization of the feature is given through the use of the <code>eg:hasFeatureCategory</code> dummy property which, along with the feature&#8217;s preferred label, indicate that this feature is a lake. Having both an area and a volume makes sense for a lake.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_b_1_2_properties"><a class="anchor" href="#_b_1_2_properties"></a>B.1.2 Properties</h3>
+<div class="paragraph">
+<p><em>New Features checklist - to be removed when all examples are complete:</em></p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Feature Properties</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasBoundingBox</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasboundingbox">Section 6.4.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasCentroid</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohascentroid">Section 6.4.4</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasLength</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohaslength">Section 6.4.5</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasArea</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasarea">Section 6.4.7</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">hasVolume</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geohasvolume">Section 6.4.9</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Geometry Serializations</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">geoJSONLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geogeojsonliteral">Section 8.4.3.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGeoJSON</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoasgeojson">Section 8.4.3.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">kmlLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_rdfs_datatype_geokmlliteral">Section 8.4.4.1</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asKML</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoaskml">Section 8.4.4.2</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">dggsWKTLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#RDFS Datatype: geo:dggsWKTLiteral">[RDFS Datatype: geo:dggsWKTLiteral]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">auspixDggsWKTLiteral</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#RDFS Datatype: geo:auspixDggsWKTLiteral">[RDFS Datatype: geo:auspixDggsWKTLiteral]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asDGGS</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_property_geoasdggs">Section 8.4.5.3</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect3">
+<h4 id="_b_1_2_1_feature_properties"><a class="anchor" href="#_b_1_2_1_feature_properties"></a>B.1.2.1 Feature Properties</h4>
+<div class="paragraph">
+<p>This example shows a <code>Feature</code> instance with each of the properties defined in <a href="#8.3. Standard Properties for geo:Feature">[8.3. Standard Properties for geo:Feature]</a> used.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:Feature ;
+    skos:preferredLabel "Feature X" ;
+    geo:hasGeometry [
+        geo:asWKT "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; POLYGON ((149.06016 -35.23610, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasDefaultGeometry [
+        geo:asWKT "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; POLYGON ((149.0601 -35.2361, ... , 149.0601 -35.2361)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasLength [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 355 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/M&gt; ;  # metre
+    ] ;
+    geo:hasArea [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 8.7 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/HA&gt; ;  # hectare
+    ] ;
+    geo:hasVolume [
+        a geo:SpatialMeasure ;
+        qudt:numericValue 624432 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/M3&gt; ;  # cubic metre
+    ]
+    geo:hasCentroid [
+        geo:asWKT "POINT (149.06017784 -35.23612321)"^^geo:wktLiteral ;
+    ] ;
+    geo:hasBoundingBox [
+        geo:asWKT "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; POLYGON ((149.060 -35.236, ... , 149.060 -35.236)))"^^geo:wktLiteral ;
+    ] ;
+    geo:hasSpatialResolution [
+        qudt:numericValue 5 ;
+        qudt:unit &lt;http://qudt.org/vocab/unit/M&gt; ;  # metre
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The properties defined for this example&#8217;s <code>Feature</code> instance are vaguely aligned in that the values are not real but are not unrealistic either. It is outside the scope of GeoSPARQL to validate <code>Feature</code> instances' property values.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_2_2_geometry_properties"><a class="anchor" href="#_b_1_2_2_geometry_properties"></a>B.1.2.2 Geometry Properties</h4>
+<div class="paragraph">
+<p>This example shows a <code>Geometry</code> instance declaread in relation to a <code>Feature</code> instance with each of the properties defined in <a href="#8.4. Standard Properties for geo:Geometry">[8.4. Standard Properties for geo:Geometry]</a> used.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:Feature ;
+    geo:hasGeometry [
+        skos:prefLabel "Geometry Y" ;
+        geo:dimension 2 ;
+        geo:coordinateDimension 2 ;
+        geo:spatialDimension 2 ;
+        geo:isEmpty false ;
+        geo:isSimple true ;
+        geo:hasSerialization "&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt; POLYGON ((149.060 -35.236, ... , 149.060 -35.236)))"^^geo:wktLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>In this example, each of the standards properties defined for a <code>Geometry</code> instance has realistic values, for example, the <a href="#_property_geoisempty">is empty</a> is set to <code>false</code> since the <code>Geometry</code> contains information.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_b_1_2_3_geometry_serializations"><a class="anchor" href="#_b_1_2_3_geometry_serializations"></a>B.1.2.3 Geometry Serializations</h4>
+<div class="paragraph">
+<p>This section shows a <code>Geometry</code> instance for a <code>Feature</code> instance which is represented in all supported GeoSPARQL serlializations. The geometry values given are real geometry values and approximate <a href="https://en.wikipedia.org/wiki/Moreton_Island">Moreton Island</a> in Queensland, Australia.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">eg:x
+    a geo:Feature ;
+    geo:hasGeometry [
+        geo:asWKT """&lt;http://www.opengis.net/def/crs/EPSG/0/4326&gt;
+            POLYGON ((
+                153.3610112 -27.0621757,
+                153.3658177 -27.1990606,
+                153.421436 -27.3406573,
+                153.4269292 -27.3607835,
+                153.4434087 -27.3315078,
+                153.4183848 -27.2913403,
+                153.4189391 -27.2039578,
+                153.4673476 -27.0267166,
+                153.3610112 -27.0621757
+            ))"""^^geo:wktLiteral ;
+
+        geo:asGML """&lt;gml:Polygon
+                srsName="http://www.opengis.net/def/crs/EPSG/0/4326"&gt;
+                &lt;gml:exterior&gt;
+                    &lt;gml:LinearRing&gt;
+                        &lt;gml:posList&gt;
+                            -27.0621757 153.3610112
+                            -27.1990606 153.3658177
+                            -27.3406573 153.421436
+                            -27.3607835 153.4269292
+                            -27.3315078 153.4434087
+                            -27.2913403 153.4183848
+                            -27.2039578 153.4189391
+                            -27.0267166 153.4673476
+                            -27.0621757 153.3610112
+                        &lt;/gml:posList&gt;
+                    &lt;/gml:LinearRing&gt;
+                &lt;/gml:exterior&gt;
+            &lt;/gml:Polygon&gt;"""^^go:gmlLiteral ;
+
+        geo:asKML """&lt;Polygon&gt;
+                &lt;outerBoundaryIs&gt;
+                    &lt;LinearRing&gt;
+                        &lt;coordinates&gt;
+                        153.3610112,-27.0621757
+                        153.3658177,-27.1990606
+                        153.421436,-27.3406573
+                        153.4269292,-27.3607835
+                        153.4434087,-27.3315078
+                        153.4183848,-27.2913403
+                        153.4189391,-27.2039578
+                        153.4673476,-27.0267166
+                        153.3610112,-27.0621757
+                        &lt;/coordinates&gt;
+                    &lt;/LinearRing&gt;
+                &lt;/outerBoundaryIs&gt;
+            &lt;/Polygon&gt;"""^^go:kmlLiteral ;
+
+        geo:asGeoJSON """{
+                "type": "Polygon",
+                "coordinates": [[
+                    [153.3610112, -27.0621757],
+                    [153.3658177, -27.1990606],
+                    [153.421436, -27.3406573],
+                    [153.4269292, -27.3607835],
+                    [153.4434087, -27.3315078],
+                    [153.4183848, -27.2913403],
+                    [153.4189391, -27.2039578],
+                    [153.4673476, -27.0267166],
+                    [153.3610112, -27.0621757]
+                ]]
+            }"""^^geo:geoJSONLiteral ;
+
+        geo:asDGGS """CELLLIST ((R8346031 R8346034 R8346037
+            R83460058 R83460065 R83460068 R83460072 R83460073 R83460074 R83460075 R83460076
+            R83460077 R83460078 R83460080 R83460081 R83460082 R83460083 R83460084 R83460085
+            R83460086 R83460087 R83460088 R83460302 R83460305 R83460308 R83460320 R83460321
+            R83460323 R83460324 R83460326 R83460327 R83460332 R83460335 R83460338 R83460350
+            R83460353 R83460356 R83460362 R83460365 R83460380 R83460610 R83460611 R83460612
+            R83460613 R83460614 R83460615 R83460617 R83460618 R83460641 R83460642 R83460644
+            R83460645 R83460648 R83460672 R83460686 R83463020 R83463021 R834600487 R834600488
+            R834600557 R834600558 R834600564 R834600565 R834600566 R834600567 R834600568
+            R834600571 R834600572 R834600573 R834600574 R834600575 R834600576 R834600577
+            R834600578 R834600628 R834600705 R834600706 R834600707 R834600708 R834600712
+            R834600713 R834600714 R834600715 R834600716 R834600717 R834600718 R834601334
+            R834601335 R834601336 R834601337 R834601338 R834601360 R834601361 R834601363
+            R834601364 R834601366 R834601367 R834601600 R834601601 R834601603 R834601606
+            R834601630 R834601633 R834603220 R834603221 R834603223 R834603224 R834603226
+            R834603227 R834603250 R834603251 R834603253 R834603256 R834603280 R834603283
+            R834603510 R834603511 R834603512 R834603513 R834603514 R834603515 R834603516
+            R834603517 R834603540 R834603541 R834603543 R834603544 R834603546 R834603547
+            R834603570 R834603573 R834603576 R834603681 R834603682 R834603684 R834603685
+            R834603687 R834603688 R834603810 R834603830 R834603831 R834603832 R834603833
+            R834603834 R834603835 R834603836 R834603837 R834603860 R834603861 R834603863
+            R834603864 R834603866 R834603867 R834606021 R834606022 R834606024 R834606025
+            R834606028 R834606052 R834606055 R834606160 R834606161 R834606162 R834606164
+            R834606165 R834606167 R834606168 R834606200 R834606203 R834606206 R834606230
+            R834606233 R834606236 R834606260 R834606263 R834606266 R834606401 R834606402
+            R834606405 R834606408 R834606432 R834606471 R834606472 R834606474 R834606475
+            R834606477 R834606478 R834606500 R834606503 R834606506 R834606530 R834606533
+            R834606536 R834606560 R834606563 R834606566 R834606712 R834606715 R834606718
+            R834606750 R834606751 R834606752 R834606753 R834606754 R834606755 R834606757
+            R834606758 R834606781 R834606782 R834606784 R834606785 R834606788 R834606800
+            R834606803 R834606806 R834606807 R834606830 R834606831 R834606833 R834606834
+            R834606835 R834606836 R834606837 R834606838 R834606870 R834606873 R834606874
+            R834606876 R834606877 R834630122 R834630125 R834630226 R834630230 R834630231
+            R834630232 R834630234 R834630235 R834630237 R834630238 R834630240 R834630241
+            R834630242 R834630243 R834630244 R834630245 R834630246 R834630247 R834630261
+            R834630262 R834630264 R834630265 R834630268 R834630270 R834630271 R834630273
+            R834630276 R834630502))""""^^geo:auspixDggsLiteral ;
+    ] ;
+.</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_b_2_example_sparql_queries_rules"><a class="anchor" href="#_b_2_example_sparql_queries_rules"></a>B.2 Example SPARQL Queries &amp; Rules</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><em>New Features checklist - to be removed when all examples are complete:</em></p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Non-topological Query Functions</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxx">Section 8.5.19</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxY</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxy">Section 8.5.20</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">maxZ</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofmaxz">Section 8.5.21</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminx">Section 8.5.22</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minY</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminy">Section 8.5.23</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">minZ</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofminz">Section 8.5.24</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Spatial Aggregate Functions</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">BBOX</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geosaf:BBOX">[Function: geosaf:BBOX]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">BoundingCircle</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:BoundingCircle">[Function: geoaf:BoundingCircle]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Centroid</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:Centroid">[Function: geoaf:Centroid]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConcatLines</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConcatLines">[Function: geoaf:ConcatLines]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConcaveHull</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConcaveHull">[Function: geoaf:ConcaveHull]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConvexHull</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:ConvexHull">[Function: geoaf:ConvexHull]</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Union</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#Function: geoaf:Union">[Function: geoaf:Union]</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>This Section provides example data and then illustrates the use of GeoSPARQL functions and the application of rules with that data.</p>
+</div>
+<div class="sect2">
+<h3 id="_b_2_1_example_data"><a class="anchor" href="#_b_2_1_example_data"></a>B.2.1 Example Data</h3>
+<div class="paragraph">
+<p>The following RDF data (Turtle format) encodes application-specific spatial data. The resulting spatial data is illustrated in Figure 3. The RDF statements define the feature class <code>my:PlaceOfInterest</code>, and two properties are created for associating geometries with features: <code>my:hasExactGeometry</code> and <code>my:hasPointGeometry</code>. <code>my:hasExactGeometry</code> is designated as the default geometry for the <code>my:PlaceOfInterest</code> feature class.</p>
+</div>
+<div class="paragraph">
+<p>All the following examples use the parameter values relation_family = Simple Features, serialization = WKT, and version = 1.0.</p>
+</div>
+<div id="img-illustration" class="imageblock text-center">
+<div class="content">
+<img src="img/03.png" alt="600" width="400">
+</div>
+<div class="title">Figure 3. Illustration of spatial data</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-turtle" data-lang="turtle">@prefix geo: &lt;http://www.opengis.net/ont/geosparql#&gt; .
+@prefix my: &lt;http://example.org/ApplicationSchema#&gt; .
+@prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
+@prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix sf: &lt;http://www.opengis.net/ont/sf#&gt; .
+
+my:PlaceOfInterest a rdfs:Class ;
+    rdfs:subClassOf geo:Feature .
+
+my:A a my:PlaceOfInterest ;
+    my:hasExactGeometry my:AExactGeom ;
+    my:hasPointGeometry my:APointGeom .
+
+my:B a my:PlaceOfInterest ;
+    my:hasExactGeometry my:BExactGeom ;
+    my:hasPointGeometry my:BPointGeom .
+
+my:C a my:PlaceOfInterest ;
+    my:hasExactGeometry my:CExactGeom ;
+    my:hasPointGeometry my:CPointGeom .
+
+my:D a my:PlaceOfInterest ;
+    my:hasExactGeometry my:DExactGeom ;
+    my:hasPointGeometry my:DPointGeom .
+
+my:E a my:PlaceOfInterest ;
+    my:hasExactGeometry my:EExactGeom .
+
+my:F a my:PlaceOfInterest ;
+    my:hasExactGeometry my:FExactGeom .
+
+my:hasExactGeometry a rdf:Property ;
+    rdfs:subPropertyOf geo:hasDefaultGeometry,
+        geo:hasGeometry .
+
+my:hasPointGeometry a rdf:Property ;
+    rdfs:subPropertyOf geo:hasGeometry .
+
+my:AExactGeom a sf:Polygon ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Polygon((-83.6 34.1, -83.2 34.1, -83.2 34.5,
+                 -83.6 34.5, -83.6 34.1))"""^^geo:wktLiteral.
+
+my:APointGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.4 34.3)"""^^geo:wktLiteral.
+
+my:BExactGeom a sf:Polygon ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Polygon((-83.6 34.1, -83.4 34.1, -83.4 34.3,
+                 -83.6 34.3, -83.6 34.1))"""^^geo:wktLiteral.
+
+my:BPointGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.5 34.2)"""^^geo:wktLiteral.
+
+my:CExactGeom a sf:Polygon ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Polygon((-83.2 34.3, -83.0 34.3, -83.0 34.5,
+                 -83.2 34.5, -83.2 34.3))"""^^geo:wktLiteral.
+
+my:CPointGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.1 34.4)"""^^geo:wktLiteral.
+
+my:DExactGeom a sf:Polygon ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Polygon((-83.3 34.0, -83.1 34.0, -83.1 34.2,
+                 -83.3 34.2, -83.3 34.0))"""^^geo:wktLiteral.
+
+my:DPointGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.2 34.1)"""^^geo:wktLiteral.
+
+my:EExactGeom a sf:LineString ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 LineString(-83.4 34.0, -83.3 34.3)"""^^geo:wktLiteral.
+
+my:FExactGeom a sf:Point ;
+    geo:asWKT """&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+                 Point(-83.4 34.4)"""^^geo:wktLiteral.</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_b_2_2_example_queries"><a class="anchor" href="#_b_2_2_example_queries"></a>B.2.2 Example Queries</h3>
+<div class="paragraph">
+<p>This Section illustrates the use of GeoSPARQL functions through a series of example queries.</p>
+</div>
+<div id="annexB_example1" class="paragraph">
+<p><strong>Example 1</strong>: <em>Find all features that feature <code>my:A</code> contains, where spatial calculations are based on</em> <code>my:hasExactGeometry</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?f
+WHERE {
+    my:A my:hasExactGeometry ?aGeom .
+    ?aGeom geo:asWKT ?aWKT .
+    ?f my:hasExactGeometry ?fGeom .
+    ?fGeom geo:asWKT ?fWKT .
+
+    FILTER (
+        geof:sfContains(?aWKT, ?fWKT) &amp;&amp;
+            !sameTerm(?aGeom, ?fGeom)
+        )
+)</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:B</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:F</code></p></td>
+</tr>
+</tbody>
+</table>
+<div id="annexB_example2" class="paragraph">
+<p><strong>Example 2</strong>: <em>Find all features that are within a transient bounding box geometry, where spatial calculations are based on</em> <code>my:hasPointGeometry</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?f
+WHERE {
+    ?f my:hasPointGeometry ?fGeom .
+    ?fGeom geo:asWKT ?fWKT .
+    FILTER (
+        geof:sfWithin(
+            ?fWKT,
+            "&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+            Polygon ((-83.4 34.0, -83.1 34.0,
+                        -83.1 34.2, -83.4 34.2,
+                        -83.4 34.0))"^^geo:wktLiteral
+        )
+    )
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:D</code></p></td>
+</tr>
+</tbody>
+</table>
+<div id="annexB_example3" class="paragraph">
+<p><strong>Example 3</strong>: <em>Find all features that touch the union of feature <code>my:A</code> and feature <code>my:D</code>, where computations are based on</em> <code>my:hasExactGeometry</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?f
+WHERE {
+    ?f my:hasExactGeometry ?fGeom .
+    ?fGeom geo:asWKT ?fWKT .
+    my:A my:hasExactGeometry ?aGeom .
+    ?aGeom geo:asWKT ?aWKT .
+    my:D my:hasExactGeometry ?dGeom .
+    ?dGeom geo:asWKT ?dWKT .
+    FILTER (
+        geof:sfTouches(
+            ?fWKT,
+            geof:union(?aWKT, ?dWKT)
+        )
+    )
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:C</code></p></td>
+</tr>
+</tbody>
+</table>
+<div id="annexB_example4" class="paragraph">
+<p><strong>Example 4</strong>: <em>Find the 3 closest features to feature my:C, where computations are based on</em> <code>my:hasExactGeometry</code>.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX uom: &lt;http://www.opengis.net/def/uom/OGC/1.0/&gt;
+PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/geosparql/function&gt;
+
+SELECT ?f
+WHERE {
+    my:C my:hasExactGeometry ?cGeom .
+    ?cGeom geo:asWKT ?cWKT .
+    ?f my:hasExactGeometry ?fGeom .
+    ?fGeom geo:asWKT ?fWKT .
+    FILTER (?fGeom != ?cGeom)
+}
+ORDER BY ASC (geof:distance(?cWKT, ?fWKT, uom:metre))
+LIMIT 3</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:A</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:D</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:E</code></p></td>
+</tr>
+</tbody>
+</table>
+<div id="annexB_example5" class="paragraph">
+<p><strong>Example 5</strong>: Find the maximum and minimum coordinates of a given set of geometries .</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?minX ?minY ?minZ ?maxX ?maxY ?maxZ
+WHERE {
+    BIND ("&lt;http://www.opengis.net/def/crs/OGC/1.3/CRS84&gt;
+            Polygon Z((-83.4 34.0 0, -83.1 34.0 1,
+                        -83.1 34.2 1, -83.4 34.2 1,
+                        -83.4 34.0 0))"^^geo:wktLiteral) AS ?testgeom)
+    BIND(geof:minX(?testgeom) AS ?minX)
+    BIND(geof:maxX(?testgeom) AS ?maxX)
+    BIND(geof:minY(?testgeom) AS ?minY)
+    BIND(geof:maxY(?testgeom) AS ?maxY)
+    BIND(geof:maxZ(?testgeom) AS ?maxZ)
+    BIND(geof:minZ(?testgeom) AS ?minZ)
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?minX</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?minY</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?minZ</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?maxX</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?maxY</strong></th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?maxZ</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>-83.4</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>34.0</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>0</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>-83.1</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>34.2</code></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>1</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_b_2_3_example_rule_application"><a class="anchor" href="#_b_2_3_example_rule_application"></a>B.2.3 Example Rule Application</h3>
+<div class="paragraph">
+<p>This section illustrates the query transformation strategy for implementing GeoSPARQL rules.</p>
+</div>
+<div id="annexB_example6" class="paragraph">
+<p><strong>Example 6</strong>: <em>Find all features or geometries that overlap feature</em> <code>my:A</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Original Query</strong>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+
+SELECT ?f
+WHERE { ?f geo:sfOverlaps my:A }</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Transformed Query (application of transformation rule geor:sfOverlaps)</strong>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-sparql" data-lang="sparql">PREFIX my: &lt;http://example.org/ApplicationSchema#&gt;
+PREFIX geo: &lt;http://www.opengis.net/ont/geosparql#&gt;
+PREFIX geof: &lt;http://www.opengis.net/def/function/geosparql/&gt;
+
+SELECT ?f
+WHERE {
+    { # check for asserted statement
+        ?f geo:sfOverlaps my:A }
+    UNION
+    { # feature – feature
+        ?f geo:hasDefaultGeometry ?fGeom .
+        ?fGeom geo:asWKT ?fSerial .
+        my:A geo:hasDefaultGeometry ?aGeom .
+        ?aGeom geo:asWKT ?aSerial .
+        FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+    }
+    UNION
+    { # feature – geometry
+        ?f geo:hasDefaultGeometry ?fGeom .
+        ?fGeom geo:asWKT ?fSerial .
+        my:A geo:asWKT ?aSerial .
+        FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+    }
+    UNION
+    { # geometry – feature
+        ?f geo:asWKT ?fSerial .
+        my:A geo:hasDefaultGeometry ?aGeom .
+        ?aGeom geo:asWKT ?aSerial .
+        FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+    }
+    UNION
+    { # geometry – geometry
+        ?f geo:asWKT ?fSerial .
+        my:A geo:asWKT ?aSerial .
+        FILTER (geof:sfOverlaps(?fSerial, ?aSerial))
+    }</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Result</strong>:</p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><strong>?f</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:D</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:DExactGeom</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:E</code></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><code>my:EExactGeom</code></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_b_2_4_example_geometry_serialization_conversion_functions"><a class="anchor" href="#_b_2_4_example_geometry_serialization_conversion_functions"></a>B.2.4 Example Geometry Serialization Conversion Functions</h3>
+<div class="paragraph">
+<p><em>New Features checklist - to be removed when all examples are complete:</em></p>
+</div>
+<table class="tableblock frame-all grid-all stripes-odd stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">New element</th>
+<th class="tableblock halign-left valign-top" style="background-color: #FFFFFF;">Section</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="2" style="background-color: #FFFFFF;"><p class="tableblock"><em>Geometry Serializations</em></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asWKT function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofaswkt">Section 8.4.1.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGML function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofasgml">Section 8.4.2.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asGeoJSON function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofasgeojson">Section 8.4.3.3</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">asKML function</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="#_function_geofaskml">Section 8.4.4.3</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect3">
+<h4 id="_b_1_2_2_1_geofaswkt"><a class="anchor" href="#_b_1_2_2_1_geofaswkt"></a>B.1.2.2.1 <code>geof:asWKT</code></h4>
+<div class="paragraph">
+<p>For the geometry literal values in <a href="#_b_1_2_3_geometry_serializations">B.1.2.3 Geometry Serializations</a>:</p>
+</div>
+<div class="paragraph">
+<p>Application of the function <a href="http://www.opengis.net/def/function/geosparql/asWKT"><code>geof:asWKT</code></a> to the GML, KML, GeoJSON and DGGS literals should return WKT literal and similarly for each of the other conversion methods, <a href="http://www.opengis.net/def/function/geosparql/asGML"><code>geof:asGML</code></a>, <a href="http://www.opengis.net/def/function/geosparql/asKML"><code>geof:asKML</code></a>, <a href="http://www.opengis.net/def/function/geosparql/asGeoJSON"><code>geof:asGeoJSON</code></a> &amp; <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a>.</p>
+</div>
+<div class="paragraph">
+<p>Note that the application of <a href="http://www.opengis.net/def/function/geosparql/asDGGS"><code>geof:asDGGS</code></a> requires a <code>specificDggsDatatype</code> parameter which indicates the particular DGGS literal form being converted to. In the case of <a href="#_b_1_2_3_geometry_serializations">B.1.2.3 Geometry Serializations</a>, this value would be <a href="http://www.opengis.net/def/function/geosparql/auspixDggsLiteral"><code>geof:auspixDggsLiteral</code></a>, the datatype of the AusPIX DGGS format provided by GeoSPARQL 1.1.</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_annex_c"><a class="anchor" href="#_annex_c"></a>Annex C</h3>
+
+</div>
+<div class="sect2">
+<h3 id="_informative"><a class="anchor" href="#_informative"></a>(informative)</h3>
+<div class="sect3">
+<h4 id="_c_3_mappings_from_simple_features_for_sql"><a class="anchor" href="#_c_3_mappings_from_simple_features_for_sql"></a>C.3 Mappings from Simple Features for SQL</h4>
+<div class="paragraph">
+<p>The following table maps the functions and properties from Simple Features for SQL <a href="#ISO19125-1">[ISO19125-1]</a> to GeoSPARQL.</p>
+</div>
+<table class="tableblock frame-none grid-none stripes-odd stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Simple Features for SQL</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeoSPARQL Equivalent</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Since GeoSPARQL</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Related Property Available</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Since GeoSPARQL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.1.1 Basic Methods on Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Dimension(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/dimension">geof:dimension</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#dimension">geo:dimension</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeometryType(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Class of geometry instance</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SRID(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/getSRID">geof:getSRID</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Envelope(): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/envelope">geof:envelope</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasBoundingBox">geo:hasBoundingBox</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">AsText(): String</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/asWKT">geof:asWKT</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#asWKT">geo:asWKT</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">AsBinary(): Binary</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsEmpty(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/isEmpty">geof:isEmpty</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#isEmpty">geo:IsEmpty</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsSimple(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/isEmpty">geof:isSimple</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#isSimple">geo:IsSimple</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Boundary(): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/boundary">geof:boundary</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.1.2 Spatial Relations</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Equals(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfEquals">geof:sfEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfEquals">geo:sfEquals</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Disjoint(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfDisjoint">geof:sfDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfDisjoint">geo:sfDisjoint</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Intersects(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfIntersects">geof:sfIntersects</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfIntersects">geo:sfIntersects</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Touches(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfTouches">geof:sfTouches</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfTouches">geo:sfTouches</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Crosses(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfCrosses">geof:sfCrosses</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfCrosses">geo:sfCrosses</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Within(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfWithin">geof:sfWithin</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfWithin">geo:sfWithin</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Contains(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfContains">geof:sfContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfContains">geo:sfContains</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Overlaps(anotherGeometry: Geometry): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/sfOverlaps">geof:sfOverlaps</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#sfOverlaps">geo:sfOverlaps</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Relate(anotherGeometry: Geometry, IntersectionPatternMatrix: String): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/relate">geof:relate</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.1.3 Spatial Analysis</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Buffer(distance: Double): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/buffer">geof:buffer</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ConvexHull(): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/convexHull">geof:convexHull</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Intersection(anotherGeometry: Geometry): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/intersection">geof:intersection</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Union(anotherGeometry: Geometry): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/union">geof:union</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Difference(anotherGeometry: Geometry): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/difference">geof:difference</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">SymDifference(anotherGeometry: Geometry): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/symDifference">geof:symDifference</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.0</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.2.1 GeometryCollection</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">NumGeometries(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/numGeometries">geof:numGeometries</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">GeometryN(N: Integer): Geometry</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/geometryN">geof:geometryN</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.3.1 Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">X(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Y(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Z(): Double (not in the SQL spec, but a logical extension)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">M(): Double (not in the SQL spec, but a logical extension)</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.5.1 Curve</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Length(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/length">geof:length</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasLength">geo:hasLength</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">StartPoint(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">EndPoint(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsClosed(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsRing(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.6.1 LineString</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">NumPoints(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">PointN(N: Integer): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.7.1 MultiCurve</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">IsClosed(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Length(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/length">geof:length</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasLength">geo:hasLength</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.9.1 Surface</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Area(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/area">geof:area</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasArea">geo:hasArea</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Centroid(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/centroid">geof:centroid</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasCentroid">geo:hasCentroid</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">PointOnSurface(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.10.1 Polygon</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">ExteriorRing(): LineString</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">NumInteriorRing(): Integer</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">InteriorRingN(N: Integer): LineString</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">2.1.11.1 MultiSurface</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Area(): Double</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/area">geof:area</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasArea">geo:hasArea</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">Centroid(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/def/function/geosparql/centroid">geof:centroid</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock"><a href="http://www.opengis.net/ont/geosparql#hasCentroid">geo:hasCentroid</a></p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">1.1</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">PointOnSurface(): Point</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">N/A</p></td>
+<td class="tableblock halign-left valign-top" style="background-color: #FFFFFF;"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_bibliography"><a class="anchor" href="#_bibliography"></a>Bibliography</h2>
+<div class="sectionbody">
+<div class="ulist bibliography">
+<ul class="bibliography">
+<li>
+<p><a id="AUSPIX"></a>[AUSPIX] Geoscience Australia, <em>AusPIX: An Australian Government implimentation of the rHEALPix DGGS in Python</em> (2020). <a href="https://github.com/GeoscienceAustralia/AusPIX_DGGS" class="bare">https://github.com/GeoscienceAustralia/AusPIX_DGGS</a></p>
+</li>
+<li>
+<p><a id="QUAL"></a>[QUAL] Cohn, Anthony G.; Brandon Bennett; John Gooday; Nicholas Mark Gotts, <em>Qualitative Spatial Representation and Reasoning with the Region Connection Calculus</em>, GeoInformatica, 1, 275–316 (1997) <a href="https://doi.org/10.1023/A:1009712514511" class="bare">https://doi.org/10.1023/A:1009712514511</a></p>
+</li>
+<li>
+<p><a id="FORMAL"></a>[FORMAL] Egenhofer, M. (1989) A Formal Definition of Binary Topological Relationships. In: Litwin, W. and Schek, H.J., Eds., Proceedings of the 3rd International Conference on Foundations of Data Organization and Algorithms (FODO), Paris, France, Lecture Notes in Computer Science, 367, (Springer-Verlag, New York, 1989) 457-472. (1989)</p>
+</li>
+<li>
+<p><a id="CATEG"></a>[CATEG] Egenhofer, Max and J. Herring <em>Categorizing Binary Topological Relations Between Regions, Lines, and Points</em>, Geographic Databases, Technical Report, Department of Surveying Engineering, University of Maine (1990)</p>
+</li>
+<li>
+<p><a id="ISO13249"></a>[ISO13249] International Organization for Standardization/International Electrotechnical Commission 13249-3, <em>ISO/IEC 13249-3: Information technology — Database languages — SQL multimedia and application packages — Part 3: Spatial</em> (2000)</p>
+</li>
+<li>
+<p><a id="ISO19105"></a>[ISO19105] International Organization for Standardization, <em>ISO 19105: Geographic information – Conformance and testing</em> (2000)</p>
+</li>
+<li>
+<p><a id="ISO19107"></a>[ISO19107] International Organization for Standardization, <em>ISO 19107: Geographic information — Spatial schema</em> (2003)</p>
+</li>
+<li>
+<p><a id="ISO19109"></a>[ISO19109] International Organization for Standardization, <em>ISO 19109: Geographic information — Rules for application schemas</em> (2005)</p>
+</li>
+<li>
+<p><a id="ISO19156"></a>[ISO19156] International Organization for Standardization, <em>ISO 19156: Geographic information — Observations and measurements</em> (2011)</p>
+</li>
+<li>
+<p><a id="LOGIC"></a>[LOGIC] Randell, D. A., Cui, Z. and Cohn, A. G.: A spatial logic based on regions and connection, Proc. 3rd Int. Conf. on Knowledge Representation and Reasoning, Morgan Kaufmann, San Mateo, pp. 165–176 (1992)</p>
+</li>
+<li>
+<p><a id="TURTLE"></a>[TURTLE] World Wide Web Consortium, <em>RDF 1.1 Turtle - Terse RDF Triple Language</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/turtle/" class="bare">https://www.w3.org/TR/turtle/</a></p>
+</li>
+<li>
+<p><a id="RDFXML"></a>[RDFXML] World Wide Web Consortium, <em>RDF 1.1 XML Syntax</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/rdf-syntax-grammar/" class="bare">https://www.w3.org/TR/rdf-syntax-grammar/</a></p>
+</li>
+<li>
+<p><a id="RDF"></a>[RDF] World Wide Web Consortium, <em>RDF 1.1 Concepts and Abstract Syntax</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/rdf11-concepts/" class="bare">https://www.w3.org/TR/rdf11-concepts/</a></p>
+</li>
+<li>
+<p><a id="RDFSEM"></a>[RDFSEM] World Wide Web Consortium, <em>RDF 1.1 Semantics</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/rdf11-mt/" class="bare">https://www.w3.org/TR/rdf11-mt/</a></p>
+</li>
+<li>
+<p><a id="RDFS"></a>[RDFS] World Wide Web Consortium, <em>RDF Schema 1.1</em>, W3C Recommendation (25 February 2014). <a href="https://www.w3.org/TR/rdf-schema/" class="bare">https://www.w3.org/TR/rdf-schema/</a></p>
+</li>
+<li>
+<p><a id="RIF"></a>[RIF] World Wide Web Consortium, <em>RIF Overview (Second Edition)</em>, W3C Working Group Note (5 February 2013). <a href="https://www.w3.org/TR/rif-overview/" class="bare">https://www.w3.org/TR/rif-overview/</a></p>
+</li>
+<li>
+<p><a id="OWL2"></a>[OWL2] World Wide Web Consortium, <em>OWL 2 Web Ontology Language Document Overview (Second Edition)</em>, W3C Recommendation (11 December 2012). <a href="https://www.w3.org/TR/owl2-overview/" class="bare">https://www.w3.org/TR/owl2-overview/</a></p>
+</li>
+<li>
+<p><a id="XML"></a>[XML] World Wide Web Consortium, <em>Extensible Markup Language (XML) 1.0 (Fifth Edition)</em>, W3C Recommendation (26 November 2008). <a href="http://www.w3.org/TR/xml/" class="bare">http://www.w3.org/TR/xml/</a></p>
+</li>
+<li>
+<p><a id="XMLNS"></a>[XMLNS] World Wide Web Consortium, <em>Namespaces in XML 1.0 (Third Edition)</em>, W3C Recommendation (8 December 2009). <a href="https://www.w3.org/TR/xml-names/" class="bare">https://www.w3.org/TR/xml-names/</a></p>
+</li>
+<li>
+<p><a id="XSD1"></a>[XSD1] World Wide Web Consortium, <em>XML Schema Part 1: Structures (Second Edition)</em>, W3C Recommendation (28 October 2004). <a href="https://www.w3.org/TR/xmlschema-1/" class="bare">https://www.w3.org/TR/xmlschema-1/</a></p>
+</li>
+<li>
+<p><a id="XSD2"></a>[XSD2] World Wide Web Consortium, <em>XML Schema Part 2: Datatypes (Second Edition)</em>, W3C Recommendation (28 October 2004). <a href="https://www.w3.org/TR/xmlschema-2/" class="bare">https://www.w3.org/TR/xmlschema-2/</a></p>
+</li>
+<li>
+<p><a id="DGGSAS"></a>[DGGSAS] Open Geospatial Consortium, <em>Abstract Standard Topic 21 - Discrete Global Grid Systems - Part 1 Core Reference system and Operations and Equal Area Earth Reference System</em>, Open Geospatial Consortium Standard (2021) <a href="http://www.opengis.net/doc/AS/dggs/2.0" class="bare">http://www.opengis.net/doc/AS/dggs/2.0</a></p>
+</li>
+<li>
+<p><a id="IETF5234"></a>[IETF5234] Internet Engineering Task Force, <em>RFC 5234: Internet Standard 68: Augmented BNF for Syntax Specifications: ABNF</em>. IETF Request for Comment (2008) <a href="https://tools.ietf.org/html/std68" class="bare">https://tools.ietf.org/html/std68</a></p>
+</li>
+<li>
+<p><a id="GEOJSON"></a>[GEOJSON] Internet Engineering Task Force, <em>RFC 7946: The GeoJSON Format</em>. IETF Request for Comment (August 2016). <a href="https://tools.ietf.org/html/rfc7946" class="bare">https://tools.ietf.org/html/rfc7946</a></p>
+</li>
+<li>
+<p><a id="OGCKML"></a>[OGCKML] Open Geospatial Consortium, <em>OGC KML 2.3</em>. OGC Implementation Standard (04 August 2015). <a href="http://www.opengis.net/doc/IS/kml/2.3" class="bare">http://www.opengis.net/doc/IS/kml/2.3</a></p>
+</li>
+<li>
+<p><a id="ISO19125-1"></a>[ISO19125-1] International Organization for Standardization, <em>ISO 19125-1: Geographic information — Simple feature access — Part 1: Common architecture</em></p>
+</li>
+<li>
+<p><a id="OGC07-036"></a>[OGC07-036] Open Geospatial Consortium, <em>OGC 07-036: Geography Markup Language (GML) Encoding Standard</em>, Version 3.2.1 (27 August 2007).</p>
+</li>
+<li>
+<p><a id="IETF3987"></a>[IETF3987] Internet Engineering Task Force, <em>RFC 3987: Internationalized Resource Identifiers (IRIs)</em>. IETF Request for Comment (January 2005). <a href="https://tools.ietf.org/html/rfc3987" class="bare">https://tools.ietf.org/html/rfc3987</a></p>
+</li>
+<li>
+<p><a id="RIFCORE"></a>[RIFCORE] World Wide Web Consortium, <em>RIF Core Dialect (Second Edition)</em>, W3C Recommendation (5 February 2013) <a href="http://www.w3.org/TR/rif-core/" class="bare">http://www.w3.org/TR/rif-core/</a></p>
+</li>
+<li>
+<p><a id="SPARQL"></a>[SPARQL] World Wide Web Consortium, <em>SPARQL 1.1 Query Language</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/sparql11-query/" class="bare">https://www.w3.org/TR/sparql11-query/</a></p>
+</li>
+<li>
+<p><a id="SPARQLENT"></a>[SPARQLENT] World Wide Web Consortium, <em>SPARQL 1.1 Entailment Regimes</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/sparql11-entailment/" class="bare">https://www.w3.org/TR/sparql11-entailment/</a></p>
+</li>
+<li>
+<p><a id="SPARQLPROT"></a>[SPARQLPROT] World Wide Web Consortium, <em>SPARQL 1.1 Protocol</em>, W3C Recommendation (21 March 2013)&gt; <a href="http://www.w3.org/TR/sparql11-protocol/" class="bare">http://www.w3.org/TR/sparql11-protocol/</a></p>
+</li>
+<li>
+<p><a id="SPARQLRESX"></a>[SPARQLRESX] World Wide Web Consortium, <em>SPARQL Query Results XML Format (Second Edition)</em>, W3C Recommendation (21 March 2013). <a href="https://www.w3.org/TR/rdf-sparql-XMLres/" class="bare">https://www.w3.org/TR/rdf-sparql-XMLres/</a></p>
+</li>
+<li>
+<p><a id="SPARQLRESJ"></a>[SPARQLRESJ] World Wide Web Consortium, <em>SPARQL 1.1 Query Results JSON Format</em>, W3C Recommendation (21 March 2013). <a href="http://www.w3.org/TR/sparql11-results-json/" class="bare">http://www.w3.org/TR/sparql11-results-json/</a></p>
+</li>
+<li>
+<p><a id="SHACL"></a>[SHACL] World Wide Web Consortium, <em>Shapes Constraint Language (SHACL)</em>, W3C Recommendation (20 July 2017). <a href="https://www.w3.org/TR/shacl/" class="bare">https://www.w3.org/TR/shacl/</a></p>
+</li>
+<li>
+<p><a id="PROF"></a>[PROF] World Wide Web Consortium, <em>The Profiles Vocabulary</em>, W3C Working Group Note (18 December 2019). <a href="https://www.w3.org/TR/dx-prof/" class="bare">https://www.w3.org/TR/dx-prof/</a></p>
+</li>
+<li>
+<p><a id="SKOS"></a>[SKOS] World Wide Web Consortium, <em>SKOS Simple Knowledge Organization System Reference</em>, W3C Recommendation (18 August 2009). <a href="https://www.w3.org/TR/skos-reference/" class="bare">https://www.w3.org/TR/skos-reference/</a></p>
+</li>
+<li>
+<p><a id="JSON-LD"></a>[JSON-LD] World Wide Web Consortium, <em>JSON-LD 1.1: A JSON-based Serialization for Linked Data</em>, W3C Recommendation (16 July 2020). <a href="https://www.w3.org/TR/json-ld11/" class="bare">https://www.w3.org/TR/json-ld11/</a></p>
+</li>
+<li>
+<p><a id="CHARTER"></a>[CHARTER] Open Geospatial Consortium, <em>OGC GeoSPARQL SWG Charter</em>, OGC Working Group Charter (25 August 2020). <a href="https://github.com/opengeospatial/ogc-geosparql/blob/master/charter/swg_charter.pdf" class="bare">https://github.com/opengeospatial/ogc-geosparql/blob/master/charter/swg_charter.pdf</a></p>
+</li>
+<li>
+<p><a id="DE-9IM"></a> Clementini, Eliseo; Di Felice, Paolino and van Oosterom, Peter, <em>A small set of formal topological relationships suitable for end-user interaction</em> (1993). In Abel, David; Ooi, Beng Chin (eds.). Advances in Spatial Databases: Third International Symposium, SSD '93 Singapore, June 23–25, 1993 Proceedings. Lecture Notes in Computer Science. 692/1993. Springer. pp. 277–295. doi:10.1007/3-540-56869-7_16.</p>
+</li>
+</ul>
+</div>
+<div style="page-break-after: always;"></div>
+</div>
+</div>
+</div>
+<div id="footnotes">
+<hr>
+<div class="footnote" id="_footnotedef_1">
+<a href="#_footnoteref_1">1</a>. <a href="https://en.wikipedia.org/wiki/SPARQL" class="bare">https://en.wikipedia.org/wiki/SPARQL</a>
+</div>
+<div class="footnote" id="_footnotedef_2">
+<a href="#_footnoteref_2">2</a>. <a href="https://www.w3.org/TR/sparql11-query/#extensionFunctions" class="bare">https://www.w3.org/TR/sparql11-query/#extensionFunctions</a>
+</div>
+<div class="footnote" id="_footnotedef_3">
+<a href="#_footnoteref_3">3</a>. <a href="https://www.ogc.org/def-server" class="bare">https://www.ogc.org/def-server</a>
+</div>
+<div class="footnote" id="_footnotedef_4">
+<a href="#_footnoteref_4">4</a>. <a href="http://www.w3.org/2003/01/geo/" class="bare">http://www.w3.org/2003/01/geo/</a>
+</div>
+<div class="footnote" id="_footnotedef_5">
+<a href="#_footnoteref_5">5</a>. <a href="http://purl.org/dc/terms/Location" class="bare">http://purl.org/dc/terms/Location</a>
+</div>
+<div class="footnote" id="_footnotedef_6">
+<a href="#_footnoteref_6">6</a>. <a href="https://schema.org/GeoCoordinates" class="bare">https://schema.org/GeoCoordinates</a>
+</div>
+<div class="footnote" id="_footnotedef_7">
+<a href="#_footnoteref_7">7</a>. <a href="https://schema.org/GeoShape" class="bare">https://schema.org/GeoShape</a>
+</div>
+<div class="footnote" id="_footnotedef_8">
+<a href="#_footnoteref_8">8</a>. <a href="https://www.w3.org/ns/locn" class="bare">https://www.w3.org/ns/locn</a>
+</div>
+<div class="footnote" id="_footnotedef_9">
+<a href="#_footnoteref_9">9</a>. <a href="https://www.w3.org/TR/vocab-dcat/#spatial-properties" class="bare">https://www.w3.org/TR/vocab-dcat/#spatial-properties</a>
+</div>
+<div class="footnote" id="_footnotedef_10">
+<a href="#_footnoteref_10">10</a>. <a href="https://www.w3.org/TR/sparql11-query/#expressions" class="bare">https://www.w3.org/TR/sparql11-query/#expressions</a>
+</div>
+<div class="footnote" id="_footnotedef_11">
+<a href="#_footnoteref_11">11</a>. <a href="https://www.w3.org/TR/sparql11-query/#operatorExtensibility" class="bare">https://www.w3.org/TR/sparql11-query/#operatorExtensibility</a>
+</div>
+<div class="footnote" id="_footnotedef_12">
+<a href="#_footnoteref_12">12</a>. <a href="https://www.ogc.org/def-server" class="bare">https://www.ogc.org/def-server</a>
+</div>
+<div class="footnote" id="_footnotedef_13">
+<a href="#_footnoteref_13">13</a>. <a href="http://www.qudt.org" class="bare">http://www.qudt.org</a>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2021-07-21 10:39:32 +1000
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Addresses comment https://github.com/opengeospatial/ogc-geosparql/pull/173#issuecomment-896896673 by converting all links between `Feature` & `FeatureCollection` in the extended example to be `rdfs:member` not `dcterms` properties, to match our ontology definition.