### PR TITLE
AusPIX removed from normative standing

### DIFF
--- a/1.1/spec/01-Preamble.adoc
+++ b/1.1/spec/01-Preamble.adoc
@@ -112,7 +112,6 @@ These new ontology elements and new functions are normatively defined in this sp
 |asKML | <<Property: geo:asKML>>
 |asKML function | <<Function: geof:asKML>>
 |dggsLiteral | <<RDFS Datatype: geo:dggsLiteral>>
-|auspixDggsLiteral | <<RDFS Datatype: geo:auspixDggsLiteral>>
 |asDGGS | <<Property: geo:asDGGS>>
 |asDGGS function | <<Function: geo:asDGGS>>
 2+|_Non-topological Query Functions_

--- a/1.1/spec/08-Part-05.adoc
+++ b/1.1/spec/08-Part-05.adoc
@@ -31,7 +31,7 @@ The following IRI namespace prefixes are used throughout this document:
 [frame=none, grid=none, cols="1, 6"]
 |===
 | ogc: | http://www.opengis.net/
-| eg: | http://example.com/
+| ex: | http://example.com/
 | geo: | http://www.opengis.net/ont/geosparql#
 | geof: | http://www.opengis.net/def/function/geosparql/
 | geor: | http://www.opengis.net/def/rule/geosparql/

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -551,7 +551,7 @@ This section establishes the requirements for representing Discrete Global Grid 
 Here is defined one RDFS Datatypes:
 http://www.opengis.net/ont/geosparql#dggsLiteral[`+http://www.opengis.net/ont/geosparql#dggsLiteral+`] and one property, http://www.opengis.net/ont/geosparql#asDGGS[`+http://www.opengis.net/ont/geosparql#asDGGS+`]. 
 
-NOTE: The datatype defined here is for an abstract DGGS implementation (http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`]) but concrete ones should be used in real implementations. For example, the AusPIX DGGS <<AUSPIX>> might implement something similar to `eg:auspixDggsLiteral`.
+NOTE: The datatype defined here is for an abstract DGGS implementation (http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`]) but concrete ones should be used in real implementations. For example, the AusPIX DGGS <<AUSPIX>> might implement something similar to `ex:auspixDggsLiteral`.
 
 ===== RDFS Datatype: geo:dggsLiteral
 
@@ -575,7 +575,7 @@ geo:dggsLiteral a rdfs:Datatype ;
 An example of a literal for concrete DGGS, AusPIX, could be
 
 ```turtle
-eg:auspixDggsLiteral 
+ex:auspixDggsLiteral 
     a rdfs:Datatype ;
     skos:prefLabel "AusPIX DGGS Literal"@en ;
     skos:definition "A textual serialization of an AusPIX Discrete Global Grid System (DGGS) geometry object."@en .
@@ -610,7 +610,7 @@ geo:asDGGS a rdf:Property, owl:DatatypeProperty ;
     rdfs:range geo:dggsLiteral .
 ```
 
-NOTE: It is expected that this property will be used to indicate specific DGGS data types, such as the example `eg:auspixDggsLiteral`, descibed above, as opposed to the generic http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`].
+NOTE: It is expected that this property will be used to indicate specific DGGS data types, such as the example `ex:auspixDggsLiteral`, described above, as opposed to the generic http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`].
 
 ===== Function: geof:asDGGS
 

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -548,10 +548,10 @@ The function http://www.opengis.net/def/function/geosparql/asKML[`geof:asKML`] c
 
 This section establishes the requirements for representing Discrete Global Grid System (DGGS) geometry data as RDF literals. The form of representation is specific to individual DGGS implementations: known DGGSes are not compatible or even very similar. 
 
-Here are defined two RDFS Datatypes:
-http://www.opengis.net/ont/geosparql#dggsLiteral[`+http://www.opengis.net/ont/geosparql#dggsLiteral+`] & http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`+http://www.opengis.net/ont/geosparql#auspixDggsLiteral+`] and one property, http://www.opengis.net/ont/geosparql#asDGGS[`+http://www.opengis.net/ont/geosparql#asDGGS+`]. 
+Here is defined one RDFS Datatypes:
+http://www.opengis.net/ont/geosparql#dggsLiteral[`+http://www.opengis.net/ont/geosparql#dggsLiteral+`] and one property, http://www.opengis.net/ont/geosparql#asDGGS[`+http://www.opengis.net/ont/geosparql#asDGGS+`]. 
 
-NOTE: The two datatypes defined here are for an abstract DGGS implementation (http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`]) and a specific one, AusPIX <<AUSPIX>> (http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`]). The purposes of including both of these are to indicate the conceptual position of DGGS literals in this specification - the abstract form acts as a parent of all other potential, specific, DGGS datatypes - and to exemplify a specific system implementation which allows for real examples of use.
+NOTE: The datatype defined here is for an abstract DGGS implementation (http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`]) but concrete ones should be used in real implementations. For example, the AusPIX DGGS <<AUSPIX>> might implement something similar to `eg:auspixDggsLiteral`.
 
 ===== RDFS Datatype: geo:dggsLiteral
 
@@ -561,8 +561,6 @@ geo:dggsLiteral a rdfs:Datatype ;
     skos:prefLabel "DGGS Literal"@en ;
     skos:definition "A textual serialization of a Discrete Global Grid System (DGGS) geometry object."@en .
 ```
-
-Valid http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`] instances are formed by encoding geometry information according to specific DGGS implementation. The specific implementation should be indicated by use of a subclass of the `geo:dggsLiteral` datatype. 
 
 |===
 | *Req 35* All RDFS Literals of type http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`] shall consist of a DGGS geometry serialization formulated according to a specific DGGS.
@@ -574,30 +572,22 @@ Valid http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`] instan
 |http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal-empty[`http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal-empty`]
 |===
 
-===== RDFS Datatype: geo:auspixDggsLiteral
+An example of a literal for concrete DGGS, AusPIX, could be
 
 ```turtle
-geo:auspixDggsLiteral 
+eg:auspixDggsLiteral 
     a rdfs:Datatype ;
-    rdfs:isDefinedBy geo: ;
     skos:prefLabel "AusPIX DGGS Literal"@en ;
     skos:definition "A textual serialization of an AusPIX Discrete Global Grid System (DGGS) geometry object."@en .
 ```
 
-Valid http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`] instances are formed by encoding geometry information according to the AusPIX DGGS implementation <<AUSPIX>>.
-
-The example http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`] below encodes a point geometry according to the _AusPIX_ DGGS. The DGGS geometry type is indicated with the token `CellList` and the list of values, a single cell, is enclosed in parenthesis. The cell value of _R3234_ is analogous to either a `Point` or simple `Polygon` in WKT geometries, so a single coordinate pair or a list of them:
+A single _Cell_ geometry encoded according to the AusPIX DGGS using the example literal above is given below. The single cell value of _R3234_ is analogous to either a `Point` or simple `Polygon` in WKT geometries.
 
 ```turtle
-"CellList (R3234)"^^<http://www.opengis.net/ont/geosparql#auspixDggsLiteral>
+"CellList (R3234)"^^<http://example.com#auspixDggsLiteral>
 ```
 
-NOTE: What `R3234` means is not handled by GeoSPARQL but by the AusPIX DGGS specification <<AUSPIX>>, just as GeoPSARQL does not delve into the internals of other geometry formats such as WKT or GeoJSON.
-
-|===
-| *Req 37* All RDFS Literals of type http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`] shall consist of a DGGS geometry serialization formulated according to the AusPIX DGGS.
-|http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/auspix-dggs-literal[`http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/auspix-dggs-literal`]
-|===
+NOTE: What `R3234` means, or the meaning of any other element within a concrete DGGS literal is not handled by GeoSPARQL but is expected to be handled by that DGGS' specification, just as GeoPSARQL does not delve into the internals of other geometry formats such as WKT or GeoJSON.
 
 ===== Property: geo:asDGGS
 
@@ -615,12 +605,12 @@ geo:asDGGS a rdf:Property, owl:DatatypeProperty ;
     rdfs:subPropertyOf geo:hasSerialization ;
     rdfs:isDefinedBy geo: ;
     skos:prefLabel "as DGGS"@en ;
-    skos:definition "A DGGS Well-Known Text serialization of a geometry."@en ;
+    skos:definition "A DGGS serialization of a geometry."@en ;
     rdfs:domain geo:Geometry ;
     rdfs:range geo:dggsLiteral .
 ```
 
-NOTE: It is expected that this property will be used to indicate specific DGGS data types, such as http://www.opengis.net/ont/geosparql#auspixDggsLiteral[`geo:auspixDggsLiteral`], descibed above, as opposed to the generic http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`].
+NOTE: It is expected that this property will be used to indicate specific DGGS data types, such as the example `eg:auspixDggsLiteral`, descibed above, as opposed to the generic http://www.opengis.net/ont/geosparql#dggsLiteral[`geo:dggsLiteral`].
 
 ===== Function: geof:asDGGS
 

--- a/1.1/spec/17-Annex-B.adoc
+++ b/1.1/spec/17-Annex-B.adoc
@@ -209,12 +209,12 @@ eg:x
     skos:prefLabel "Feature X";
     geo:hasGeometry [
         geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
-        geo:asDGGS "<https://w3id.org/dggs/aspix> CELLLIST ((R1234 R1235 R1236 ... R1256))"^^geo:auspixDggsLiteral ;
+        geo:asDGGS "<https://w3id.org/dggs/aspix> CELLLIST ((R1234 R1235 R1236 ... R1256))"^^eg:auspixDggsLiteral ;
     ] ;
 .
 ```
 
-Here a single `Geometry`, linked to a `Feature` instance, is expressed using two different serializations: Well-known Text and the AusPIX DGGS.
+Here a single `Geometry`, linked to a `Feature` instance, is expressed using two different serializations: Well-known Text and the example AusPIX DGGS. Note that the latter is not formally defined in GeoSPARQL.
 
 ==== B 1.1.4 `SpatialMeasure`
 The `SpatialMeasure` class is defined in <<Class: geo:SpatialMeasure>>.
@@ -292,7 +292,6 @@ _New Features checklist - to be removed when all examples are complete:_
 |kmlLiteral | <<RDFS Datatype: geo:kmlLiteral>>
 |asKML | <<Property: geo:asKML>>
 |dggsWKTLiteral | <<RDFS Datatype: geo:dggsWKTLiteral>>
-|auspixDggsWKTLiteral | <<RDFS Datatype: geo:auspixDggsWKTLiteral>>
 |asDGGS | <<Property: geo:asDGGS>>
 |===
 
@@ -364,6 +363,8 @@ In this example, each of the standards properties defined for a `Geometry` insta
 ==== B.1.2.3 Geometry Serializations
 
 This section shows a `Geometry` instance for a `Feature` instance which is represented in all supported GeoSPARQL serlializations. The geometry values given are real geometry values and approximate link:https://en.wikipedia.org/wiki/Moreton_Island[Moreton Island] in Queensland, Australia.
+
+Note that the concrete DGGS serialization used is for example purposes only as it is not formally defined in GeoSPARQL.
 
 ```turtle
 eg:x
@@ -470,7 +471,7 @@ eg:x
             R834630232 R834630234 R834630235 R834630237 R834630238 R834630240 R834630241 
             R834630242 R834630243 R834630244 R834630245 R834630246 R834630247 R834630261 
             R834630262 R834630264 R834630265 R834630268 R834630270 R834630271 R834630273 
-            R834630276 R834630502))""""^^geo:auspixDggsLiteral ;
+            R834630276 R834630502))""""^^eg:auspixDggsLiteral ;
     ] ;
 .
 ```
@@ -841,4 +842,4 @@ For the geometry literal values in <<B.1.2.3 Geometry Serializations>>:
 
 Application of the function http://www.opengis.net/def/function/geosparql/asWKT[`geof:asWKT`] to the GML, KML, GeoJSON and DGGS literals should return WKT literal and similarly for each of the other conversion methods, http://www.opengis.net/def/function/geosparql/asGML[`geof:asGML`], http://www.opengis.net/def/function/geosparql/asKML[`geof:asKML`], http://www.opengis.net/def/function/geosparql/asGeoJSON[`geof:asGeoJSON`] & http://www.opengis.net/def/function/geosparql/asDGGS[`geof:asDGGS`].
 
-Note that the application of http://www.opengis.net/def/function/geosparql/asDGGS[`geof:asDGGS`] requires a `specificDggsDatatype` parameter which indicates the particular DGGS literal form being converted to. In the case of <<B.1.2.3 Geometry Serializations>>, this value would be http://www.opengis.net/def/function/geosparql/auspixDggsLiteral[`geof:auspixDggsLiteral`], the datatype of the AusPIX DGGS format provided by GeoSPARQL 1.1.
+Note that the application of http://www.opengis.net/def/function/geosparql/asDGGS[`geof:asDGGS`] requires a `specificDggsDatatype` parameter which indicates the particular DGGS literal form being converted to. In the case of <<B.1.2.3 Geometry Serializations>>, this value would be `eg:auspixDggsLiteral`, the example datatype of the AusPIX DGGS.


### PR DESCRIPTION
As discussed two meeting back, here AusPIX DGGS is removed from normative standing but retained as an example for DGGSes.