### PR TITLE
Update geo.ttl

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -336,7 +336,7 @@
 		<http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
 	skos:definition """The minimum or smallest bounding or enclosing box of a given Feature."""@en ;
 	skos:prefLabel "has bounding box"@en ;
-	skos:scopeNote "The target is a Geometry that defines a rectilinear region whose edges are aligned with the axes of the coordinate reference system, which exactly contains the Geometry or Feature e.g. sf:Envelope."@en ;
+	skos:scopeNote "The target is a Geometry that defines a rectilinear region whose edges are aligned with the axes of the coordinate reference system, which exactly contains the Feature, for example an instance of http://www.opengis.net/ont/sf#envelope."@en ;
 	skos:example
 		spec11:B.1.2.2 ;
 .


### PR DESCRIPTION
Improve the scopenote of hasBoundingBox because

- the property cannot be used with Geometry in the subject position
- the namespace `sf` is unknown in the context of the GeoSPARQL ontology