### PR TITLE
definition of geof:distance

### DIFF
--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -893,7 +893,7 @@ geof:distance (geom1: ogc:geomLiteral,
                units: xsd:anyURI): xsd:double
 ```
 
-Returns the shortest distance between any two Points in the two geometric objects. Calculations are in spatial reference system of `geom1`.
+Returns the shortest distance in `units` between any two Points in the two geometric objects. Calculations are in spatial reference system of `geom1`.
 
 ==== Function: geof:envelope
 


### PR DESCRIPTION
Add an explanation of the unit argument of geof:distance. Fixes [issue 273](https://github.com/opengeospatial/ogc-geosparql/issues/273).