### PR TITLE
Updated requirements to make use of the ogc spec element namespaces

### DIFF
--- a/1.1/reqs.ttl
+++ b/1.1/reqs.ttl
@@ -7,6 +7,7 @@
 @prefix prov: <http://www.w3.org/ns/prov-o/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix spec: <http://www.opengis.net/def/spec-element/> .
 @prefix reqs10: <http://www.opengis.net/spec/geosparql/1.0/req/> .
 @prefix confs10: <http://www.opengis.net/spec/geosparql/1.0/conf/> .
 @prefix confs11: <http://www.opengis.net/spec/geosparql/1.1/conf/> .
@@ -48,14 +49,14 @@
                                                      skos:ConceptScheme .
 
 confs10:core rdf:type 
-                      skos:Collection ;
+                      spec:ConformanceClass, skos:Collection ;
              skos:member conf10core:feature-class ,
                          conf10core:sparql-protocol ,
                          conf10core:spatial-object-class ;
              skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Core"@en .
 
 confs10:geometry-extension rdf:type 
-                                    skos:Concept ;
+                                    spec:ConformanceClass, skos:Collection ;
                            dcterms:requires confs10:core ;
                            skos:member conf10gx:feature-properties ,
                                        conf10gx:geometry-as-gml-literal ,
@@ -73,7 +74,7 @@ confs10:geometry-extension rdf:type
                            skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Geometry Extension"@en .
 
 confs10:geometry-topology-extension rdf:type 
-                                             skos:Collection ;
+                                             spec:ConformanceClass, skos:Collection ;
                                     dcterms:requires confs10:topology-vocab-extension, confs10:geometry-extension ;
                                     skos:member conf10gtx:eh-query-functions ,
                                                 conf10gtx:rcc8-query-functions ,
@@ -82,7 +83,7 @@ confs10:geometry-topology-extension rdf:type
                                     skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Geometry Topology Extension"@en .
 
 confs10:rdfs-entailment-extension rdf:type 
-                                           skos:Collection ;
+                                           spec:ConformanceClass, skos:Collection ;
                                   dcterms:requires confs10:geometry-topology-extension ;
                                   skos:member conf10qre:eh-query-rewrite ,
                                               conf10qre:rcc8-query-rewrite ,
@@ -90,7 +91,7 @@ confs10:rdfs-entailment-extension rdf:type
                                   skos:prefLabel "GeoSPARQL 1.0 Conformance Class: RDFS Entailment Extension"@en .
 
 confs10:topology-vocab-extension rdf:type 
-                                          skos:Concept ;
+                                          spec:ConformanceClass, spec:ConformanceClass ;
                                  dcterms:requires confs10:core ;
                                  skos:member conf10gtx:eh-query-functions ,
                                              conf10gtx:rcc8-query-functions ,
@@ -99,175 +100,175 @@ confs10:topology-vocab-extension rdf:type
                                  skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Topology Vocabulary Extension"@en .
 
 conf10core:feature-class rdf:type 
-                                  skos:Concept ;
-                         geo:testPurpose "check conformance with this requirement" ;
-                         geo:testType geo:Capabilities ;
+                                  spec:ConformanceTest ;
+                         spec:testPurpose "check conformance with this requirement" ;
+                         spec:testType spec:Capabilities ;
                          rdfs:seeAlso reqs10core:feature-class ;
                          skos:definition "Verify that queries involving geo:Feature return the correct result on a test dataset" ;
                          skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Feature Class"@en .
 
 conf10core:sparql-protocol rdf:type 
-                                    skos:Concept ;
-                           geo:testPurpose "check conformance with this requirement" ;
-                           geo:testType geo:Capabilities ;
+                                    spec:ConformanceTest ;
+                           spec:testPurpose "check conformance with this requirement" ;
+                           spec:testType spec:Capabilities ;
                            rdfs:seeAlso reqs10core:sparql-protocol ;
                            skos:definition "Verify that the implementation accepts SPARQL queries and returns the correct results in the correct format, according to the SPARQL Query Language for RDF, the SPARQL Protocol for RDF and SPARQL Query Results XML Format W3C specifications" ;
                            skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SPARQL Protocol"@en .
 
 conf10core:spatial-object-class rdf:type 
-                                         skos:Concept ;
-                                geo:testPurpose "check conformance with this requirement" ;
-                                geo:testType geo:Capabilities ;
+                                         spec:ConformanceTest ;
+                                spec:testPurpose "check conformance with this requirement" ;
+                                spec:testType spec:Capabilities ;
                                 rdfs:seeAlso reqs10core:spatial-object-class ;
                                 skos:definition "Verify that queries involving geo:SpatialObject return the correct result on a test dataset" ;
                                 skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Spatial Object Class"@en .
 
 conf10gx:feature-properties rdf:type 
-                                     skos:Concept ;
-                            geo:testPurpose "check conformance with this requirement" ;
-                            geo:testType geo:Capabilities ;
+                                     spec:ConformanceTest ;
+                            spec:testPurpose "check conformance with this requirement" ;
+                            spec:testType spec:Capabilities ;
                             rdfs:seeAlso reqs10gx:feature-properties ;
                             skos:definition "Verify that queries involving these properties return the correct result for a test dataset" ;
                             skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Feature Properties"@en .
 
 conf10gx:geometry-as-gml-literal rdf:type 
-                                          skos:Concept ;
-                                 geo:testPurpose "check conformance with this requirement" ;
-                                 geo:testType geo:Capabilities ;
+                                          spec:ConformanceTest ;
+                                 spec:testPurpose "check conformance with this requirement" ;
+                                 spec:testType spec:Capabilities ;
                                  rdfs:seeAlso reqs10gx:geometry-as-gml-literal ;
                                  skos:definition "Verify that queries involving the geo:asGML property return the correct result for a test dataset" ;
                                  skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Geometry asGML Literal"@en .
 
 conf10gx:geometry-as-wkt-literal rdf:type 
-                                          skos:Concept ;
-                                 geo:testPurpose "check conformance with this requirement" ;
-                                 geo:testType geo:Capabilities ;
+                                          spec:ConformanceTest ;
+                                 spec:testPurpose "check conformance with this requirement" ;
+                                 spec:testType spec:Capabilities ;
                                  rdfs:seeAlso reqs10gx:geometry-as-wkt-literal ;
                                  skos:definition "Verify that queries involving geo:wktLiteral values return the correct result for a test dataset" ;
                                  skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Geometry asWKT Literal"@en .
 
 conf10gx:geometry-class rdf:type 
-                                 skos:Concept ;
-                        geo:testPurpose "check conformance with this requirement" ;
-                        geo:testType geo:Capabilities ;
+                                 spec:ConformanceTest ;
+                        spec:testPurpose "check conformance with this requirement" ;
+                        spec:testType spec:Capabilities ;
                         rdfs:seeAlso reqs10gx:geometry-class ;
                         skos:definition "Verify that queries involving geo:Geometry return the correct result on a test dataset" ;
                         skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Geometry Class"@en .
 
 conf10gx:geometry-properties rdf:type 
-                                      skos:Concept ;
-                             geo:testPurpose "check conformance with this requirement" ;
-                             geo:testType geo:Capabilities ;
+                                      spec:ConformanceTest ;
+                             spec:testPurpose "check conformance with this requirement" ;
+                             spec:testType spec:Capabilities ;
                              rdfs:seeAlso reqs10gx:geometry-properties ;
                              skos:definition "Verify that queries involving these properties return the correct result for a test dataset" ;
                              skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Geometry Properties"@en .
 
 conf10gx:gml-literal rdf:type 
-                              skos:Concept ;
-                     geo:testPurpose "check conformance with this requirement" ;
-                     geo:testType geo:Capabilities ;
+                              spec:ConformanceTest ;
+                     spec:testPurpose "check conformance with this requirement" ;
+                     spec:testType spec:Capabilities ;
                      rdfs:seeAlso reqs10gx:gml-literal ;
                      skos:definition "Verify that queries involving geo:gmlLiteral values return the correct result for a test dataset" ;
                      skos:prefLabel "GeoSPARQL 1.0 Conformance Test: GML Literal"@en .
 
 conf10gx:gml-literal-empty rdf:type 
-                                    skos:Concept ;
-                           geo:testPurpose "check conformance with this requirement" ;
-                           geo:testType geo:Capabilities ;
+                                    spec:ConformanceTest ;
+                           spec:testPurpose "check conformance with this requirement" ;
+                           spec:testType spec:Capabilities ;
                            rdfs:seeAlso reqs10gx:gml-literal-empty ;
                            skos:definition "Verify that queries involving empty geo:gmlLiteral values return the correct result for a test dataset" ;
                            skos:prefLabel "GeoSPARQL 1.0 Conformance Test: GML Literal Empty"@en .
 
 conf10gx:gml-profile rdf:type 
-                              skos:Concept ;
-                     geo:testPurpose "check conformance with this requirement" ;
-                     geo:testType geo:Capabilities ;
+                              spec:ConformanceTest ;
+                     spec:testPurpose "check conformance with this requirement" ;
+                     spec:testType spec:Capabilities ;
                      rdfs:seeAlso reqs10gx:gml-profile ;
                      skos:definition "Examine the implementation’s documentation to verify that the supported GML profiles are documented" ;
                      skos:prefLabel "GeoSPARQL 1.0 Conformance Test: GML Profile"@en .
 
 conf10gx:query-functions rdf:type 
-                                  skos:Concept ;
-                         geo:testPurpose "check conformance with this requirement" ;
-                         geo:testType geo:Capabilities ;
+                                  spec:ConformanceTest ;
+                         spec:testPurpose "check conformance with this requirement" ;
+                         spec:testType spec:Capabilities ;
                          rdfs:seeAlso reqs10gx:query-functions ;
                          skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:distance, geof:buffer, geof:convexHull, geof:intersection, geof:union, geof:difference,geof:symDifference, geof:envelope and geof:boundary" ;
                          skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Query Functions"@en .
 
 conf10gx:srid-function rdf:type 
-                                skos:Concept ;
-                       geo:testPurpose "check conformance with this requirement" ;
-                       geo:testType geo:Capabilities ;
+                                spec:ConformanceTest ;
+                       spec:testPurpose "check conformance with this requirement" ;
+                       spec:testType spec:Capabilities ;
                        rdfs:seeAlso reqs10gx:srid-function ;
                        skos:definition "Verify that a SPARQL query involving the geof:getSRID function returns the correct result for a test dataset when using the specified serialization and version" ;
                        skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SRID Function"@en .
 
 conf10gx:wkt-axis-order rdf:type 
-                                 skos:Concept ;
-                        geo:testPurpose "check conformance with this requirement" ;
-                        geo:testType geo:Capabilities ;
+                                 spec:ConformanceTest ;
+                        spec:testPurpose "check conformance with this requirement" ;
+                        spec:testType spec:Capabilities ;
                         rdfs:seeAlso reqs10gx:wkt-axis-order ;
                         skos:definition "Verify that queries involving geo:wktLiteral values return the correct result for a test dataset" ;
                         skos:prefLabel "GeoSPARQL 1.0 Conformance Test: WKT Axis Order"@en .
 
 conf10gx:wkt-literal rdf:type 
-                              skos:Concept ;
-                     geo:testPurpose "check conformance with this requirement" ;
-                     geo:testType geo:Capabilities ;
+                              spec:ConformanceTest ;
+                     spec:testPurpose "check conformance with this requirement" ;
+                     spec:testType spec:Capabilities ;
                      rdfs:seeAlso reqs10gx:wkt-literal ;
                      skos:definition "Verify that queries involving geo:wktLiteral values return the correct result for a test dataset" ;
                      skos:prefLabel "GeoSPARQL 1.0 Conformance Test: WKT Literal"@en .
 
 conf10gx:wkt-literal-default-srs rdf:type 
-                                          skos:Concept ;
-                                 geo:testPurpose "check conformance with this requirement" ;
-                                 geo:testType geo:Capabilities ;
+                                          spec:ConformanceTest ;
+                                 spec:testPurpose "check conformance with this requirement" ;
+                                 spec:testType spec:Capabilities ;
                                  rdfs:seeAlso reqs10gx:wkt-literal-default-srs ;
                                  skos:definition "Verify that queries involving geo:wktLiteral values without an explicit encoded spatial reference system URI return the correct result for a test dataset" ;
                                  skos:prefLabel "GeoSPARQL 1.0 Conformance Test: WKT Literal Default SRS"@en .
 
 conf10gx:wkt-literal-empty rdf:type 
-                                    skos:Concept ;
-                           geo:testPurpose "check conformance with this requirement" ;
-                           geo:testType geo:Capabilities ;
+                                    spec:ConformanceTest ;
+                           spec:testPurpose "check conformance with this requirement" ;
+                           spec:testType spec:Capabilities ;
                            rdfs:seeAlso reqs10gx:wkt-literal-empty ;
                            skos:definition "Verify that queries involving geo:wktLiteral values return the correct result for a test dataset" ;
                            skos:prefLabel "GeoSPARQL 1.0 Conformance Test: WKT Literal Empty"@en .
 
 conf10gtx:eh-query-functions rdf:type 
-                                      skos:Concept ;
-                             geo:testPurpose "check conformance with this requirement" ;
-                             geo:testType geo:Capabilities ;
+                                      spec:ConformanceTest ;
+                             spec:testPurpose "check conformance with this requirement" ;
+                             spec:testType spec:Capabilities ;
                              rdfs:seeAlso reqs10gtx:eh-query-functions ;
                              skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:ehEquals, geof:ehDisjoint, geof:ehMeet, geof:ehOverlap, geof:ehCovers, geof:ehCoveredBy, geof:ehInside, geof:ehContains" ;
                              skos:prefLabel "GeoSPARQL 1.0 Conformance Test: EH Query Functions"@en .
 
 conf10gtx:rcc8-query-functions rdf:type 
-                                        skos:Concept ;
-                               geo:testPurpose "check conformance with this requirement" ;
-                               geo:testType geo:Capabilities ;
+                                        spec:ConformanceTest ;
+                               spec:testPurpose "check conformance with this requirement" ;
+                               spec:testType spec:Capabilities ;
                                rdfs:seeAlso reqs10gtx:rcc8-query-functions ;
                                skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:rcc8eq, geof:rcc8dc, geof:rcc8ec, geof:rcc8po, geof:rcc8tppi, geof:rcc8tpp, geof:rcc8ntpp, geof:rcc8ntppi" ;
                                skos:prefLabel "GeoSPARQL 1.0 Conformance Test: RCC8 Query Functions"@en .
 
 conf10gtx:relate-query-function rdf:type 
-                                         skos:Concept ;
-                                geo:testPurpose "check conformance with this requirement" ;
-                                geo:testType geo:Capabilities ;
+                                         spec:ConformanceTest ;
+                                spec:testPurpose "check conformance with this requirement" ;
+                                spec:testType spec:Capabilities ;
                                 rdfs:seeAlso reqs10gtx:relate-query-function ;
                                 skos:definition "Verify that a set of SPARQL queries involving the geof:relate function returns the correct result for a test dataset when using the specified serialization and version" ;
                                 skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Relate Query Function"@en .
 
 conf10gtx:sf-query-functions rdf:type 
-                                      skos:Concept ;
-                             geo:testPurpose "check conformance with this requirement" ;
-                             geo:testType geo:Capabilities ;
+                                      spec:ConformanceTest ;
+                             spec:testPurpose "check conformance with this requirement" ;
+                             spec:testType spec:Capabilities ;
                              rdfs:seeAlso reqs10gtx:sf-query-functions ;
                              skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:sfEquals, geof:sfDisjoint, geof:sfIntersects, geof:sfTouches, geof:sfCrosses, geof:sfWithin, geof:sfContains, geof:sfOverlaps" ;
                              skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SF Query Functions"@en .
 
 confs10:query-rewrite-extension: rdf:type 
-                    skos:Concept ;
+                    spec:ConformanceClass, skos:Collection ;
            dcterms:requires confs10:geometry-topology-extension ;
            skos:member conf10qre:eh-query-rewrite ,
                        conf10qre:rcc8-query-rewrite ,
@@ -275,73 +276,73 @@ confs10:query-rewrite-extension: rdf:type
            skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Query Rewrite Extension"@en .
 
 conf10qre:eh-query-rewrite rdf:type 
-                                    skos:Concept ;
-                           geo:testPurpose "check conformance with this requirement" ;
-                           geo:testType geo:Capabilities ;
+                                    spec:ConformanceTest ;
+                           spec:testPurpose "check conformance with this requirement" ;
+                           spec:testType spec:Capabilities ;
                            rdfs:seeAlso reqs10qre:eh-query-rewrite ;
                            skos:definition "Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: geor:ehEquals, geor:ehDisjoint, geor:ehMeet, geor:ehOverlap, geor:ehCovers, geor:ehCoveredBy, geor:ehInside, geor:ehContains" ;
                            skos:prefLabel "GeoSPARQL 1.0 Conformance Test: EH Query Rewrite"@en .
 
 conf10qre:rcc8-query-rewrite rdf:type 
-                                      skos:Concept ;
-                             geo:testPurpose "check conformance with this requirement" ;
-                             geo:testType geo:Capabilities ;
+                                      spec:ConformanceTest ;
+                             spec:testPurpose "check conformance with this requirement" ;
+                             spec:testType spec:Capabilities ;
                              rdfs:seeAlso reqs10qre:rcc8-query-rewrite ;
                              skos:definition "Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: geor:rcc8eq, geor:rcc8dc, geor:rcc8ec, geor:rcc8po, geor:rcc8tppi, geor:rcc8tpp, geor:rcc8ntpp, geor:rcc8ntppi" ;
                              skos:prefLabel "GeoSPARQL 1.0 Conformance Test: RCC8 Query Rewrite"@en .
 
 conf10qre:sf-query-rewrite rdf:type 
-                                    skos:Concept ;
-                           geo:testPurpose "check conformance with this requirement" ;
-                           geo:testType geo:Capabilities ;
+                                    spec:ConformanceTest ;
+                           spec:testPurpose "check conformance with this requirement" ;
+                           spec:testType spec:Capabilities ;
                            rdfs:seeAlso reqs10qre:sf-query-rewrite ;
                            skos:definition "Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: geor:sfEquals, geor:sfDisjoint, geor:sfIntersects, geor:sfTouches, geor:sfCrosses, geor:sfWithin, geor:sfContains and geor:sfOverlaps" ;
                            skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SF Query Rewrite"@en .
 
 conf10ree:bgp-rdfs-ent rdf:type 
-                                skos:Concept ;
-                       geo:testPurpose "check conformance with this requirement" ;
-                       geo:testType geo:Capabilities ;
+                                spec:ConformanceTest ;
+                       spec:testPurpose "check conformance with this requirement" ;
+                       spec:testType spec:Capabilities ;
                        rdfs:seeAlso reqs10ree:bgp-rdfs-ent ;
                        skos:definition "Verify that a set of SPARQL queries involving entailed RDF triples returns the correct result for a test dataset using the specified serialization, version and relation_family" ;
                        skos:prefLabel "GeoSPARQL 1.0 Conformance Test: BGP RDFS Entailment"@en .
 
 conf10ree:gml-geometry-types rdf:type 
-                                      skos:Concept ;
-                             geo:testPurpose "check conformance with this requirement" ;
-                             geo:testType geo:Capabilities ;
+                                      spec:ConformanceTest ;
+                             spec:testPurpose "check conformance with this requirement" ;
+                             spec:testType spec:Capabilities ;
                              rdfs:seeAlso reqs10ree:gml-geometry-types ;
                              skos:definition "Verify that a set of SPARQL queries involving GML Geometry types returns the correct result for a test dataset using the specified version of GML" ;
                              skos:prefLabel "GeoSPARQL 1.0 Conformance Test: GML Geometry Types"@en .
 
 conf10ree:wkt-geometry-types rdf:type 
-                                      skos:Concept ;
-                             geo:testPurpose "check conformance with this requirement" ;
-                             geo:testType geo:Capabilities ;
+                                      spec:ConformanceTest ;
+                             spec:testPurpose "check conformance with this requirement" ;
+                             spec:testType spec:Capabilities ;
                              rdfs:seeAlso reqs10ree:wkt-geometry-types ;
                              skos:definition "Verify that a set of SPARQL queries involving WKT Geometry types returns the correct result for a test dataset using the specified version of Simple Features" ;
                              skos:prefLabel "GeoSPARQL 1.0 Conformance Test: WKT Geometry Types"@en .
 
 conf10tve:eh-spatial-relations rdf:type 
-                                        skos:Concept ;
-                               geo:testPurpose "check conformance with this requirement" ;
-                               geo:testType geo:Capabilities ;
+                                        spec:ConformanceTest ;
+                               spec:testPurpose "check conformance with this requirement" ;
+                               spec:testType spec:Capabilities ;
                                rdfs:seeAlso reqs10tve:eh-spatial-relations ;
                                skos:definition "Verify that queries involving these properties return the correct result for a test dataset" ;
                                skos:prefLabel "GeoSPARQL 1.0 Conformance Test: EH Spatial Relations"@en .
 
 conf10tve:rcc8-spatial-relations rdf:type 
-                                          skos:Concept ;
-                                 geo:testPurpose "check conformance with this requirement" ;
-                                 geo:testType geo:Capabilities ;
+                                          spec:ConformanceTest ;
+                                 spec:testPurpose "check conformance with this requirement" ;
+                                 spec:testType spec:Capabilities ;
                                  rdfs:seeAlso reqs10tve:rcc8-spatial-relations ;
                                  skos:definition "Verify that queries involving these properties return the correct result for a test dataset" ;
                                  skos:prefLabel "GeoSPARQL 1.0 Conformance Test: RCC8 Spatial Relations"@en .
 
 conf10tve:sf-spatial-relations rdf:type 
-                                        skos:Concept ;
-                               geo:testPurpose "check conformance with this requirement" ;
-                               geo:testType geo:Capabilities ;
+                                        spec:ConformanceTest ;
+                               spec:testPurpose "check conformance with this requirement" ;
+                               spec:testType spec:Capabilities ;
                                rdfs:seeAlso reqs10tve:sf-spatial-relations ;
                                skos:definition "Verify that queries involving these properties return the correct result for a test dataset" ;
                                skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SF Spatial Relations"@en .
@@ -407,158 +408,158 @@ reqs10:geosparql11reqs rdf:type
                        skos:prefLabel "GeoSPARQL 1.1 Requirements" .
 
 reqs10core:feature-class rdf:type 
-                                  skos:Concept ;
+                                  spec:Requirement ;
                          skos:definition "Implementations shall allow the RDFS class geo:Feature to be used in SPARQL graph patterns" ;
                          skos:prefLabel "GeoSPARQL 1.0 Requirement: Feature Class"@en .
 
 reqs10core:sparql-protocol rdf:type 
-                                    skos:Concept ;
+                                    spec:Requirement ;
                            skos:definition "Implementations shall support the SPARQL Query Language for RDF, the SPARQL Protocol for RDF and the SPARQL Query Results XML Format" ;
                            skos:prefLabel "GeoSPARQL 1.0 Requirement: SPARQL Protocol"@en .
 
 reqs10core:spatial-object-class rdf:type 
-                                         skos:Concept ;
+                                         spec:Requirement ;
                                 skos:definition "Implementations shall allow the RDFS class geo:SpatialObject to be used in SPARQL graph patterns" ;
                                 skos:prefLabel "GeoSPARQL 1.0 Requirement: Spatial Object Class"@en .
 
 reqs10gx:feature-properties rdf:type 
-                                     skos:Concept ;
+                                     spec:Requirement ;
                             skos:definition "Implementations shall allow the properties geo:hasGeometry and geo:hasDefaultGeometry to be used in SPARQL graph patterns" ;
                             skos:prefLabel "GeoSPARQL 1.0 Requirement: Feature Properties"@en .
 
 reqs10gx:geometry-as-gml-literal rdf:type 
-                                          skos:Concept ;
+                                          spec:Requirement ;
                                  skos:definition "Implementations shall allow the RDF property geo:asGML to be used in SPARQL graph patterns" ;
                                  skos:prefLabel "GeoSPARQL 1.0 Requirement:  Geometry asGML Literal"@en .
 
 reqs10gx:geometry-as-wkt-literal rdf:type 
-                                          skos:Concept ;
+                                          spec:Requirement ;
                                  skos:definition "Implementations shall allow the RDF property geo:asWKT to be used in SPARQL graph patterns" ;
                                  skos:prefLabel "GeoSPARQL 1.0 Requirement: Geometry asWKT Literal"@en .
 
 reqs10gx:geometry-class rdf:type 
-                                 skos:Concept ;
+                                 spec:Requirement ;
                         skos:definition "Implementations shall allow the RDFS class geo:Geometry to be used in SPARQL graph patterns" ;
                         skos:prefLabel "GeoSPARQL 1.0 Requirement: Geometry Class"@en .
 
 reqs10gx:geometry-properties rdf:type 
-                                      skos:Concept ;
+                                      spec:Requirement ;
                              skos:definition "Implementations shall allow the properties geo:dimension, geo:coordinateDimension, geo:spatialDimension, geo:isEmpty, geo:isSimple, geo:hasSerialization to be used in SPARQL graph patterns" ;
                              skos:prefLabel "GeoSPARQL 1.0 Requirement: Geometry Properties"@en .
 
 reqs10gx:gml-literal rdf:type 
-                              skos:Concept ;
+                              spec:Requirement ;
                      skos:definition "All geo:gmlLiterals shall consist of a valid element from the GML schema that implements a subtype of GM_Object as defined in [OGC 07-036]" ;
                      skos:prefLabel "GeoSPARQL 1.0 Requirement: GML Literal"@en .
 
 reqs10gx:gml-literal-empty rdf:type 
-                                    skos:Concept ;
+                                    spec:Requirement ;
                            skos:requires reqs10gx:gml-literal ;
                            skos:definition "An empty geo:gmlLiteral shall be interpreted as an empty geometry" ;
                            skos:prefLabel "GeoSPARQL 1.0 Requirement: GML Literal Empty"@en .
 
 reqs10gx:gml-profile rdf:type 
-                              skos:Concept ;
+                              spec:Requirement ;
                      skos:definition "Implementations shall document supported GML profiles" ;
                      skos:prefLabel "GeoSPARQL 1.0 Requirement: GML Profile"@en .
 
 reqs10gx:query-functions rdf:type 
-                                  skos:Concept ;
+                                  spec:Requirement ;
                          skos:definition "Implementations shall support geof:distance, geof:buffer, geof:convexHull, geof:intersection, geof:union, geof:difference, geof:symDifference, geof:envelope and geof:boundary as SPARQL extension functions, consistent with the definitions of the corresponding functions (distance, buffer, convexHull, intersection, difference, symDifference, envelope and boundary respectively) in Simple Features [ISO 19125-1]" ;
                          skos:prefLabel "GeoSPARQL 1.0 Requirement: Query Functions"@en .
 
 reqs10gx:srid-function rdf:type 
-                                skos:Concept ;
+                                spec:Requirement ;
                        skos:definition "Implementations shall support geof:getSRID as a SPARQL extension function" ;
                        skos:prefLabel "GeoSPARQL 1.0 Requirement: SRID Function"@en .
 
 reqs10gx:wkt-axis-order rdf:type 
-                                 skos:Concept ;
+                                 spec:Requirement ;
                         skos:definition "Coordinate tuples within geo:wktLiterals shall be interpreted using the axis order defined in the spatial reference system used" ;
                         skos:prefLabel "GeoSPARQL 1.0 Requirement: WKT Axis Order"@en .
 
 reqs10gx:wkt-literal rdf:type 
-                              skos:Concept ;
+                              spec:Requirement ;
                      skos:definition "All RDFS Literals of type geo:wktLiteral shall consist of an optional URI identifying the coordinate reference system followed by Simple Features Well Known Text (WKT) describing a geometric value. Valid geo:wktLiterals are formed by concatenating a valid, absolute URI as defined in [RFC 2396], one or more spaces U+0020 character) as a separator, and a WKT string as defined in Simple Features [ISO 19125-1]" ;
                      skos:prefLabel "GeoSPARQL 1.0 Requirement: WKT Literal"@en .
 
 reqs10gx:wkt-literal-default-srs rdf:type 
-                                          skos:Concept ;
+                                          spec:Requirement ;
                                  skos:definition "The URI <http://www.opengis.net/def/crs/OGC/1.3/CRS84> shall be assumed as the spatial reference system for geo:wktLiterals that do not specify an explicit spatial reference system URI" ;
                                  skos:prefLabel "GeoSPARQL 1.0 Requirement: WKT Literal Default SRS"@en .
 
 reqs10gx:wkt-literal-empty rdf:type 
-                                    skos:Concept ;
+                                    spec:Requirement ;
                            skos:definition "An empty RDFS Literal of type geo:wktLiteral shall be interpreted as an empty geometry" ;
                            skos:prefLabel "GeoSPARQL 1.0 Requirement: WKT Literal Empty"@en .
 
 reqs10gtx:eh-query-functions rdf:type 
-                                      skos:Concept ;
+                                      spec:Requirement ;
                              skos:definition "Implementations shall support geof:ehEquals, geof:ehDisjoint, geof:ehMeet, geof:ehOverlap, geof:ehCovers, geof:ehCoveredBy, geof:ehInside, geof:ehContains as SPARQL extension functions, consistent with their corresponding DE9IM intersection patterns, as defined by Simple Features [ISO 19125-1]" ;
                              skos:prefLabel "GeoSPARQL 1.0 Requirement: EH Query Functions"@en .
 
 reqs10gtx:rcc8-query-functions rdf:type 
-                                        skos:Concept ;
+                                        spec:Requirement ;
                                skos:definition "Implementations shall support geof:rcc8eq, geof:rcc8dc, geof:rcc8ec, geof:rcc8po, geof:rcc8tppi, geof:rcc8tpp, geof:rcc8ntpp, geof:rcc8ntppi as SPARQL extension functions, consistent with their corresponding DE-9IM intersection patterns, as defined by Simple Features [ISO 19125-1]" ;
                                skos:prefLabel "GeoSPARQL 1.0 Requirement: RCC8 Query Functions"@en .
 
 reqs10gtx:relate-query-function rdf:type 
-                                         skos:Concept ;
+                                         spec:Requirement ;
                                 skos:definition "Implementations shall support geof:relate as a SPARQL extension function, consistent with the relate operator defined in Simple Features [ISO 19125-1]" ;
                                 skos:prefLabel "GeoSPARQL 1.0 Requirement: Relate Query Function"@en .
 
 reqs10gtx:sf-query-functions rdf:type 
-                                      skos:Concept ;
+                                      spec:Requirement ;
                              skos:definition "Implementations shall support geof:sfEquals, geof:sfDisjoint, geof:sfIntersects, geof:sfTouches, geof:sfCrosses, geof:sfWithin, geof:sfContains, geof:sfOverlaps as  SPARQL extension functions, consistent with their corresponding DE9IM intersection patterns, as defined by Simple Features [ISO 19125-1]" ;
                              skos:prefLabel "GeoSPARQL 1.0 Requirement: SF Query Functions"@en .
 
 reqs10qre:eh-query-rewrite rdf:type 
-                                    skos:Concept ;
+                                    spec:Requirement ;
                            skos:definition "Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime [W3C SPARQL Entailment] for the RIF rules [W3C RIF Core] geor:ehEquals, geor:ehDisjoint, geor:ehMeet, geor:ehOverlap, geor:ehCovers, geor:ehCoveredBy, geor:ehInside, geor:ehContains" ;
                            skos:prefLabel "GeoSPARQL 1.0 Requirement: EH Query Rewrite"@en .
 
 reqs10qre:rcc8-query-rewrite rdf:type 
-                                      skos:Concept ;
+                                      spec:Requirement ;
                              skos:definition "Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime [W3C SPARQL Entailment] for the RIF rules [W3C RIF Core] geor:rcc8eq, geor:rcc8dc, geor:rcc8ec, geor:rcc8po, geor:rcc8tppi, geor:rcc8tpp, geor:rcc8ntpp, geor:rcc8ntppi" ;
                              skos:prefLabel "GeoSPARQL 1.0 Requirement: RCC8 Query Rewrite"@en .
 
 reqs10qre:sf-query-rewrite rdf:type 
-                                    skos:Concept ;
+                                    spec:Requirement ;
                            skos:definition "Basic graph pattern matching shall use the semantics defined by the RIF Core Entailment Regime [W3C SPARQL Entailment] for the RIF rules [W3C RIF Core] geor:sfEquals, geor:sfDisjoint, geor:sfIntersects, geor:sfTouches, geor:sfCrosses, geor:sfWithin, geor:sfContains, geor:sfOverlaps" ;
                            skos:prefLabel "GeoSPARQL 1.0 Requirement: SF Query Rewrite"@en .
 
 reqs10ree:bgp-rdfs-ent rdf:type 
-                                skos:Concept ;
+                                spec:Requirement ;
                        skos:definition "Basic graph pattern matching shall use the semantics defined by the RDFS Entailment Regime [W3C SPARQL Entailment]" ;
                        skos:prefLabel "GeoSPARQL 1.0 Requirement: BGP RDFS Entailment"@en .
 
 reqs10ree:gml-geometry-types rdf:type 
-                                      skos:Concept ;
+                                      spec:Requirement ;
                              skos:definition "Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the GML schema that implements GM_Object using the specified version of GML [OGC 07-036]" ;
                              skos:prefLabel "GeoSPARQL 1.0 Requirement: GML Geometry Types"@en .
 
 reqs10ree:wkt-geometry-types rdf:type 
-                                      skos:Concept ;
+                                      spec:Requirement ;
                              skos:definition "Implementations shall support graph patterns involving terms from an RDFS/OWL class hierarchy of geometry types consistent with the one in the specified version of Simple Features [ISO 19125-1]" ;
                              skos:prefLabel "GeoSPARQL 1.0 Requirement: WKT Geometry Types"@en .
 
 reqs10tve:eh-spatial-relations rdf:type 
-                                        skos:Concept ;
+                                       spec:Requirement ;
                                skos:definition "Implementations shall allow the properties geo:ehEquals, geo:ehDisjoint, geo:ehMeet, geo:ehOverlap, geo:ehCovers, geo:ehCoveredBy, geo:ehInside, geo:ehContains to be used in SPARQL graph patterns" ;
                                skos:prefLabel "GeoSPARQL 1.0 Requirement: EH Spatial Relations"@en .
 
 reqs10tve:rcc8-spatial-relations rdf:type 
-                                          skos:Concept ;
+                                          spec:Requirement ;
                                  skos:definition "Implementations shall allow the properties geo:rcc8eq, geo:rcc8dc, geo:rcc8ec, geo:rcc8po, geo:rcc8tppi, geo:rcc8tpp, geo:rcc8ntpp, geo:rcc8ntppi to be used in SPARQL graph patterns" ;
                                  skos:prefLabel "GeoSPARQL 1.0 Requirement: RCC8 Spatial Relations"@en .
 
 reqs10tve:sf-spatial-relations rdf:type 
-                                        skos:Concept ;
+                                        spec:Requirement ;
                                skos:definition "Implementations shall allow the properties geo:sfEquals, geo:sfDisjoint, geo:sfIntersects, geo:sfTouches, geo:sfCrosses, geo:sfWithin, geo:sfContains, geo:sfOverlaps to be used in SPARQL graph patterns" ;
                                skos:prefLabel "GeoSPARQL 1.0 Requirement: SF Spatial Relations"@en .
 
 confs11:core rdf:type 
-                      skos:Collection ;
+                      spec:ConformanceClass, skos:Collection ;
              skos:member conf11core:feature-collection-class ,
                          conf11core:geometry-collection-class ,
                          conf11core:sparql-protocol ,
@@ -566,7 +567,7 @@ confs11:core rdf:type
              skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Core"@en .
 
 confs11:geometry-extension rdf:type 
-                                    skos:Concept ;
+                                    spec:ConformanceClass, skos:Collection ;
                             dcterms:requires confs11:geometry-extension ;
                            skos:member conf10gx:geometry-class ,
                                        conf11gx:dggs-literal ,
@@ -588,328 +589,328 @@ confs11:geometry-extension rdf:type
                            skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Geometry Extension"@en .
 
 confs11:geometry-topology-extension rdf:type 
-                                             skos:Concept ;
+                                             spec:ConformanceClass, skos:Collection ;
                                     dcterms:requires confs11:geometry-extension, confs11:topology-vocab-extension ;
                                     skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Geometry Topology Extension"@en .
 
 confs11:rdfs-entailment-extension rdf:type 
-                                           skos:Collection ;
+                                           spec:ConformanceClass, skos:Collection ;
                                   dcterms:requires confs11:geometry-topology-extension ;
                                   skos:prefLabel "GeoSPARQL 1.1 Conformance Class: RDFS Entailment Extension"@en .
 
 confs11:topology-vocab-extension rdf:type 
-                                          skos:Concept ;
+                                          spec:ConformanceClass, skos:Collection ;
                                  dcterms:requires confs11:core ;
                                  skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Topology Vocabulary Extension"@en .
 
 conf11core:feature-collection-class rdf:type 
-                                             skos:Concept ;
-                                    geo:testPurpose "check conformance with this requirement" ;
-                                    geo:testType geo:Capabilities ;
+                                             spec:ConformanceTest ;
+                                    spec:testPurpose "check conformance with this requirement" ;
+                                    spec:testType spec:Capabilities ;
                                     skos:definition "Verify that queries involving geo:FeatureCollection return the correct result on a test dataset" ;
                                     skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Feature Collection Class"@en .
 
 conf11core:geometry-collection-class rdf:type 
-                                              skos:Concept ;
-                                     geo:testPurpose "check conformance with this requirement" ;
-                                     geo:testType geo:Capabilities ;
+                                              spec:ConformanceTest ;
+                                     spec:testPurpose "check conformance with this requirement" ;
+                                     spec:testType spec:Capabilities ;
                                      skos:definition "Verify that queries involving geo:GeometryCollection return the correct result on a test dataset" ;
                                      skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Geometry Collection Class"@en .
 
 conf11core:sparql-protocol rdf:type 
-                                    skos:Concept ;
-                           geo:testPurpose "check conformance with this requirement" ;
-                           geo:testType geo:Capabilities ;
+                                    spec:ConformanceTest ;
+                           spec:testPurpose "check conformance with this requirement" ;
+                           spec:testType spec:Capabilities ;
                            rdfs:seeAlso reqs11core:sparql-protocol ;
                            skos:definition "Verify that the implementation accepts SPARQL queries and returns the correct results in the correct format, according to the SPARQL Query Language for RDF, the SPARQL Protocol for RDF and SPARQL Query Results XML Format W3C specifications" ;
                            skos:prefLabel "GeoSPARQL 1.1 Conformance Test: SPARQL Protocol"@en ;
                            prov:wasDerivedFrom conf10core:sparql-protocol .
 
 conf11gx:dggs-literal rdf:type 
-                               skos:Concept ;
-                      geo:testPurpose "check conformance with this requirement" ;
-                      geo:testType geo:Capabilities ;
+                               spec:ConformanceTest ;
+                      spec:testPurpose "check conformance with this requirement" ;
+                      spec:testType spec:Capabilities ;
                       rdfs:seeAlso reqs11gx:dggs-literal ;
                       skos:definition "Verify that queries do not use use this datatype but instead use specializations of it" ;
                       skos:prefLabel "GeoSPARQL 1.1 Conformance Test: DGGS Literal"@en .
 
 conf11gx:dggs-literal-empty rdf:type 
-                                     skos:Concept ;
-                            geo:testPurpose "check conformance with this requirement" ;
-                            geo:testType geo:Capabilities ;
+                                     spec:ConformanceTest ;
+                            spec:testPurpose "check conformance with this requirement" ;
+                            spec:testType spec:Capabilities ;
                             rdfs:seeAlso reqs11gx:dggs-literal-empty ;
                             skos:definition "Verify that queries involving empty geo:dggsLiteral values return the correct result for a test dataset" ;
                             skos:prefLabel "GeoSPARQL 1.1 Conformance Test: DGGS Literal Empty"@en .
 
 conf11gx:feature-properties rdf:type 
-                                     skos:Concept ;
-                            geo:testPurpose "check conformance with this requirement" ;
-                            geo:testType geo:Capabilities ;
+                                     spec:ConformanceTest ;
+                            spec:testPurpose "check conformance with this requirement" ;
+                            spec:testType spec:Capabilities ;
                             rdfs:seeAlso reqs11gx:feature-properties ;
                             skos:definition "Verify that queries involving these properties return the correct result for a test dataset" ;
                             skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Feature Properties"@en .
 
 conf11gx:geojson-literal rdf:type 
-                                  skos:Concept ;
-                         geo:testPurpose "check conformance with this requirement" ;
-                         geo:testType geo:Capabilities ;
+                                 spec:ConformanceTest ;
+                         spec:testPurpose "check conformance with this requirement" ;
+                         spec:testType spec:Capabilities ;
                          rdfs:seeAlso reqs11gx:geojson-literal ;
                          skos:definition "Verify that queries involving geo:geoJSONLiteral values return the correct result for a test dataset" ;
                          skos:prefLabel "GeoSPARQL 1.1 Conformance Test: GeoJSON Literal"@en .
 
 conf11gx:geojson-literal-empty rdf:type 
-                                        skos:Concept ;
-                               geo:testPurpose "check conformance with this requirement" ;
-                               geo:testType geo:Capabilities ;
+                                        spec:ConformanceTest ;
+                               spec:testPurpose "check conformance with this requirement" ;
+                               spec:testType spec:Capabilities ;
                                rdfs:seeAlso reqs11gx:geojson-literal-empty ;
                                skos:definition "Verify that queries involving geo:kmlLiteral values without an explicit encoded SRS IRI return the correct result for a test dataset" ;
                                skos:prefLabel "GeoSPARQL 1.1 Conformance Test: KML Literal Empty"@en .
 
 conf11gx:geojson-literal-srs rdf:type 
-                                      skos:Concept ;
-                             geo:testPurpose "check conformance with this requirement" ;
-                             geo:testType geo:Capabilities ;
+                                      spec:ConformanceTest ;
+                             spec:testPurpose "check conformance with this requirement" ;
+                             spec:testType spec:Capabilities ;
                              rdfs:seeAlso reqs11gx:geojson-literal-srs ;
                              skos:definition "Verify that queries involving geo:geoJSONLiteral values without an explicit encoded SRS IRI return the correct result for a test dataset" ;
                              skos:prefLabel "GeoSPARQL 1.1 Conformance Test: GeoJSON Literal Default SRS"@en .
 
 conf11gx:geometry-as-dggs-function rdf:type 
-                                            skos:Concept ;
-                                   geo:testPurpose "check conformance with this requirement" ;
-                                   geo:testType geo:Capabilities ;
+                                            spec:ConformanceTest ;
+                                   spec:testPurpose "check conformance with this requirement" ;
+                                   spec:testType spec:Capabilities ;
                                    rdfs:seeAlso reqs11gx:geometry-as-dggs-function ;
                                    skos:definition "Verify that a set of SPARQL queries involving the geof:asDGGS function returns the correct result for a test dataset when using the specified serialization and version" ;
                                    skos:prefLabel "GeoSPARQL 1.1 Conformance Test: asDGGS Function"@en .
 
 conf11gx:geometry-as-dggs-literal rdf:type 
-                                           skos:Concept ;
-                                  geo:testPurpose "check conformance with this requirement" ;
-                                  geo:testType geo:Capabilities ;
+                                           spec:ConformanceTest ;
+                                  spec:testPurpose "check conformance with this requirement" ;
+                                  spec:testType spec:Capabilities ;
                                   rdfs:seeAlso reqs11gx:geometry-as-dggs-literal ;
                                   skos:definition "Verify that queries involving the geo:asDGGS property return the correct result for a test dataset" ;
                                   skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Geometry asDGGS Literal"@en .
 
 conf11gx:geometry-as-geojson-function rdf:type 
-                                               skos:Concept ;
-                                      geo:testPurpose "check conformance with this requirement" ;
-                                      geo:testType geo:Capabilities ;
+                                               spec:ConformanceTest ;
+                                      spec:testPurpose "check conformance with this requirement" ;
+                                      spec:testType spec:Capabilities ;
                                       rdfs:seeAlso reqs11gx:geometry-as-geojson-function ;
                                       skos:definition "Verify that a set of SPARQL queries involving the geof:asGeoJSON function returns the correct result for a test dataset when using the specified serialization and version" ;
                                       skos:prefLabel "GeoSPARQL 1.1 Conformance Test: asGeoJSON Function"@en .
 
 conf11gx:geometry-as-geojson-literal rdf:type 
-                                              skos:Concept ;
-                                     geo:testPurpose "check conformance with this requirement" ;
-                                     geo:testType geo:Capabilities ;
+                                             spec:ConformanceTest ;
+                                     spec:testPurpose "check conformance with this requirement" ;
+                                     spec:testType spec:Capabilities ;
                                      rdfs:seeAlso reqs11gx:geometry-as-geojson-literal ;
                                      skos:definition "Verify that queries involving the geo:asGeoJSON property return the correct result for a test dataset" ;
                                      skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Geometry asGeoJSON Literal"@en .
 
 conf11gx:geometry-as-gml-function rdf:type 
-                                           skos:Concept ;
-                                  geo:testPurpose "check conformance with this requirement" ;
-                                  geo:testType geo:Capabilities ;
+                                           spec:ConformanceTest ;
+                                  spec:testPurpose "check conformance with this requirement" ;
+                                  spec:testType spec:Capabilities ;
                                   rdfs:seeAlso reqs11gx:geometry-as-gml-function ;
                                   skos:definition "Verify that a set of SPARQL queries involving the geof:asGML function returns the correct result for a test dataset when using the specified serialization and version" ;
                                   skos:prefLabel "GeoSPARQL 1.1 Conformance Test: asGML Function"@en .
 
 conf11gx:geometry-as-kml-function rdf:type 
-                                           skos:Concept ;
-                                  geo:testPurpose "check conformance with this requirement" ;
-                                  geo:testType geo:Capabilities ;
+                                           spec:ConformanceTest ;
+                                  spec:testPurpose "check conformance with this requirement" ;
+                                  spec:testType spec:Capabilities ;
                                   rdfs:seeAlso reqs11gx:geometry-as-kml-function ;
                                   skos:definition "Verify that a set of SPARQL queries involving the geof:asKML function returns the correct result for a test dataset when using the specified serialization and version" ;
                                   skos:prefLabel "GeoSPARQL 1.1 Conformance Test: asKML Function"@en .
 
 conf11gx:geometry-as-kml-literal rdf:type 
-                                          skos:Concept ;
-                                 geo:testPurpose "check conformance with this requirement" ;
-                                 geo:testType geo:Capabilities ;
+                                          spec:ConformanceTest ;
+                                 spec:testPurpose "check conformance with this requirement" ;
+                                 spec:testType spec:Capabilities ;
                                  rdfs:seeAlso reqs11gx:geometry-as-kml-literal ;
                                  skos:definition "Verify that queries involving the geo:asKML property return the correct result for a test dataset" ;
                                  skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Geometry asKML Literal"@en .
 
 conf11gx:geometry-as-wkt-function rdf:type 
-                                           skos:Concept ;
-                                  geo:testPurpose "check conformance with this requirement" ;
-                                  geo:testType geo:Capabilities ;
+                                           spec:ConformanceTest ;
+                                  spec:testPurpose "check conformance with this requirement" ;
+                                  spec:testType spec:Capabilities ;
                                   rdfs:seeAlso reqs11gx:geometry-as-wkt-function ;
                                   skos:definition "Verify that a set of SPARQL queries involving the geof:asWKT function returns the correct result for a test dataset when using the specified serialization and version" ;
                                   skos:prefLabel "GeoSPARQL 1.1 Conformance Test: asWKT Function"@en .
 
 conf11gx:geometry-properties rdf:type 
-                                      skos:Concept ;
-                             geo:testPurpose "check conformance with this requirement" ;
-                             geo:testType geo:Capabilities ;
+                                      spec:ConformanceTest ;
+                             spec:testPurpose "check conformance with this requirement" ;
+                             spec:testType spec:Capabilities ;
                              rdfs:seeAlso reqs11gx:geometry-properties ;
                              skos:definition "Verify that queries involving these properties return the correct result for a test dataset" ;
                              skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Geometry Properties"@en .
 
 conf11gx:kml-literal rdf:type 
-                              skos:Concept ;
-                     geo:testPurpose "check conformance with this requirement" ;
-                     geo:testType geo:Capabilities ;
+                              spec:ConformanceTest ;
+                     spec:testPurpose "check conformance with this requirement" ;
+                     spec:testType spec:Capabilities ;
                      rdfs:seeAlso reqs11gx:kml-literal ;
                      skos:definition "Verify that queries involving geo:kmlLiteral values return the correct result for a test dataset" ;
                      skos:prefLabel "GeoSPARQL 1.1 Conformance Test: KML Literal"@en .
 
 conf11gx:kml-literal-empty rdf:type 
-                                    skos:Concept ;
-                           geo:testPurpose "check conformance with this requirement" ;
-                           geo:testType geo:Capabilities ;
+                                    spec:ConformanceTest ;
+                           spec:testPurpose "check conformance with this requirement" ;
+                           spec:testType spec:Capabilities ;
                            rdfs:seeAlso reqs11gx:kml-literal-empty ;
                            skos:definition "Verify that queries involving geo:geoJSONLiteral values without an explicit encoded SRS IRI return the correct result for a test dataset" ;
                            skos:prefLabel "GeoSPARQL 1.1 Conformance Test: GeoJSON Literal Empty"@en .
 
 conf11gx:kml-literal-srs rdf:type 
-                                  skos:Concept ;
-                         geo:testPurpose "check conformance with this requirement" ;
-                         geo:testType geo:Capabilities ;
+                                  spec:ConformanceTest ;
+                         spec:testPurpose "check conformance with this requirement" ;
+                         spec:testType spec:Capabilities ;
                          rdfs:seeAlso reqs11gx:kml-literal-srs ;
                          skos:definition "Verify that queries involving geo:kmlLiteral values without an explicit encoded SRS IRI return the correct result for a test dataset" ;
                          skos:prefLabel "GeoSPARQL 1.1 Conformance Test: KML Literal Default SRS"@en .
 
 conf11gx:query-functions rdf:type 
-                                  skos:Concept ;
-                         geo:testPurpose "check conformance with this requirement" ;
-                         geo:testType geo:Capabilities ;
+                                  spec:ConformanceTest ;
+                         spec:testPurpose "check conformance with this requirement" ;
+                         spec:testType spec:Capabilities ;
                          rdfs:seeAlso reqs11gx:query-functions ;
                          skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:distance, geof:buffer, geof:convexHull, geof:intersection, geof:union, geof:difference,geof:symDifference, geof:envelope and geof:boundary" ;
                          skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Query Functions"@en .
 
 conf11gx:sa-functions rdf:type 
-                               skos:Concept ;
-                      geo:testPurpose "check conformance with this requirement" ;
-                      geo:testType geo:Capabilities ;
+                               spec:ConformanceTest ;
+                      spec:testPurpose "check conformance with this requirement" ;
+                      spec:testType spec:Capabilities ;
                       rdfs:seeAlso reqs11gx:sa-functions ;
                       skos:definition "Verify that queries involving these functions return the correct result for a test dataset" ;
                       skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Spatial Aggregate Functions"@en .
 
 conf11qre: rdf:type 
-                    skos:Concept ;
+                    spec:ConformanceClass ;
            dcterms:requires confs11:geometry-topology-extension ;
            skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Query Rewrite Extension"@en .
 
 reqs11core:feature-collection-class rdf:type 
-                                             skos:Concept ;
+                                             spec:Requirement ;
                                     skos:definition "Implementations shall allow the RDFS class geo:FeatureCollection to be used in SPARQL graph patterns" ;
                                     skos:prefLabel "GeoSPARQL 1.1 Requirement: Feature Collection Class"@en .
 
 reqs11core:geometry-collection-class rdf:type 
-                                              skos:Concept ;
+                                              spec:Requirement ;
                                      skos:definition "Implementations shall allow the RDFS class geo:GeometryCollection to be used in SPARQL graph patterns" ;
                                      skos:prefLabel "GeoSPARQL 1.1 Requirement: Geometry Collection Class"@en .
 
 reqs11core:sparql-protocol rdf:type 
-                                    skos:Concept ;
+                                    spec:Requirement ;
                            skos:definition "Implementations shall support the SPARQL Query Language for RDF [SPARQL], the SPARQL Protocol [SPARQLPROT] and the SPARQL Query Results XML [SPARQLRESX] and JSON [SPARQLRESJ] Formats" ;
                            skos:prefLabel "GeoSPARQL 1.1 Requirement: SPARQL Protocol"@en ;
                            prov:wasDerivedFrom reqs10core:sparql-protocol .
 
 reqs11core:spatial-object-collection-class rdf:type 
-                                                    skos:Concept ;
+                                                    spec:Requirement ;
                                            skos:definition "Implementations shall allow the RDFS class geo:SpatialObjectCollection to be used in SPARQL graph patterns" ;
                                            skos:prefLabel "GeoSPARQL 1.1 Requirement: Spatial Object Collection Class"@en .
 
 reqs11gx:dggs-literal rdf:type 
-                               skos:Concept ;
+                               spec:Requirement ;
                       skos:definition "All RDFS Literals of type geo:dggsLiteral shall consist of a DGGS geometry serialization formulated according to a specific DGGS literal type identified by a datatype specializing this generic datatype" ;
                       skos:prefLabel "GeoSPARQL 1.1 Requirement: DGGS Literal"@en .
 
 reqs11gx:dggs-literal-empty rdf:type 
-                                     skos:Concept ;
+                                     spec:Requirement ;
                             skos:definition "An empty geo:dggsLiteral shall be interpreted as an empty geometry" ;
                             skos:prefLabel "GeoSPARQL 1.1 Requirement: DGGS Literal Empty"@en .
 
 reqs11gx:feature-properties rdf:type 
-                                     skos:Concept ;
+                                     spec:Requirement ;
                             skos:definition "Implementations shall allow the properties geo:hasGeometry, geo:hasDefaultGeometry, geo:hasLength, geo:hasArea, geo:hasVolume geo:hasCentroid, geo:hasBoundingBox and geo:hasSpatialResolution to be used in SPARQL graph patterns" ;
                             skos:prefLabel "GeoSPARQL 1.1 Requirement: Feature Properties"@en ;
                             prov:wasDerivedFrom reqs10gx:feature-properties .
 
 reqs11gx:geojson-literal rdf:type 
-                                  skos:Concept ;
+                                  spec:Requirement ;
                          skos:definition "All geo:geoJSONLiteral instances shall consist of the Geometry objects as defined in the GeoJSON specification [GEOJSON]" ;
                          skos:prefLabel "GeoSPARQL 1.1 Requirement: GeoJSON Literal"@en .
 
 reqs11gx:geojson-literal-empty rdf:type 
-                                        skos:Concept ;
+                                        spec:Requirement ;
                                skos:definition "An empty geo:kmlLiteral shall be interpreted as an empty geometry" ;
                                skos:prefLabel "GeoSPARQL 1.1 Requirement: KML Literal Empty"@en .
 
 reqs11gx:geojson-literal-srs rdf:type 
-                                      skos:Concept ;
+                                      spec:Requirement ;
                              skos:definition "RDFS Literals of type geo:geoJSONLiteral do not contain a SRS definition. All literals of this type shall, according to the GeoJSON specification, be encoded only in, and be assumed to use, the WGS84 geodetic longitude-latitude spatial reference system (http://www.opengis.net/def/crs/OGC/1.3/CRS84)" ;
                              skos:prefLabel "GeoSPARQL 1.1 Requirement: GeoJSON Literal Default SRS"@en .
 
 reqs11gx:geometry-as-dggs-function rdf:type 
-                                            skos:Concept ;
+                                            spec:Requirement ;
                                    skos:definition "Implementations shall support geof:asDGGS, as a SPARQL extension function" ;
                                    skos:prefLabel "GeoSPARQL 1.1 Requirement: asDGGS Function"@en .
 
 reqs11gx:geometry-as-dggs-literal rdf:type 
-                                           skos:Concept ;
+                                           spec:Requirement ;
                                   skos:definition "Implementations shall allow the RDF property geo:asDGGS to be used in SPARQL graph patterns" ;
                                   skos:prefLabel "GeoSPARQL 1.1 Requirement: Geometry asDGGS Literal"@en .
 
 reqs11gx:geometry-as-geojson-function rdf:type 
-                                               skos:Concept ;
+                                               spec:Requirement ;
                                       skos:definition "Implementations shall support geof:asGeoJSON, as a SPARQL extension function" ;
                                       skos:prefLabel "GeoSPARQL 1.1 Requirement: asGeoJSON Function"@en .
 
 reqs11gx:geometry-as-geojson-literal rdf:type 
-                                              skos:Concept ;
+                                              spec:Requirement ;
                                      skos:definition "Implementations shall allow the RDF property geo:asGeoJSON to be used in SPARQL graph patterns" ;
                                      skos:prefLabel "GeoSPARQL 1.1 Requirement: Geometry asGeoJSON Literal"@en .
 
 reqs11gx:geometry-as-gml-function rdf:type 
-                                           skos:Concept ;
+                                           spec:Requirement ;
                                   skos:definition "Implementations shall support geof:asGML, as a SPARQL extension function" ;
                                   skos:prefLabel "GeoSPARQL 1.1 Requirement: asGML Function"@en .
 
 reqs11gx:geometry-as-kml-function rdf:type 
-                                           skos:Concept ;
+                                           spec:Requirement ;
                                   skos:definition "Implementations shall support geof:asKML, as a SPARQL extension function" ;
                                   skos:prefLabel "GeoSPARQL 1.1 Requirement: asKML Function"@en .
 
 reqs11gx:geometry-as-kml-literal rdf:type 
-                                          skos:Concept ;
+                                          spec:Requirement ;
                                  skos:definition "Implementations shall allow the RDF property geo:asKML to be used in SPARQL graph patterns" ;
                                  skos:prefLabel "GeoSPARQL 1.1 Requirement: Geometry asKML Literal"@en .
 
 reqs11gx:geometry-as-wkt-function rdf:type 
-                                           skos:Concept ;
+                                           spec:Requirement ;
                                   skos:definition "Implementations shall support geof:asWKT, as a SPARQL extension function" ;
                                   skos:prefLabel "GeoSPARQL 1.1 Requirement: asWKT Function"@en .
 
 reqs11gx:geometry-properties rdf:type 
-                                      skos:Concept ;
+                                      spec:Requirement ;
                              skos:definition "Implementations shall allow the properties geo:dimension, geo:coordinateDimension, geo:spatialDimension, geo:isEmpty, geo:isSimple, geo:hasSerialization to be used in SPARQL graph patterns" ;
                              skos:prefLabel "GeoSPARQL 1.1 Requirement: Geometry Properties"@en ;
                              prov:wasDerivedFrom reqs10gx:geometry-properties .
 
 reqs11gx:kml-literal rdf:type 
-                              skos:Concept ;
+                              spec:Requirement ;
                      skos:definition "All geo:kmlLiteral instances shall consist of the Geometry objects as defined in the KML specification [OGCKML]" ;
                      skos:prefLabel "GeoSPARQL 1.1 Requirement: KML Literal"@en .
 
 reqs11gx:kml-literal-empty rdf:type 
-                                    skos:Concept ;
+                                    spec:Requirement ;
                            skos:definition "An empty geo:geoJSONLiteral shall be interpreted as an empty geometry" ;
                            skos:prefLabel "GeoSPARQL 1.1 Requirement: GeoJSON Literal Empty"@en .
 
 reqs11gx:kml-literal-srs rdf:type 
-                                  skos:Concept ;
+                                  spec:Requirement ;
                          skos:definition "The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84 shall be assumed as the SRS for geo:kmlLiterals that do not specify an explicit SRS IRI" ;
                          skos:prefLabel "GeoSPARQL 1.1 Requirement: KML Literal Default SRS"@en .
 
 reqs11gx:query-functions rdf:type 
-                                  skos:Concept ;
+                                  spec:Requirement ;
                          skos:definition "Implementations shall support geof:distance, geof:buffer, geof:convexHull, geof:intersection,  geof:union, geof:isEmpty, geof:isSimple, geof:area, geof:length, geof:numGeometries, geof:geometryN, geof:dimension, geof:difference, geof:symDifference, geof:envelope and geof:boundary as SPARQL extension functions, consistent with the definitions of the corresponding functions (distance, buffer, convexHull, intersection, isEmpty, isSimple, area, length, , numGeometries, geometryN, dimension, difference, symDifference, envelope and boundary respectively) in Simple Features [ISO 19125-1]" ;
                          skos:prefLabel "GeoSPARQL 1.1 Requirement: Query Functions"@en ;
                          prov:wasDerivedFrom reqs10gx:query-functions .
 
 reqs11gx:sa-functions rdf:type 
-                               skos:Concept ;
+                               spec:Requirement ;
                       skos:definition "Implementations shall support geof:concaveHull, geof:boundingCircle, geof:union2, geof:concatLines, geof:centroid, geof:maxX, geof:maxY, geof:maxZ, geof:minX, geof:minY and geof:minZ as a SPARQL extension functions." ;
                       skos:prefLabel "GeoSPARQL 1.1 Requirement: Spatial Aggregate Functions"@en .

--- a/1.1/reqs.ttl
+++ b/1.1/reqs.ttl
@@ -91,7 +91,7 @@ confs10:rdfs-entailment-extension rdf:type
                                   skos:prefLabel "GeoSPARQL 1.0 Conformance Class: RDFS Entailment Extension"@en .
 
 confs10:topology-vocab-extension rdf:type 
-                                          spec:ConformanceClass, spec:ConformanceClass ;
+                                          spec:ConformanceClass, skos:Collection ;
                                  dcterms:requires confs10:core ;
                                  skos:member conf10gtx:eh-query-functions ,
                                              conf10gtx:rcc8-query-functions ,

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -607,7 +607,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S16-wkt-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asWKT ;
-	sh:pattern "^(P|C|S|L|T|<)" ;  # starts with P, C, S, L, T, or < for Point, TIN etc. or IRI
+	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)" ;  # starts with P, C, S, L, T, or < for Point, TIN etc. or IRI
 	sh:message "The content of an RDF literal with an incoming geo:asWKT relation must conform to a well-formed WKT string, as defined by its official specification (Simple Features Access)."@en ;
 	skos:example 
 		"""
@@ -641,7 +641,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S17-gml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGML ;
-	sh:pattern "^(<)(.+)(>)$" ;  # starts with < ends with >
+	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asGML relation must conform to a well-formed GML geometry XML string, as defined by its official specification."@en ;
 .
 
@@ -654,7 +654,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S18-geojson-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGeoJSON ;
-	sh:pattern "^({)(.*)(})$" ;  # starts with { ends with }
+	sh:pattern "^\\s*$|^\\s*({)(.*)(})\\s*$" ;  # starts with { ends with }
 	sh:message "The content of an RDF literal with an incoming geo:asGeoJSON relation must conform to a well-formed GeoJSON geometry string, as defined by its official specification."@en ;
 .
 
@@ -667,7 +667,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S19-kml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asKML ;
-	sh:pattern "^(<)(.+)(>)$" ;  # starts with < ends with >
+	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asKML relation must conform to a well-formed KML geometry XML string, as defined by its official specification."@en ;
 .
 

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -607,7 +607,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S16-wkt-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asWKT ;
-	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)" ;  # starts with P, C, S, L, T, or < for Point, TIN etc. or IRI
+	sh:pattern "^(P|C|S|L|T|<)" ;  # starts with P, C, S, L, T, or < for Point, TIN etc. or IRI
 	sh:message "The content of an RDF literal with an incoming geo:asWKT relation must conform to a well-formed WKT string, as defined by its official specification (Simple Features Access)."@en ;
 	skos:example 
 		"""
@@ -641,7 +641,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S17-gml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGML ;
-	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
+	sh:pattern "^(<)(.+)(>)$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asGML relation must conform to a well-formed GML geometry XML string, as defined by its official specification."@en ;
 .
 
@@ -654,7 +654,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S18-geojson-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGeoJSON ;
-	sh:pattern "^\\s*$|^\\s*({)(.*)(})\\s*$" ;  # starts with { ends with }
+	sh:pattern "^({)(.*)(})$" ;  # starts with { ends with }
 	sh:message "The content of an RDF literal with an incoming geo:asGeoJSON relation must conform to a well-formed GeoJSON geometry string, as defined by its official specification."@en ;
 .
 
@@ -667,7 +667,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S19-kml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asKML ;
-	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
+	sh:pattern "^(<)(.+)(>)$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asKML relation must conform to a well-formed KML geometry XML string, as defined by its official specification."@en ;
 .
 


### PR DESCRIPTION
Elements in reqs.ttl are now associated with the <http://www.opengis.net/def/spec-element/> namespace as defined by OGC.
