### PR TITLE
dcterms:isPartOf flipped to rdfs:member

### DIFF
--- a/1.1/examples/demo-dataset.ttl
+++ b/1.1/examples/demo-dataset.ttl
@@ -49,35 +49,47 @@ Note that GeoSPARQL 1.1 makes no recommendations regarding dataset-level data pa
     sdo:affiliation <https://linked.data.gov.au/org/surround> ;
   ] ;
   dcat:keyword "GeoSPARQL", "demonstration" , "Australia" ;
+  rdfs:member
+    points: ,
+    polys: ;
 .
 
 points:
   a geo:FeatureCollection ;
   dcterms:identifier "points"^^xsd:token ;
-  dcterms:isPartOf dataset: ;
   dcterms:title "Points Feature Collection" ;
   dcterms:description "A FeatureCollection of POINT instances"@en ;
   geo:hasBoundingBox [
     a geo:Geometry ;
     geo:asWKT "POLYGON ((150.467423 -33.491384, 150.467423 -34.3223631, 150.9920201 -34.3223631, 150.9920201 -33.491384, 150.467423 -33.491384))"^^geo:wktLiteral ;
   ] ;
+  rdfs:member
+    :camerons-corner ,
+    :shorncliffe-point-1 ,
+    :shorncliffe-point-2 ,
+    :shorncliffe-point-3 ,
+    :wyvenhoe ;
 .
 
 polys:
   a geo:FeatureCollection ;
   dcterms:identifier "polys"^^xsd:token ;
-  dcterms:isPartOf dataset: ;
   dcterms:title "Polygons Feature Collection" ;
   dcterms:description "A FeatureCollection of POLYGON instances"@en ;
   geo:hasBoundingBox [
     a geo:Geometry ;
     geo:asWKT "POLYGON ((150.467423 -33.491384, 150.467423 -34.3223631, 150.9920201 -34.3223631, 150.9920201 -33.491384, 150.467423 -33.491384))"^^geo:wktLiteral ;
   ] ;
+  rdfs:member
+    :curlew-park ,
+    :shorncliffe ,
+    :sandgate-golf-club ,
+    :queensland ,
+    :australia ;
 .
 
 :camerons-corner
   a geo:Feature ;
-  dcterms:isPartOf points: ;
   dcterms:identifier "camerons-corner"^^xsd:token ;
   geo:hasGeometry [
     a geo:Geometry ;
@@ -90,7 +102,6 @@ polys:
 
 :shorncliffe-point-1
   a geo:Feature ;
-  dcterms:isPartOf points: ;
   dcterms:identifier "shorncliffe-point-1"^^xsd:token ;
   geo:hasGeometry [
     a geo:Geometry ;
@@ -108,7 +119,6 @@ polys:
 .
 :shorncliffe-point-2
   a geo:Feature ;
-  dcterms:isPartOf points: ;
   dcterms:identifier "shorncliffe-point-2"^^xsd:token ;
   geo:hasGeometry [
     a geo:Geometry ;
@@ -126,7 +136,6 @@ polys:
 .
 :shorncliffe-point-3
   a geo:Feature ;
-  dcterms:isPartOf points: ;
   dcterms:identifier "shorncliffe-point-3"^^xsd:token ;
   geo:hasBoundingBox [
     a geo:Geometry ;
@@ -138,7 +147,6 @@ polys:
 .
 :wyvenhoe
   a geo:Feature ;
-  dcterms:isPartOf points: ;
   dcterms:identifier "wyvenhoe"^^xsd:token ;
   geo:hasGeometry [
     a geo:Geometry ;
@@ -151,7 +159,6 @@ polys:
 
 :curlew-park
   a geo:Feature ;
-  dcterms:isPartOf polys: ;
   dcterms:identifier "curlew-park"^^xsd:token ;
   geo:hasCentroid [
     a geo:Geometry ;
@@ -173,7 +180,6 @@ polys:
 .
 :shorncliffe
   a geo:Feature ;
-  dcterms:isPartOf polys: ;
   dcterms:identifier "shorncliffe"^^xsd:token ;
   geo:hasCentroid [
     a geo:Geometry ;
@@ -195,7 +201,6 @@ polys:
 .
 :sandgate-golf-club
   a geo:Feature ;
-  dcterms:isPartOf polys: ;
   dcterms:identifier "sandgate-golf-club"^^xsd:token ;
   geo:hasCentroid [
     a geo:Geometry ;
@@ -218,7 +223,6 @@ polys:
 
 :queensland
   a geo:Feature ;
-  dcterms:isPartOf polys: ;
   dcterms:identifier "queensland"^^xsd:token ;
   geo:hasCentroid [
     a geo:Geometry ;
@@ -251,7 +255,6 @@ polys:
 
 :australia
   a geo:Feature ;
-  dcterms:isPartOf polys: ;
   dcterms:identifier "australia"^^xsd:token ;
   geo:hasCentroid [
     a geo:Geometry ;

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -92,13 +92,15 @@ geo:SpatialObjectCollection
       rdf:type owl:Restriction ;
       owl:allValuesFrom geo:SpatialObject ;
       owl:onProperty rdfs:member ;
-    ] ;
+  ] ;
   skos:prefLabel "Collection of spatial objects" ;
   skos:definition """The class Spatial Object Collection represents any collection of things that can 
                     have a spatial representation. It is superclass of Feature Collection
                     and Geometry Collection""" ;
 .
 ```
+
+The restriction imposed on the generic `rdfs:Container` that defines this class is that only instances of <<Class: SpatialObject, Spatial Object>> are allowed to be members of it and these are indicated with the `rdfs:member` property.
 
 |===
 | *Req 5* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#SpatialObjectCollection[`geo:SpatialObjectCollection`] to be used in SPARQL graph patterns.
@@ -122,6 +124,8 @@ geo:FeatureCollection
   skos:definition "The class Feature Collection represents any collection of individual Features. " ;
 .
 ```
+
+The restriction imposed on the more general <<Class: SpatialObjectCollection, Spatial Object Collection>> that defines this class is that only instances of <<Class: Feature, Feature>> are allowed to be members of it and these are to be indicated with the `rdfs:member` property.
 
 |===
 | *Req 6* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#FeatureCollection[`geo:FeatureCollection`] to be used in SPARQL graph patterns.

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -66,6 +66,8 @@ geo:GeometryCollection
 .
 ```
 
+The restriction imposed on the more general <<Class: SpatialObjectCollection, Spatial Object Collection>> that defines this class is that only instances of <<Class: Geometry, Geometry>> are allowed to be members of it and these are to be indicated with the `rdfs:member` property.
+
 |===
 | *Req 12* Implementations shall allow the RDFS class http://www.opengis.net/ont/geosparql#GeometryCollection[`geo:GeometryCollection`] to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.1/req/core/geometry-collection-class[`http://www.opengis.net/spec/geosparql/1.1/req/core/geometry-collection-class`]


### PR DESCRIPTION
This PR addresses the comment https://github.com/opengeospatial/ogc-geosparql/pull/173#issuecomment-896896673 by re-implementing the information of the extended example's `dcterms:isPartOf` property to the inverse `rdfs:member` to align with our ontology definitions of collections.