### PR TITLE
declare equivalence of topological properties

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -252,7 +252,7 @@
 
 :ehEquals
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :rcc8eq, :sfEquals ;
+	owl:equivalentProperty :sfEquals ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy
@@ -467,7 +467,6 @@
 
 :rcc8eq
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :ehEquals, :sfEquals ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy 
@@ -586,7 +585,7 @@
 
 :sfEquals
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :ehEquals, :rcc8eq ;
+	owl:equivalentProperty :ehEquals ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy 

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -238,6 +238,7 @@
 
 :ehDisjoint
 	a rdf:Property, owl:ObjectProperty ;
+	owl:equivalentProperty :sfDisjoint ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy
@@ -251,7 +252,7 @@
 
 :ehEquals
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :rcc8eq ;
+	owl:equivalentProperty :rcc8eq, :sfEquals ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy
@@ -278,6 +279,7 @@
 
 :ehMeet
 	a rdf:Property, owl:ObjectProperty ;
+	owl:equivalentProperty :sfTouches ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy
@@ -465,7 +467,7 @@
 
 :rcc8eq
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :ehEquals ;
+	owl:equivalentProperty :ehEquals, :sfEquals ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy 
@@ -570,6 +572,7 @@
 
 :sfDisjoint
 	a rdf:Property, owl:ObjectProperty ;
+	owl:equivalentProperty :ehDisjoint ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy 
@@ -583,6 +586,7 @@
 
 :sfEquals
 	a rdf:Property, owl:ObjectProperty ;
+	owl:equivalentProperty :ehEquals, :rcc8eq ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy 
@@ -622,6 +626,7 @@
 
 :sfTouches
 	a rdf:Property, owl:ObjectProperty ;
+	owl:equivalentProperty :ehMeet ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy 

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -251,6 +251,7 @@
 
 :ehEquals
 	a rdf:Property, owl:ObjectProperty ;
+	owl:equivalentProperty :rcc8eq ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy
@@ -464,6 +465,7 @@
 
 :rcc8eq
 	a rdf:Property, owl:ObjectProperty ;
+	owl:equivalentProperty :ehEquals ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy 


### PR DESCRIPTION
Declare equivalence of topological relationships in different families. Resolves [issue 267](https://github.com/opengeospatial/ogc-geosparql/issues/267).