### PR TITLE
recommend QUDT as UOM vocabulary

### DIFF
--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -186,7 +186,7 @@ NOTE: See the <<Recommendation for specification of units of measurement>>.
 
 ==== Property: geo:hasMetricSpatialResolution
 
-The property http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution[`geo:hasMetricSpatialResolution`] is similar to <<Property: geo:hasSpatialResolution, `geo:hasSpatialResolution`>>, specifies that the unit of resolution distance is always meter (the standard distance unit of the International System of Units). 
+The property http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution[`geo:hasMetricSpatialResolution`] is similar to <<Property: geo:hasSpatialResolution, `geo:hasSpatialResolution`>>, specifies that the unit of resolution is always meter (the standard distance unit of the International System of Units). 
 
 ```turtle
 geo:hasMetricSpatialResolution 
@@ -899,6 +899,7 @@ geof:distance (geom1: ogc:geomLiteral,
 ```
 
 Returns the shortest distance between any two Points in the two geometric objects. Calculations are in spatial reference system of `geom1`.
+NOTE: See the <<Recommendation for specification of units of measurement>>.
 
 ==== Function: geof:envelope
 

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -12,6 +12,9 @@ Since 2012 and the first version of GeoSPARQL, many ontologies have imported Geo
 
 Some of the properties defined in these vocabularies, such as DCAT2's `spatialResolution` have motivated the inclusion of new properties in this version of GeoSPARQL. In this case the equivalent property is <<Property: geo:hasSpatialResolution, `geo:hasSpatialResolution`>>. The GeoSPARQL 1.1 Standards Working Group charter <<CHARTER>> contains references to a number of vocabularies/ontologies that were influential in the generation of this version of GeoSPARQL.
 
+=== Recommendation for specification of units of measurement
+For geometric data to be interpreted and used correctly, the unit of distance should be known. Typically, the particular Coordinate Reference System (CRS) that is associated with a Geometry instance will specify a unit of measurement. However, some elements of GeoSPARQL allow arbitrary units of distance to be used, for example the property <<Property: geo:hasSpatialResolution, `geo:hasSpatialResolution`>> or the function <<Function: geof:buffer, `geof:buffer`>>. In those cases it is advisable to make use of a well known web vocabulary for units of measurement. That will improve data interoperability. The recommended vocabulary for units of measurement for GeoSPARQL is the _Quantities, Units, Dimensions and Types (QUDT)_ ontologyfootnote:[http://www.qudt.org].
+
 === Influence of Coordinate Reference Systems on geometric computations
 Geometric computations must always be mindful of the kind of space that is described by a Coordinate Reference System (CRS). A Geometry object consists of a set of coordinates and a specification on how the coordinates should be interpreted: the CRS. Taken together, coordinates and CRS allow performing computations on Geometry objects. For example, sizes can be calculated or new Geometry objects can be created. Some Coordinate Reference Systems describe a two-dimensional flat space. In that case, coordinates are understood to be Cartesian, and Cartesian geometric computations can be performed. But Coordinate Reference Systems can describe other types of spaces, to which Cartesian computations are not applicable. For example, if CRS http://www.opengis.net/def/crs/OGC/1.3/CRS84[`+<http://www.opengis.net/def/crs/OGC/1.3/CRS84>+`] is used, coordinates are to be interpreted as degrees of latitude and longitude, designating positions on a spheroid. The distance between two points using this CRS is different from the distance between two points that have the same coordinates but are based on a Cartesian CRS.
 
@@ -179,7 +182,7 @@ geo:hasSpatialResolution
     rdfs:domain geo:Geometry ;
 .
 ```
-
+NOTE: See the <<Recommendation for specification of units of measurement>>.
 
 ==== Property: geo:hasMetricSpatialResolution
 
@@ -210,6 +213,7 @@ geo:hasSpatialAccuracy
     rdfs:domain geo:Geometry ;
 .
 ```
+NOTE: See the <<Recommendation for specification of units of measurement>>.
 
 ==== Property: geo:hasMetricSpatialAccuracy
 
@@ -851,6 +855,7 @@ geof:buffer (geom: ogc:geomLiteral,
 ```
 
 Returns a geometric object that represents all Points whose distance from `geom1` is less than or equal to the `radius` measured in `units`. Calculations are in the spatial reference system of `geom1`.
+NOTE: See the <<Recommendation for specification of units of measurement>>.
 
 ==== Function: geof:convexHull
 


### PR DESCRIPTION
Add a recommendation to use QUDT for arbitrary units, and refer to that recommendation where appropriate. Resolves [issue 259](https://github.com/opengeospatial/ogc-geosparql/issues/259).