### PR TITLE
Tidy SO Properties

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -79,7 +79,7 @@
 		sdo:url "https://orcid.org/0000-0002-3313-924X"^^xsd:anyURI ;
 	] ;	
 	dcterms:created "2020-09-09"^^xsd:date ;
-	dcterms:modified "2021-08-29"^^xsd:date ;
+	dcterms:modified "2021-10-25"^^xsd:date ;
 	dcterms:replaces <http://www.opengis.net/ont/geosparql/1.0> ;
 	dcterms:description "An RDF/OWL vocabulary for representing spatial information"@en ;
 	dcterms:source <http://www.opengis.net/doc/IS/geosparql/1.1> , "OGC GeoSPARQL – A Geographic Query Language for RDF Data OGC 11-052r5"@en ;

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -96,7 +96,7 @@
 
 :gmlLiteral
 	a rdfs:Datatype ;
-	rdfs:isDefinedBy <>, <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal>  , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/gml-literal> ;
+	rdfs:isDefinedBy :, <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal>  , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/gml-literal> ;
 	skos:definition """A GML serialization of a geometry object."""@en ;
 	rdfs:seeAlso <https://portal.ogc.org/files/?artifact_id=20509> ; # Can the URI be replaced with one that is guaranteed to be persistent?
 	skos:prefLabel "GML Literal"@en ;
@@ -104,7 +104,7 @@
 
 :wktLiteral
 	a rdfs:Datatype ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/wkt-literal> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/wkt-literal> ;
 	skos:definition """A Well-known Text serialization of a geometry object."""@en ;
 	rdfs:seeAlso <https://portal.ogc.org/files/?artifact_id=25355> ; # Can the URI be replaced with one that is guaranteed to be persistent?
 	skos:prefLabel "Well-known Text Literal"@en ;
@@ -114,7 +114,7 @@
 :geoJSONLiteral
 	a rdfs:Datatype ;
 	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal> ;
 	skos:definition """A GeoJSON serialization of a geometry object."""@en ;
 	skos:prefLabel "GeoJSON Literal"@en ;
 .
@@ -122,14 +122,14 @@
 :kmlLiteral
 	a rdfs:Datatype ;
 	rdfs:seeAlso <https://www.ogc.org/standards/kml/> ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal> ;
 	skos:definition """A KML serialization of a geometry object."""@en ;
 	skos:prefLabel "KML Literal"@en ;
 .
 
 :dggsLiteral
 	a rdfs:Datatype ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/dggs-literal> ;
 	skos:definition """A textual serialization of a Discrete Global Grid (DGGS) geometry object."""@en ;
 	skos:example """ "<https://w3id.org/dggs/auspix> OrdinateList (R3234)"^^<http://www.opengis.net/ont/geosparql#dggsLiteral>""" ;
   rdfs:seeAlso <http://www.opengis.net/doc/AS/dggs/2.0> ;
@@ -144,7 +144,7 @@
 # #################################################################
 
 :defaultGeometry
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:subPropertyOf :hasGeometry ;
 	rdfs:domain :Feature ;
 	rdfs:range :Geometry ;
@@ -156,11 +156,11 @@
 .
 
 :hasDefaultGeometry 
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:subPropertyOf :hasGeometry ;
 	rdfs:domain :Feature ;
 	rdfs:range :Geometry ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/feature-properties> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/feature-properties> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
 	skos:definition """The default geometry to be used in spatial calculations. It is usually the most detailed geometry."""@en ;
 	owl:equivalentProperty :defaultGeometry ;
 	skos:note """Duplicate properties defaultGeometry and hasDefaultGeometry exist because of an inconsistency between ontology and documentation in GeoSPARQL 1.0. Only hasDefaultGeometry is described in the documention.""" ;
@@ -168,153 +168,153 @@
 .
 
 :ehContains 
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*TFF*FF*"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "contains"@en ;
 .
 
 :ehCoveredBy
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFF*TFT**"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "covered by"@en ;
 .
 
 :ehCovers
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: T*TFT*FF*"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "covers"@en ;
 .
 
 :ehDisjoint
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "disjoint"@en ;
 .
 
 :ehEquals
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "equals"@en ;
 .
 
 :ehInside
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFF*FFT**"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "inside"@en ;
 .
 
 :ehMeet
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "meet"@en ;
 .
 
 :ehOverlap
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/eh-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/eh-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "overlap"@en ;
 .
 
 :hasGeometry
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :Feature ;
 	rdfs:range :Geometry ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/feature-properties> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/feature-properties> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
 	skos:definition """A spatial representation for a given feature."""@en ;
 	skos:prefLabel "has geometry"@en ;
 	skos:example geosparql-doc:annexB_example1 ,  geosparql-doc:annexB_example2 , geosparql-doc:annexB_example3 , geosparql-doc:annexB_example4 ;
 .
 
 :hasBoundingBox
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:subPropertyOf :hasGeometry ;
 	rdfs:domain :Feature ;
 	rdfs:range :Geometry ;
-	rdfs:isDefinedBy <> , geosparql-spec: ;
+	rdfs:isDefinedBy : , geosparql-spec: ;
 	skos:definition """The minimum or smallest bounding or enclosing box of a given feature."""@en ;
 	skos:prefLabel "has bounding box"@en ;
 	skos:scopeNote "The target is a geometry that defines a rectilinear region whose edges are aligned with the axes of the coordinate reference system, which exactly contains the Geometry or Feature e.g. sf:Envelope."@en ;
 .
 
 :hasCentroid
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:subPropertyOf :hasGeometry ;
 	rdfs:domain :Feature ;
 	rdfs:range :Geometry ;
-	rdfs:isDefinedBy <> , geosparql-spec: ;
+	rdfs:isDefinedBy : , geosparql-spec: ;
 	skos:definition """The arithmetic mean position of all the geometry points of a given feature."""@en ;
 	skos:prefLabel "has centroid"@en ;
 	skos:scopeNote "The target geometry shall describe a point, e.g. sf:Point."@en ;
 .
 
 :hasLength
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:subPropertyOf :hasSize ;
-	rdfs:isDefinedBy <> ;
+	rdfs:isDefinedBy : ;
 	skos:definition """The length of a Spatial Object."""@en ;
 	skos:prefLabel "has length"@en ;
 	skos:example geosparql-doc:annexB_exampleB.1.1.2.7 ;
 .
 
 :hasPerimeter
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:subPropertyOf :hasSize ;
-	rdfs:isDefinedBy <> ;
+	rdfs:isDefinedBy : ;
 	skos:definition """The perimeter of a Spatial Object."""@en ;
 	skos:prefLabel "has perimeter"@en ;
 .
 
 :hasArea
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:subPropertyOf :hasSize ;
-	rdfs:isDefinedBy <> ;
+	rdfs:isDefinedBy : ;
 	skos:definition """The area of a Spatial Object."""@en ;
 	skos:prefLabel "has area"@en ;
 	skos:example geosparql-doc:annexB_exampleB.1.1.2.4 ;
 .
 
 :hasVolume
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:subPropertyOf :hasSize ;
-	rdfs:isDefinedBy <> ;
+	rdfs:isDefinedBy : ;
 	skos:definition """The volume of a three-dimensional Spatial Object."""@en ;
 	skos:prefLabel "has volume"@en ;
 .	
 
 :hasSpatialResolution
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :Geometry ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
 	skos:definition """The spatial resolution of a Geometry."""@en ;
@@ -323,178 +323,178 @@
 .
 
 :hasSpatialAccuracy
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :Geometry ;
-	rdfs:isDefinedBy <> , geosparql-spec: ;
+	rdfs:isDefinedBy : , geosparql-spec: ;
 	skos:definition """The positional accuracy of the coordinates of a Geometry."""@en ;
 	skos:note """Spatial accuracy is applicable when a Geometry is used to represent a Feature. It is expressed as a distance that indicates the truthfullness of the positions (coordinates) that define the Geometry. In this case accuracy defines a zone surrounding each coordinate within wich the real positions are known to be. The accuracy value defines this zone as a distance from the coordinate(s) in all directions (e.g. a line, a circle or a sphere, depending on spatial dimension)."""@en;
 	skos:prefLabel "has spatial accuracy"@en ;
 .
 
 :rcc8dc
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <>  , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
+	rdfs:isDefinedBy :  , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FFTFFTTTT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "disconnected"@en ;
 .
 
 :rcc8ec
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially meets the object SpatialObject. DE-9IM: FFTFTTTTT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "externally connected"@en ;
 .
 
 :rcc8eq
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "equals"@en ;
 .
 
 :rcc8ntpp
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject is spatially inside the object SpatialObject. DE-9IM: TFFTFFTTT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "non-tangential proper part"@en ;
 .
 
 :rcc8ntppi
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <>, <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations>  , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
+	rdfs:isDefinedBy :, <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations>  , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: TTTFFTFFT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "non-tangential proper part inverse"@en ;
 .
 
 :rcc8po
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: TTTTTTTTT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "partially overlapping"@en ;
 .
 
 :rcc8tpp
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject is spatially covered by the object SpatialObject. DE-9IM: TFFTTFTTT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "tangential proper part"@en ;
 .
 
 :rcc8tppi
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/rcc8-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially covers the object SpatialObject. DE-9IM: TTTFTTFFT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "tangential proper part inverse"@en ;
 .
 
 :sfContains
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially contains the object SpatialObject. DE-9IM: T*****FF*"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "contains"@en ;
 .
 
 :sfCrosses
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially crosses the object SpatialObject. DE-9IM: T*T******"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "crosses"@en ;
 .
 
 :sfDisjoint
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject is spatially disjoint from the object SpatialObject. DE-9IM: FF*FF****"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "disjoint"@en ;
 .
 
 :sfEquals
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially equals the object SpatialObject. DE-9IM: TFFFTFFFT"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "equals"@en ;
 .
 
 :sfIntersects
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject is not spatially disjoint from the object SpatialObject. DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "intersects"@en ;
 .
 
 :sfOverlaps
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially overlaps the object SpatialObject. DE-9IM: T*T***T**"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "overlaps"@en ;
 .
 
 :sfTouches
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject spatially touches the object SpatialObject. DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "touches"@en ;
 .
 
 :sfWithin
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> , <http://www.opengis.net/spec/geosparql/1.1/req/topology-vocab-extension/sf-spatial-relations> ;
 	skos:definition """States that the subject SpatialObject is spatially within the object SpatialObject. DE-9IM: T*F**F***"""@en ;
 	rdfs:seeAlso <http://dbpedia.org/resource/DE-9IM> ;
 	skos:prefLabel "within"@en ;
 .
 
 :hasSize
-	a owl:ObjectProperty ;
+	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
-	rdfs:isDefinedBy <> ;
+	rdfs:isDefinedBy : ;
 	skos:definition """Subproperties of this property are used to indicate the size of a Spatial Object as a measurement or estimate of one or more dimensions of the Spatial Object's spatial presence."""@en ;
 	skos:note """The recommended way to specify size is by using a subproperty of hasMetricSize. Subproperties of hasSize can be used if more complex expressions are necessary, for example if the unit of length can not be converted to meter, or if additional data are needed to describe the measurement or estimate."""@en ;
 	skos:prefLabel "has size"@en ;
@@ -507,21 +507,21 @@
 # #################################################################
 
 :asGML
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:subPropertyOf :hasSerialization ;
 	rdfs:domain :Geometry ;
 	rdfs:range :gmlLiteral ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-gml-literal> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-gml-literal> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-gml-literal> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-gml-literal> ;
 	skos:definition """The GML serialization of a geometry"""@en ;
 	skos:prefLabel "as GML"@en ;
 .
 
 :asWKT
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:subPropertyOf :hasSerialization ;
 	rdfs:domain :Geometry ;
 	rdfs:range :wktLiteral ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-wkt-literal> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-wkt-literal> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-as-wkt-literal> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-wkt-literal> ;
 	skos:definition """The WKT serialization of a geometry"""@en ;
 	skos:prefLabel "as WKT"@en ;
 	skos:example 
@@ -529,39 +529,39 @@
 .
 
 :asGeoJSON
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:subPropertyOf :hasSerialization;
 	rdfs:domain :Geometry ;
 	rdfs:range :geoJSONLiteral ;
 	rdfs:seeAlso <https://tools.ietf.org/html/rfc7946> ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-geojson-literal> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-geojson-literal> ;
 	skos:definition """The GeoJSON serialization of a geometry"""@en ;
 	skos:prefLabel "as GeoJSON"@en ;
 .	
 
 :asKML
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:subPropertyOf :hasSerialization;
 	rdfs:domain :Geometry ;
 	rdfs:range :kmlLiteral ;
 	rdfs:seeAlso <https://www.ogc.org/standards/kml> ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-kml-literal> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-kml-literal> ;
 	skos:definition """The KML serialization of a geometry"""@en ;
 	skos:prefLabel "as KML"@en ;
 .	
 
 :asDGGS
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:subPropertyOf :hasSerialization;
 	rdfs:domain :Geometry ;
 	rdfs:range :dggsLiteral ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-dggs-literal> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-dggs-literal> ;
 	skos:definition """The Discrete Global Grid System (DGGS) serialization of a geometry"""@en ;	
 	skos:prefLabel "as DGGS"@en ;
 .	
 
 :coordinateDimension
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:domain :Geometry ;
 	rdfs:range xsd:integer ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-properties> ;
@@ -570,7 +570,7 @@
 .
 
 :dimension
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:domain :Geometry ;
 	rdfs:range xsd:integer ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-properties> ;
@@ -579,7 +579,7 @@
 .
 
 :hasSerialization
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:domain :Geometry ;
 	rdfs:range rdfs:Literal ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-properties> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-properties> ;
@@ -588,7 +588,7 @@
 .
 
 :isEmpty
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:domain :Geometry ;
 	rdfs:range xsd:boolean ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-properties> ;
@@ -597,7 +597,7 @@
 .
 
 :isSimple
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:domain :Geometry ;
 	rdfs:range xsd:boolean ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-properties> ;
@@ -607,7 +607,7 @@
 .
 
 :spatialDimension
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:domain :Geometry ;
 	rdfs:range xsd:integer ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-properties> ;
@@ -616,64 +616,64 @@
 .
 
 :hasMetricSpatialResolution
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:domain :Geometry ;
 	rdfs:range xsd:double ;
-	rdfs:isDefinedBy <> , geosparql-spec: ;
+	rdfs:isDefinedBy : , geosparql-spec: ;
 	skos:definition """The spatial resolution of a Geometry in meters."""@en ;
 	skos:note """Spatial resolution specifies the level of detail of a Geometry. It the smallest dinstinguishable distance between spatially adjacent coordinates."""@en;
 	skos:prefLabel "has spatial resolution in meters"@en ;
 .
 
 :hasMetricSpatialAccuracy
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:domain :Geometry ;
 	rdfs:range xsd:double ;
-	rdfs:isDefinedBy <> , geosparql-spec: ;
+	rdfs:isDefinedBy : , geosparql-spec: ;
 	skos:definition """The positional accuracy of the coordinates of a Geometry in meters."""@en ;
 	skos:note """Spatial accuracy is applicable when a Geometry is used to represent a Feature. It is expressed as a distance that indicates the truthfullness of the positions (coordinates) that define the Geometry. In this case accuracy defines a zone surrounding each coordinate within wich the real positions are known to be. The accuracy value defines this zone as a distance from the coordinate(s) in all directions (e.g. a line, a circle or a sphere, depending on spatial dimension)."""@en;
 	skos:prefLabel "has spatial accuracy in meters"@en ;
 .
 
 :hasMetricLength
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:subPropertyOf :hasMetricSize ;
-	rdfs:isDefinedBy <> , geosparql-spec: ;
+	rdfs:isDefinedBy : , geosparql-spec: ;
 	skos:definition """The length of a Spatial Object in meters."""@en ;
 	skos:prefLabel "has length in meters"@en ;
 .
 
 :hasMetricPerimeter
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:subPropertyOf :hasMetricSize ;
-	rdfs:isDefinedBy <> , geosparql-spec: ;
+	rdfs:isDefinedBy : , geosparql-spec: ;
 	skos:definition """The perimeter of a Spatial Object in meters."""@en ;
 	skos:prefLabel "has perimeter in meters"@en ;
 .
 
 :hasMetricArea
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:subPropertyOf :hasMetricSize ;
-	rdfs:isDefinedBy <> , geosparql-spec: ;
+	rdfs:isDefinedBy : , geosparql-spec: ;
 	skos:definition """The area of a Spatial Object in square meters."""@en ;
 	skos:prefLabel "has area in square meters"@en ;
 	skos:example geosparql-doc:annexB_exampleB.1.1.2.3, geosparql-doc:annexB_exampleB.1.1.2.9,  geosparql-doc:annexB_exampleB.1.1.3.3 ;
 .
 
 :hasMetricVolume
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:subPropertyOf :hasMetricSize ;
-	rdfs:isDefinedBy <> , geosparql-spec: ;
+	rdfs:isDefinedBy : , geosparql-spec: ;
 	skos:definition """The volume of a Spatial Object in cubic meters."""@en ;
 	skos:prefLabel "has volume in cubic meters"@en ;
 	skos:example geosparql-doc:annexB_exampleB.1.1.2.9 ;
 .
 
 :hasMetricSize
-	a owl:DatatypeProperty ;
+	a rdf:Property, owl:DatatypeProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range xsd:double ;
-	rdfs:isDefinedBy <> ;
+	rdfs:isDefinedBy : ;
 	skos:definition """Subproperties of this property are used to indicate the size of a Spatial Object, as a measurement or estimate of one or more dimensions of the Spatial Object's spatial presence. Units are always metric (meter, square meter or cubic meter)."""@en ;
 	skos:prefLabel "has metric size"@en ;
 .
@@ -685,10 +685,10 @@
 # #################################################################
 
 :Feature
-	a owl:Class ;
+	a rdf:Class, owl:Class ;
 	rdfs:subClassOf :SpatialObject ;
 	owl:disjointWith :Geometry ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/core/feature-class> , <http://www.opengis.net/spec/geosparql/1.1/req/core/feature-class> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/core/feature-class> , <http://www.opengis.net/spec/geosparql/1.1/req/core/feature-class> ;
 	skos:definition """A discrete spatial phenomenon in a universe of discourse."""@en ;
 	skos:note """A Feature represents a uniquely identifiable phenomenon, for example a river or an apple. While such phenomena (and therefore the Features used to represent them) are bounded, their boundaries may be crisp (e.g., the declared boundaries of a state), vague (e.g., the delineation of a valley versus its neighboring mountains), and change with time (e.g., a storm front). While discrete in nature, Features may be created from continuous observations, such as an isochrone that determines the region that can be reached by ambulance within 5 minutes."""@en ;
 	skos:prefLabel "Feature"@en ;
@@ -710,7 +710,7 @@
 .
 
 :FeatureCollection
-	a owl:Class ;
+	a rdf:Class, owl:Class ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/core/feature-collection-class> ;
 	rdfs:subClassOf :SpatialObjectCollection ;
 	rdfs:subClassOf [
@@ -723,9 +723,9 @@
 .
 
 :Geometry
-	a owl:Class ;
+	a rdf:Class, owl:Class ;
 	rdfs:subClassOf :SpatialObject ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-class> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-class> ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-class> , <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-class> ;
 	skos:definition """A coherent set of direct positions in Euclidian space. A direct position holds the coordinates for a position within a Coordinate Reference System (CRS)."""@en ;
 	skos:note """Geometry can be used as a representation of the shape, extent or location of a Feature, or can exist as a self-contained entity."""@en ;
 	skos:prefLabel "Geometry"@en ;
@@ -733,7 +733,7 @@
 .
 
 :GeometryCollection
-	a owl:Class ;
+	a rdf:Class, owl:Class ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/core/geometry-collection-class> ;
 	rdfs:subClassOf :SpatialObjectCollection ;
 	rdfs:subClassOf [
@@ -746,15 +746,15 @@
 .
 
 :SpatialObject
-	a owl:Class ;
-	rdfs:isDefinedBy <> , <http://www.opengis.net/spec/geosparql/1.0/req/core/spatial-object-class> , <http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-object-class> ;
+	a rdf:Class, owl:Class ;
+	rdfs:isDefinedBy : , <http://www.opengis.net/spec/geosparql/1.0/req/core/spatial-object-class> , <http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-object-class> ;
 	skos:definition """Anything spatial (having or being a shape, position or an extent)."""@en ;
 	skos:note """Subclasses are expected to be used for instance data."""@en ;
 	skos:prefLabel "Spatial Object"@en ;
 .
 
 :SpatialObjectCollection
-	a owl:Class ;
+	a rdf:Class, owl:Class ;
 	rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/core/spatial-object-collection-class> ;
 	rdfs:subClassOf rdfs:Container ;
 	rdfs:subClassOf [

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -121,7 +121,41 @@ The restriction imposed on the more general <<Class: SpatialObjectCollection, Sp
 
 === Standard Properties for geo:SpatialObject
 
+Properties are defined for associating Spatial Objects with scalar spatial measurements (sizes) .
+
+|===
+| *Req 7* Implementations shall allow the properties 
+<<Property: geo:hasSize, `geo:hasSize`>>,
+<<Property: geo:hasMetricSize, `geo:hasMetricSize`>>,
+<<Property: geo:hasLength, `geo:hasLength`>>, 
+<<Property: geo:hasMetricLength, `geo:hasMetricLength`>>,
+<<Property: geo:hasPerimeter, `geo:hasPerimeter`>>, 
+<<Property: geo:hasMetricPerimeter, `geo:hasMetricPerimeter`>>, 
+<<Property: geo:hasArea, `geo:hasArea`>>,
+<<Property: geo:hasMetricArea, `geo:hasMetricArea`>>,
+<<Property: geo:hasVolume, `geo:hasVolume`>> and
+<<Property: geo:hasMetricVolume, `geo:hasMetricVolume`>>.
+to be used in SPARQL graph patterns.
+|http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties[`http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties`]
+|===
+
+==== Property: geo:hasSize
+
+The property http://www.opengis.net/ont/geosparql#hasSize[`geo:hasSize`] is the superproperty of all properties that can be used to indicate the size of a Spatial Object in case (only) metric units (meter, square meter or cubic meter) can not be used. If it is possible to express size in metric units, subproperties of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>> should be used.
+This property has not range specification. This makes it possible to use other vocabularies for expressions of size, for example vocabularies for units of measurment or vocabularies for specifying measurement quality.
+
+GeoSPARQL 1.1 defines the following subproperties of this property: <<Property: geo:hasLength, `geo:hasLength`>>, <<Property: geo:hasPerimeter, `geo:hasPerimter`>>, <<Property: geo:hasArea, `geo:hasArea`>> and <<Property: geo:hasVolume, `geo:hasVolume`>>.
+
+```turtle
+:hasSize a owl:ObjectProperty ;
+	rdfs:domain :SpatialObject ;
+	skos:definition "Subproperties of this property are used to indicate the size of a Spatial Object
+	as a measurement or estimate of one or more dimensions of the Spatial Object's spatial presence."@en ;
+	skos:prefLabel "has size"@en .
+```
+
 ==== Property: geo:hasMetricSize
+
 The property http://www.opengis.net/ont/geosparql#hasMetricSize[`geo:hasMetricSize`] is the superproperty of all properties that can be used to indicate the size of a Spatial Object using metric units (meter, square meter or cubic meter). Using a subproperty of this property is the recommended way to specify size, because using a standard unit of length (meter) benefits data interoperability and simplicity. Subproperties of <<Property: geo:hasSize, `geo:hasSize`>> can be used if more complex expressions are necessary, for example if the unit of length can not be converted to meter, or if additional data are needed to describe the measurement or estimate of size.
 
 GeoSPARQL 1.1 defines the following subproperties of this property: <<Property: geo:hasMetricLength, `geo:hasMetricLength`>>, <<Property: geo:hasMetricPerimeter, `geo:hasMetricPerimeter`>>, <<Property: geo:hasMetricArea, `geo:hasMetricArea`>> and <<Property: geo:hasMetricVolume, `geo:hasMetricVolume`>>.
@@ -136,7 +170,19 @@ GeoSPARQL 1.1 defines the following subproperties of this property: <<Property: 
 	skos:prefLabel "has metric size"@en .
 ```
 
+==== Property: geo:hasLength
+
+The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] can be used to indicate the length of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricLength, `geo:hasMetricLength`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
+
+```turtle
+:hasLength a owl:ObjectProperty ;
+	rdfs:subPropertyOf :hasSize ;
+	skos:definition """The length of a Spatial Object."""@en ;
+	skos:prefLabel "has length"@en .
+```
+
 ==== Property: geo:hasMetricLength
+
 The property http://www.opengis.net/ont/geosparql#hasMetricLength[`geo:hasMetricLength`] can be used to indicate the length of a Spatial Object in meters (m). It is a subproperty of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>>. This property can be used for Spatial Objects having one, two, or three dimensions.
 
 ```turtle
@@ -146,7 +192,19 @@ The property http://www.opengis.net/ont/geosparql#hasMetricLength[`geo:hasMetric
 	skos:prefLabel "has length in meters"@en .
 ```
 
+==== Property: geo:hasPerimeter
+
+The property http://www.opengis.net/ont/geosparql#hasPerimeter[`geo:hasPerimeter`] can be used to indicate the length of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricPerimeter, `geo:hasMetricPerimeter`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
+
+```turtle
+:hasLength a owl:ObjectProperty ;
+	rdfs:subPropertyOf :hasSize ;
+	skos:definition """The perimeter of a Spatial Object."""@en ;
+	skos:prefLabel "has perimeter"@en .
+```
+
 ==== Property: geo:hasMetricPerimeter
+
 The property http://www.opengis.net/ont/geosparql#hasMetricPerimeter[`geo:hasMetricPerimeter`] can be used to indicate the length of the outer boundary of a Spatial Object in meters (m). It is a subproperty of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>>. Circumference is considered a type of perimeter, so this property can be used for circular or curved objects too. This property can be used for Spatial Objects having two or three dimensions.
 
 ```turtle
@@ -169,7 +227,20 @@ TIP: A consistency check can be applied to Geometry instances indicating both th
     }
 ```
 
+
+==== Property: geo:hasArea
+
+The property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`] can be used to indicate the area of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricArea, `geo:hasMetricArea`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
+
+```turtle
+:hasArea a owl:ObjectProperty ;
+	rdfs:subPropertyOf :hasSize ;
+	skos:definition """The area of a Spatial Object."""@en ;
+	skos:prefLabel "has area"@en .
+```
+
 ==== Property: geo:hasMetricArea
+
 The property http://www.opengis.net/ont/geosparql#hasMetricArea[`geo:hasMetricArea`] can be used to indicate the area of a Spatial Object in square meters (m^2^). It is a subproperty of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>>. This property can be used for Spatial Objects having two or three dimensions.
 
 ```turtle
@@ -191,7 +262,19 @@ TIP: A consistency check can be applied to Geometry instances indicating both th
     }
 ```
 
+==== Property: geo:hasVolume
+
+The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] can be used to indicate the volume of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricVolume, `geo:hasMetricVolume`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
+
+```turtle
+:hasVolume a owl:ObjectProperty ;
+	rdfs:subPropertyOf :hasSize ;
+	skos:definition """The volume of a three-dimensional Spatial Object."""@en ;
+	skos:prefLabel "has volume"@en .
+```
+
 ==== Property: geo:hasMetricVolume
+
 The property http://www.opengis.net/ont/geosparql#hasMetricVolume[`geo:hasMetricVolume`] can be used to indicate the volume of a Spatial Object in cubic meters (m^3^). It is a subproperty of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>>. This property can be used for Spatial Objects having three dimensions.
 
 ```turtle
@@ -213,75 +296,16 @@ TIP: A consistency check can be applied to Geometries indicating both this prope
     }
 ```
 
-==== Property: geo:hasSize
-The property http://www.opengis.net/ont/geosparql#hasSize[`geo:hasSize`] is the superproperty of all properties that can be used to indicate the size of a Spatial Object in case (only) metric units (meter, square meter or cubic meter) can not be used. If it is possible to express size in metric units, subproperties of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>> should be used.
-This property has not range specification. This makes it possible to use other vocabularies for expressions of size, for example vocabularies for units of measurment or vocabularies for specifying measurement quality.
-
-GeoSPARQL 1.1 defines the following subproperties of this property: <<Property: geo:hasLength, `geo:hasLength`>>, <<Property: geo:hasPerimeter, `geo:hasPerimter`>>, <<Property: geo:hasArea, `geo:hasArea`>> and <<Property: geo:hasVolume, `geo:hasVolume`>>.
-
-```turtle
-:hasSize a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	skos:definition "Subproperties of this property are used to indicate the size of a Spatial Object
-	as a measurement or estimate of one or more dimensions of the Spatial Object's spatial presence."@en ;
-	skos:prefLabel "has size"@en .
-```
-
-==== Property: geo:hasLength
-The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] can be used to indicate the length of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricLength, `geo:hasMetricLength`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
-
-```turtle
-:hasLength a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasSize ;
-	skos:definition """The length of a Spatial Object."""@en ;
-	skos:prefLabel "has length"@en .
-```
-
-==== Property: geo:hasPerimeter
-The property http://www.opengis.net/ont/geosparql#hasPerimeter[`geo:hasPerimeter`] can be used to indicate the length of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricPerimeter, `geo:hasMetricPerimeter`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
-
-```turtle
-:hasLength a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasSize ;
-	skos:definition """The perimeter of a Spatial Object."""@en ;
-	skos:prefLabel "has perimeter"@en .
-```
-
-==== Property: geo:hasArea
-The property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`] can be used to indicate the area of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricArea, `geo:hasMetricArea`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
-
-```turtle
-:hasArea a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasSize ;
-	skos:definition """The area of a Spatial Object."""@en ;
-	skos:prefLabel "has area"@en .
-```
-
-==== Property: geo:hasVolume
-The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] can be used to indicate the volume of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricVolume, `geo:hasMetricVolume`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
-
-```turtle
-:hasVolume a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasSize ;
-	skos:definition """The volume of a three-dimensional Spatial Object."""@en ;
-	skos:prefLabel "has volume"@en .
-```
-
 === Standard Properties for geo:Feature
 
-Properties are defined for associating geometries with features.
+Properties are defined for associating <<Class: geo:Feature, `geo:Feature`>> instances with <<Class: geo:Geometry, `geo:Geometry`>> instances.
 
 |===
 | *Req 7* Implementations shall allow the properties 
 <<Property: geo:hasGeometry, `geo:hasGeometry`>>, 
 <<Property: geo:hasDefaultGeometry, `geo:hasDefaultGeometry`>>, 
-<<Property: geo:hasLength, `geo:hasLength`>>, 
-<<Property: geo:hasPerimeter, `geo:hasPerimeter`>>, 
-<<Property: geo:hasArea, `geo:hasArea`>>, 
-<<Property: geo:hasVolume, `geo:hasVolume`>> 
-<<Property: geo:hasCentroid, `geo:hasCentroid`>>, 
-<<Property: geo:hasBoundingBox, `geo:hasBoundingBox`>> and 
-<<Property: geo:hasSpatialResolution, `geo:hasSpatialResolution`>> 
+<<Property: geo:hasCentroid, `geo:hasCentroid`>> and 
+<<Property: geo:hasBoundingBox, `geo:hasBoundingBox`>>
 to be used in SPARQL graph patterns.
 |http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties[`http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties`]
 |===

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -147,11 +147,15 @@ This property has not range specification. This makes it possible to use other v
 GeoSPARQL 1.1 defines the following subproperties of this property: <<Property: geo:hasLength, `geo:hasLength`>>, <<Property: geo:hasPerimeter, `geo:hasPerimter`>>, <<Property: geo:hasArea, `geo:hasArea`>> and <<Property: geo:hasVolume, `geo:hasVolume`>>.
 
 ```turtle
-:hasSize a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	skos:definition "Subproperties of this property are used to indicate the size of a Spatial Object
-	as a measurement or estimate of one or more dimensions of the Spatial Object's spatial presence."@en ;
-	skos:prefLabel "has size"@en .
+geo:hasSize 
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+	rdfs:domain geo:SpatialObject ;
+	skos:definition "Subproperties of this property are used to indicate the size of a 
+                    Spatial Object as a measurement or estimate of one or more dimensions 
+                    of the Spatial Object's spatial presence."@en ;
+	skos:prefLabel "has size"@en ;
+.
 ```
 
 ==== Property: geo:hasMetricSize
@@ -161,13 +165,17 @@ The property http://www.opengis.net/ont/geosparql#hasMetricSize[`geo:hasMetricSi
 GeoSPARQL 1.1 defines the following subproperties of this property: <<Property: geo:hasMetricLength, `geo:hasMetricLength`>>, <<Property: geo:hasMetricPerimeter, `geo:hasMetricPerimeter`>>, <<Property: geo:hasMetricArea, `geo:hasMetricArea`>> and <<Property: geo:hasMetricVolume, `geo:hasMetricVolume`>>.
 
 ```turtle
-:hasMetricSize a owl:DatatypeProperty ;
-	rdfs:domain :SpatialObject ;
+geo:hasMetricSize 
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+	rdfs:domain geo:SpatialObject ;
 	rdfs:range xsd:double ;
-	skos:definition "Subproperties of this property are used to indicate the size of a Spatial Object, as
-		a measurement or estimate of one or more dimensions of the Spatial Object's spatial presence.
-		Units are always metric (meter,	square meter or cubic meter)."@en ;
-	skos:prefLabel "has metric size"@en .
+	skos:definition "Subproperties of this property are used to indicate the size of a 
+                    Spatial Object, as a measurement or estimate of one or more dimensions 
+                    of the Spatial Object's spatial presence. Units are always metric 
+                    (meter, square meter or cubic meter)."@en ;
+	skos:prefLabel "has metric size"@en ;
+.
 ```
 
 ==== Property: geo:hasLength
@@ -175,10 +183,13 @@ GeoSPARQL 1.1 defines the following subproperties of this property: <<Property: 
 The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] can be used to indicate the length of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricLength, `geo:hasMetricLength`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
 
 ```turtle
-:hasLength a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasSize ;
+geo:hasLength 
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+	rdfs:subPropertyOf geo:hasSize ;
 	skos:definition """The length of a Spatial Object."""@en ;
-	skos:prefLabel "has length"@en .
+	skos:prefLabel "has length"@en ;
+.
 ```
 
 ==== Property: geo:hasMetricLength
@@ -186,10 +197,13 @@ The property http://www.opengis.net/ont/geosparql#hasLength[`geo:hasLength`] can
 The property http://www.opengis.net/ont/geosparql#hasMetricLength[`geo:hasMetricLength`] can be used to indicate the length of a Spatial Object in meters (m). It is a subproperty of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>>. This property can be used for Spatial Objects having one, two, or three dimensions.
 
 ```turtle
-:hasMetricLength a owl:DatatypeProperty ;
-	rdfs:subPropertyOf :hasMetricSize ;
+geo:hasMetricLength 
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+	rdfs:subPropertyOf geo:hasMetricSize ;
 	skos:definition "The length of a Spatial Object in meters."@en ;
-	skos:prefLabel "has length in meters"@en .
+	skos:prefLabel "has length in meters"@en ;
+.
 ```
 
 ==== Property: geo:hasPerimeter
@@ -197,10 +211,13 @@ The property http://www.opengis.net/ont/geosparql#hasMetricLength[`geo:hasMetric
 The property http://www.opengis.net/ont/geosparql#hasPerimeter[`geo:hasPerimeter`] can be used to indicate the length of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricPerimeter, `geo:hasMetricPerimeter`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
 
 ```turtle
-:hasLength a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasSize ;
+geo:hasLength
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+	rdfs:subPropertyOf geo:hasSize ;
 	skos:definition """The perimeter of a Spatial Object."""@en ;
-	skos:prefLabel "has perimeter"@en .
+	skos:prefLabel "has perimeter"@en ;
+.
 ```
 
 ==== Property: geo:hasMetricPerimeter
@@ -208,10 +225,13 @@ The property http://www.opengis.net/ont/geosparql#hasPerimeter[`geo:hasPerimeter
 The property http://www.opengis.net/ont/geosparql#hasMetricPerimeter[`geo:hasMetricPerimeter`] can be used to indicate the length of the outer boundary of a Spatial Object in meters (m). It is a subproperty of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>>. Circumference is considered a type of perimeter, so this property can be used for circular or curved objects too. This property can be used for Spatial Objects having two or three dimensions.
 
 ```turtle
-:hasMetricPerimeter a owl:DatatypeProperty ;
-	rdfs:subPropertyOf :hasMetricSize ;
+geo:hasMetricPerimeter
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+	rdfs:subPropertyOf geo:hasMetricSize ;
 	skos:definition "The perimeter of a Spatial Object in meters."@en ;
-	skos:prefLabel "has perimeter in meters"@en .
+	skos:prefLabel "has perimeter in meters"@en ;
+.
 ```
 
 TIP: A consistency check can be applied to Geometry instances indicating both this property and the property <<Property: geo:dimension, `geo:dimension`>>: if supplied, the <<Property: geo:dimension, `geo:dimension`>> property's range value must be the literal integer 2 or 3. The following SPARQL query will return `true` if applied to a graph where this is not the case for all Geometries:
@@ -233,10 +253,13 @@ TIP: A consistency check can be applied to Geometry instances indicating both th
 The property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`] can be used to indicate the area of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricArea, `geo:hasMetricArea`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
 
 ```turtle
-:hasArea a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasSize ;
+geo:hasArea
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+	rdfs:subPropertyOf geo:hasSize ;
 	skos:definition """The area of a Spatial Object."""@en ;
-	skos:prefLabel "has area"@en .
+	skos:prefLabel "has area"@en ;
+.
 ```
 
 ==== Property: geo:hasMetricArea
@@ -244,15 +267,19 @@ The property http://www.opengis.net/ont/geosparql#hasArea[`geo:hasArea`] can be 
 The property http://www.opengis.net/ont/geosparql#hasMetricArea[`geo:hasMetricArea`] can be used to indicate the area of a Spatial Object in square meters (m^2^). It is a subproperty of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>>. This property can be used for Spatial Objects having two or three dimensions.
 
 ```turtle
-:hasMetricArea a owl:DatatypeProperty ;
-	rdfs:subPropertyOf :hasMetricSize ;
+geo:hasMetricArea
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
+	rdfs:subPropertyOf geo:hasMetricSize ;
 	skos:definition "The area of a Spatial Object in square meters."@en ;
-	skos:prefLabel "has area in meters"@en .
+	skos:prefLabel "has area in meters"@en ;
+.
 ```
 TIP: A consistency check can be applied to Geometry instances indicating both this property and the property <<Property: geo:dimension, `geo:dimension`>>: if supplied, the <<Property: geo:dimension, `geo:dimension`>> property's range value must be the literal integer 2 or 3. The following SPARQL query will return `true` if applied to a graph where this is not the case for all Geometries:
 
 ```sparql
     PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+
     ASK 
     WHERE {
         ?g geo:hasMetricArea ?a ;
@@ -267,10 +294,13 @@ TIP: A consistency check can be applied to Geometry instances indicating both th
 The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] can be used to indicate the volume of a Spatial Object if it is not possible to use the property <<Property: geo:hasMetricVolume, `geo:hasMetricVolume`>>. It is a subproperty of <<Property: geo:hasSize, `geo:hasSize`>>.
 
 ```turtle
-:hasVolume a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasSize ;
+geo:hasVolume
+    a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy geo: ;
+	rdfs:subPropertyOf geo:hasSize ;
 	skos:definition """The volume of a three-dimensional Spatial Object."""@en ;
-	skos:prefLabel "has volume"@en .
+	skos:prefLabel "has volume"@en ;
+.
 ```
 
 ==== Property: geo:hasMetricVolume
@@ -278,15 +308,19 @@ The property http://www.opengis.net/ont/geosparql#hasVolume[`geo:hasVolume`] can
 The property http://www.opengis.net/ont/geosparql#hasMetricVolume[`geo:hasMetricVolume`] can be used to indicate the volume of a Spatial Object in cubic meters (m^3^). It is a subproperty of <<Property: geo:hasMetricSize, `geo:hasMetricSize`>>. This property can be used for Spatial Objects having three dimensions.
 
 ```turtle
-:hasMetricVolume a owl:DatatypeProperty ;
+geo:hasMetricVolume
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:isDefinedBy geo: ;
 	rdfs:subPropertyOf :hasMetricSize ;
 	skos:definition "The volume of a Spatial Object in cubic meters."@en ;
-	skos:prefLabel "has area in meters"@en .
+	skos:prefLabel "has area in meters"@en ;
+.
 ```
 TIP: A consistency check can be applied to Geometries indicating both this property and the property <<Property: geo:dimension, `geo:dimension`>>: if supplied, the property <<Property: geo:dimension, `geo:dimension`>> property's range value must be the literal integer 3. The following SPARQL query will return `true` if applied to a graph where this is not the case for all Geometries:
 
 ```sparql
     PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+
     ASK 
     WHERE {
         ?g geo:hasMetricVolume ?v ;
@@ -321,7 +355,8 @@ geo:hasGeometry
     skos:prefLabel "has Geometry"@en ;
     skos:definition "A spatial representation for a given feature."@en ;     
     rdfs:domain geo:Feature;
-    rdfs:range geo:Geometry .
+    rdfs:range geo:Geometry ;
+.
 ```
 
 ==== Property: geo:hasDefaultGeometry
@@ -337,7 +372,8 @@ geo:hasDefaultGeometry
                     usually the most detailed geometry."@en ; 
     rdfs:subPropertyOf geo:hasGeometry;
     rdfs:domain geo:Feature; 
-    rdfs:range geo:Geometry .
+    rdfs:range geo:Geometry ;
+.
 ```
 
 GeoSPARQL does not restrict the cardinality of the <<Property: geo:hasDefaultGeometry, has default geometry>> property. It is thus possible for a feature to have more than one distinct default geometry or to have no default geometry. This situation does not result in a query processing error; SPARQL graph pattern matching simply proceeds as normal. Certain queries may, however, give logically inconsistent results. For example, if a feature `my:f1` has two asserted default geometries, and those two geometries are disjoint polygons, the query below could return a non-zero count on a system supporting the GeoSPARQL Query Rewrite Extension (rule http://www.opengis.net/def/rule/geosparql/sfDisjoint[`geor:sfDisjoint`]).
@@ -358,15 +394,16 @@ The property http://www.opengis.net/ont/geosparql#hasBoundingBox[`geo:hasBoundin
 ```turtle
 geo:hasBoundingBox 
     a rdf:Property, owl:ObjectProperty ;
-    rdfs:subPropertyOf geo:hasGeometry;
     rdfs:isDefinedBy geo: ;
+    rdfs:subPropertyOf geo:hasGeometry;    
     skos:prefLabel "has bounding box"@en ;
     skos:definition "The minimum or smallest bounding or enclosing box of a given feature."@en ; 
     skos:scopeNote "The target is a geometry that defines a rectilinear region whose edges are 
                     aligned with the axes of the coordinate reference system, which exactly 
                     contains the geometry or feature e.g. sf:Envelope"@en ;
     rdfs:domain geo:Feature ;      
-    rdfs:range geo:Geometry .
+    rdfs:range geo:Geometry ;
+.
 ```
 
 GeoSPARQL does not restrict the cardinality of the <<Property: geo:hasBoundingBox, `geo:hasBoundingBox`>> property. A feature may be associated with more than one bounding-box, for example in different coordinate reference systems.
@@ -378,14 +415,15 @@ The property http://www.opengis.net/ont/geosparql#hasCentroid[`geo:hasCentroid`]
 ```turtle
 geo:hasCentroid 
     a rdf:Property, owl:ObjectProperty ;
-    rdfs:subPropertyOf geo:hasGeometry;
     rdfs:isDefinedBy geo: ;
+    rdfs:subPropertyOf geo:hasGeometry;    
     skos:prefLabel "has centroid"@en ;
     skos:definition "The arithmetic mean position of all the geometry points 
                     of a given feature."@en ; 
     skos:scopeNote "The target geometry shall describe a point, e.g. sf:Point"@en ;
     rdfs:domain geo:Feature ;     
-    rdfs:range geo:Geometry .
+    rdfs:range geo:Geometry ;
+.
 ```
 
 GeoSPARQL does not restrict the cardinality of the <<Property: geo:hasCentroid, `geo:hasCentroid`>> property. A feature may be associated with more than one centroid, for example computed using different rules or in different coordinate reference systems.


### PR DESCRIPTION
The defining RDF in the Spec for the Spatial Object properties (hasSize etc) has been aligned with other defining RDF : formatting & prefixes.

The ontology SO Props have been aligned with the Spec's RDF.