### PR TITLE
Fixes for SHACL shapes

### DIFF
--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -607,7 +607,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S16-wkt-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asWKT ;
-	sh:pattern "^(P|C|S|L|T|<)" ;  # starts with P, C, S, L, T, or < for Point, TIN etc. or IRI
+	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)" ;  # starts with P, C, S, L, T, or < for Point, TIN etc. or IRI
 	sh:message "The content of an RDF literal with an incoming geo:asWKT relation must conform to a well-formed WKT string, as defined by its official specification (Simple Features Access)."@en ;
 	skos:example 
 		"""
@@ -641,7 +641,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S17-gml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGML ;
-	sh:pattern "^(<)(.+)(>)$" ;  # starts with < ends with >
+	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asGML relation must conform to a well-formed GML geometry XML string, as defined by its official specification."@en ;
 .
 
@@ -654,7 +654,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S18-geojson-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGeoJSON ;
-	sh:pattern "^({)(.*)(})$" ;  # starts with { ends with }
+	sh:pattern "^\\s*$|^\\s*({)(.*)(})\\s*$" ;  # starts with { ends with }
 	sh:message "The content of an RDF literal with an incoming geo:asGeoJSON relation must conform to a well-formed GeoJSON geometry string, as defined by its official specification."@en ;
 .
 
@@ -667,7 +667,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S19-kml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asKML ;
-	sh:pattern "^(<)(.+)(>)$" ;  # starts with < ends with >
+	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asKML relation must conform to a well-formed KML geometry XML string, as defined by its official specification."@en ;
 .
 


### PR DESCRIPTION
For our GeoSPARQL benchmark I have tried to validate the benchmark dataset we use with the SHACL shapes.
You can find the dataset here: https://github.com/OpenLinkSoftware/GeoSPARQLBenchmark/blob/master/src/main/resources/gsb_dataset/dataset.rdf

I have changed the following things in the shapes:
- For all literal types: Check also for empty literals and consider whitespace at the beginning and end of regexes. Using pyshacl this does not seem to work for multiline literals though 

I have observed the following behaviors when applying the shapes:
- The benchmark dataset contains the self-defined relations my:hasExactGeometry and my:hasPointGeometry which are rdf:subPropertyOf geo:hasGeometry which cause a validation error when applying the SHACL shapes, but should not
- Shape S32-geometryClass-hasSerialization-sub forces only one geometry serialization for a Geometry and punishes this with a violation error, but S1-b-hasGeometry-hasSerialization-sub just gives a warning. Should we maybe change S32-geometryClass-hasSerialization-sub to check for at least one outgoing geo:hasSerialization?

Any ideas how to fix the last two issues? Can we only do this with reasoning enabled?
@nicholascar @mathib any ideas?