### PR TITLE
license & rights added to all assets

### DIFF
--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -19,6 +19,8 @@
     owl:imports <http://www.opengis.net/def/ogc-na> ;
     owl:versionIRI <http://defs-dev.opengis.net/static/definitions/conceptschemes/functions_geosparql.ttl> ;
     skos:definition "A vocabulary (taxonomy) of the functions and rules defined within the GeoSPARQL 1.1 specification"@en ;
+    dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
+	dcterms:rights "(c) 2021 Open Geospatial Consortium" ;    
     skos:hasTopConcept
         funcs:area,
 		funcs:asDGGS,

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -81,6 +81,8 @@
 	dcterms:modified "2021-10-27"^^xsd:date ;
 	dcterms:replaces <http://www.opengis.net/ont/geosparql/1.0> ;
 	dcterms:description "An RDF/OWL vocabulary for representing spatial information"@en ;
+	dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
+	dcterms:rights "(c) 2021 Open Geospatial Consortium" ;
 	dcterms:source <http://www.opengis.net/doc/IS/geosparql/1.1> , "OGC GeoSPARQL – A Geographic Query Language for RDF Data OGC 11-052r5"@en ;
 	rdfs:seeAlso <http://www.opengis.net/doc/IS/geosparql/1.1> ;
 	owl:versionInfo "OGC GeoSPARQL 1.1" ;

--- a/1.1/profile.html
+++ b/1.1/profile.html
@@ -246,9 +246,13 @@ EAfDe6H3Dy6Ll456WEJsRZS630MwCAOI20ei5OBpxse5zcBZw8eS4uPpfIuDiCainIg9umBCU0GZzgLZ
         <dd>2021-06-16</dd>
         <dt><a class="proplink" href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/issued">Issued</a></dt>
         <dd>2021-01-01</dd>
-        <dt>Version URI</dt>
+        <dt><a class="proplink" href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/license">License</a></dt>
+        <dd><a href="https://www.ogc.org/license">OGC License</a></dd>
+        <dt><a class="proplink" href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/rights">Copyright</a></dt>
+        <dd>(c) 2021 Open Geospatial Consortium</dd> 
+        <dt>Version IRI</dt>
         <dd><a href="http://www.opengis.net/def/geosparql/1.1">http://www.opengis.net/def/geosparql/1.1</a></dd>
-        <dt>Profile RDF</dt>
+        <dt>RDF Source</dt>
         <dd><a href="profile.ttl">RDF (turtle)</a></dd>
     </dl>
       <dt><a class="proplink" href="https://www.w3.org/TR/dx-prof/#Property:hasResource">Has Resource Descriptor(s)</a></dt>

--- a/1.1/profile.ttl
+++ b/1.1/profile.ttl
@@ -23,6 +23,8 @@
 	  ] ;
     dcterms:title "GeoSPARQL 1.1 Profile" ;
     dcterms:description """This is a 'profile declaration' for the GeoSPARQL 1.1 specification (standard). It describes the multiple parts of the specification and how the standard relates to other standards. It is formulated according to the Profiles Vocabulary."""@en ;
+	dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
+	dcterms:rights "(c) 2021 Open Geospatial Consortium" ;    
     skos:scopeNote """Profile declarations are used to allow data to identify specifications in a way that allows data to make conformance claims to them - a broader conformance claim than that made to individual 'conformance classes' that are commonly found in recent OGC specifications. Profile declarations are also used to describe and relate the often multiple parts of specifications: ontologies, specification 'documents', vocabularies, validators and so on. This declaration describes where those parts are, what form (format) they take, what information models they implement and what roles they play."""@en ;
     prof:hasResource 
         <http://www.opengis.net/doc/IS/geosparql/1.1> ,

--- a/1.1/reqs.ttl
+++ b/1.1/reqs.ttl
@@ -43,6 +43,8 @@
                                              dcterms:modified "2021-07-13"^^xsd:date ;
                                              rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
                                              skos:definition "A vocabulary of the requirements and conformance classes in the GeoSPARQL 1.1 specification"@en ;
+                                             dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
+	                                     dcterms:rights "(c) 2021 Open Geospatial Consortium" ;
                                              skos:prefLabel "GeoSPARQL 1.1 Requirements and Conformance Class Register" .
 
 <http://www.opengis.net/def/geosparql/reqs> rdf:type 

--- a/1.1/sa_functions.ttl
+++ b/1.1/sa_functions.ttl
@@ -15,6 +15,8 @@
     dcterms:modified "2021-02-27"^^xsd:date ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A vocabulary (taxonomy) of the spatial aggregate functions defined within the GeoSPARQL 1.1 specification"@en ;
+    dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
+	dcterms:rights "(c) 2021 Open Geospatial Consortium" ;
     skos:hasTopConcept
         geof:aggBoundingBox,
         geof:aggBoundingCircle,

--- a/1.1/sf_geometries.ttl
+++ b/1.1/sf_geometries.ttl
@@ -1,6 +1,6 @@
 @base <http://www.opengis.net/ont/sf> .
 
-@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -10,11 +10,13 @@
 
 <http://www.opengis.net/ont/sf> a owl:Ontology ;
     owl:imports <http://www.opengis.net/ont/geosparql> ;
-    dc:title "Simple Features Vocabulary" ;
-	dc:creator "Open Geospatial Consortium"^^xsd:string ;
-	dc:date "2012-09-11"^^xsd:date ;
-	dc:modified "2022-06-03"^^xsd:date ;
-	dc:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types"^^xsd:string ;
+    dcterms:title "Simple Features Vocabulary" ;
+	dcterms:creator "Open Geospatial Consortium"^^xsd:string ;
+	dcterms:date "2012-09-11"^^xsd:date ;
+	dcterms:modified "2021-12-15"^^xsd:date ;
+	dcterms:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types"^^xsd:string ;
+    dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
+	dcterms:rights "(c) 2021 Open Geospatial Consortium" ;    
 	owl:versionInfo "OGC GeoSPARQL 1.1"^^xsd:string .
 
 sf:Curve a rdfs:Class,

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -23,6 +23,8 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
 	dcterms:created "2021-06-13"^^xsd:date ;
 	dcterms:modified "2021-08-12"^^xsd:date ;
+    dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
+	dcterms:rights "(c) 2021 Open Geospatial Consortium" ; 	
 	owl:versionInfo "OGC GeoSPARQL 1.1" ;
 	owl:versionIRI <http://www.opengis.net/def/geosparql/validator/1.1> ;
 .


### PR DESCRIPTION
Closes #60

Although we haven't attained a full RDF license, we have a stable reference in all assets for now. We will replace this with an RDF reference IF the OGC presents one before 1.1 is released, if not, the RDF version can be referenced in future GeoSPARQL work. 