### PR TITLE
SHACL test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ release.properties
 Thumbs.db
 
 venv
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ release.properties
 # OS folder lists
 .DS_Store
 Thumbs.db
+
+venv

--- a/1.1/examples/shacl/README.md
+++ b/1.1/examples/shacl/README.md
@@ -1,0 +1,3 @@
+# SHACL examples
+
+This folder contains a series of RDF data files that are either valid or invalid according to the numbered shaped in GeoSPARQL 1.1's SHACL validator. It also contains a Python file that can be used to execute the validator against each data file and check the results.

--- a/1.1/examples/shacl/S01-invalid-01.ttl
+++ b/1.1/examples/shacl/S01-invalid-01.ttl
@@ -1,0 +1,6 @@
+# Invalid: wrong literal content
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<http://example.com/geometry/a>
+    geo:asWKT "{ \"type\": \"Point\", \"coordinates\": [149.06017784, -35.23612321] }"^^geo:wktLiteral ;
+.

--- a/1.1/examples/shacl/S01-invalid-02.ttl
+++ b/1.1/examples/shacl/S01-invalid-02.ttl
@@ -1,0 +1,6 @@
+# Invalid: wrong datatype type for asWKT predicate
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<http://example.com/geometry/a>
+    geo:asWKT "{ \"type\": \"Point\", \"coordinates\": [149.06017784, -35.23612321] }"^^geo:gmlLiteral ;
+.

--- a/1.1/examples/shacl/S01-invalid-03.ttl
+++ b/1.1/examples/shacl/S01-invalid-03.ttl
@@ -1,0 +1,7 @@
+# Invalid: multiple asWKT values
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<http://example.com/geometry/a>
+    geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    geo:asWKT "POINT (153.08 -27.32)"^^geo:wktLiteral ;
+.

--- a/1.1/examples/shacl/S01-valid.ttl
+++ b/1.1/examples/shacl/S01-valid.ttl
@@ -1,0 +1,6 @@
+# Valid: testing asWKT predicate & matching datatype
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<http://example.com/geometry/a>
+    geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+.

--- a/1.1/examples/shacl/S02-invalid-01.ttl
+++ b/1.1/examples/shacl/S02-invalid-01.ttl
@@ -1,0 +1,13 @@
+# Invalid: the Resource <http://example.com/geometry/b> has both an outgoing and an incoming geo:hasGeometry property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<http://example.com/feature/a>
+    geo:hasGeometry <http://example.com/geometry/b> ;
+.
+
+<http://example.com/geometry/b>
+    geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    geo:hasGeometry [
+        geo:asWKT "POINT (153.084231 -27.322739)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S02-invalid-02.ttl
+++ b/1.1/examples/shacl/S02-invalid-02.ttl
@@ -1,0 +1,13 @@
+# Invalid: the Resource <http://example.com/geometry/b> has an incoming hasDefaultGeometry and an outgoing geo:hasGeometry property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<http://example.com/feature/a>
+    geo:hasDefaultGeometry <http://example.com/geometry/b> ;
+.
+
+<http://example.com/geometry/b>
+    geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    geo:hasGeometry [
+        geo:asWKT "POINT (153.084231 -27.322739)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S02-valid.ttl
+++ b/1.1/examples/shacl/S02-valid.ttl
@@ -1,0 +1,10 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<http://example.com/feature/a>
+    geo:hasGeometry <http://example.com/geometry/b> ;
+.
+
+<http://example.com/geometry/b>
+    geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+.

--- a/1.1/examples/shacl/S03-invalid.ttl
+++ b/1.1/examples/shacl/S03-invalid.ttl
@@ -1,0 +1,8 @@
+# Invalid: the Geometry has a non-Literal serialization
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asWKT <http://should-be-a-literal.com/thing/x>
+    ] ;
+.

--- a/1.1/examples/shacl/S03-valid.ttl
+++ b/1.1/examples/shacl/S03-valid.ttl
@@ -1,0 +1,8 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<http://example.com/feature/a>
+    geo:hasGeometry [
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S04-invalid-01.ttl
+++ b/1.1/examples/shacl/S04-invalid-01.ttl
@@ -1,4 +1,4 @@
-# Invalid: the geometry literal doesn;t have a datatype matching the property that indicates it
+# Invalid: the geometry literal doesn't have a datatype matching the property that indicates it
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 
 <feature-z>

--- a/1.1/examples/shacl/S04-invalid-01.ttl
+++ b/1.1/examples/shacl/S04-invalid-01.ttl
@@ -1,0 +1,8 @@
+# Invalid: the geometry literal doesn;t have a datatype matching the property that indicates it
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-z>
+    geo:hasGeometry [
+        geo:asWKT "POINT (153.084230 -27.322738)" ;
+    ] ;
+.

--- a/1.1/examples/shacl/S04-invalid-02.ttl
+++ b/1.1/examples/shacl/S04-invalid-02.ttl
@@ -1,0 +1,8 @@
+# Invalid: the geometry literal doesn;t have a datatype matching the property that indicates it
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-z>
+    geo:hasGeometry [
+        geo:asWKT "POINT (153.084230 -27.322738)"^^xsd:gmlLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S04-invalid-02.ttl
+++ b/1.1/examples/shacl/S04-invalid-02.ttl
@@ -1,8 +1,9 @@
-# Invalid: the geometry literal doesn;t have a datatype matching the property that indicates it
+# Invalid: the geometry literal doesn't have a datatype matching the property that indicates it
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <feature-z>
     geo:hasGeometry [
-        geo:asWKT "POINT (153.084230 -27.322738)"^^xsd:gmlLiteral ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^xsd:string ;
     ] ;
 .

--- a/1.1/examples/shacl/S04-valid.ttl
+++ b/1.1/examples/shacl/S04-valid.ttl
@@ -1,0 +1,8 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<http://example.com/feature/a>
+    geo:hasGeometry [
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S09-invalid.ttl
+++ b/1.1/examples/shacl/S09-invalid.ttl
@@ -1,0 +1,9 @@
+# Invalid:
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-y>
+    geo:hasGeometry [
+        geo:coordinateDimension 2 , 3 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S09-valid.ttl
+++ b/1.1/examples/shacl/S09-valid.ttl
@@ -1,0 +1,9 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:coordinateDimension 2 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S10-invalid.ttl
+++ b/1.1/examples/shacl/S10-invalid.ttl
@@ -1,0 +1,9 @@
+# Invalid: More than one dimension property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:dimension 2, 3 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S10-valid.ttl
+++ b/1.1/examples/shacl/S10-valid.ttl
@@ -1,0 +1,9 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:dimension 2 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S11-invalid.ttl
+++ b/1.1/examples/shacl/S11-invalid.ttl
@@ -1,0 +1,8 @@
+# Invalid: More than one isEmpty property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:isEmpty true , false ;
+    ] ;
+.

--- a/1.1/examples/shacl/S11-valid.ttl
+++ b/1.1/examples/shacl/S11-valid.ttl
@@ -1,0 +1,8 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:isEmpty true ;
+    ] ;
+.

--- a/1.1/examples/shacl/S12-invalid.ttl
+++ b/1.1/examples/shacl/S12-invalid.ttl
@@ -1,0 +1,8 @@
+# Invalid: More than one isSimple property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:isSimple true , false ;
+    ] ;
+.

--- a/1.1/examples/shacl/S12-valid.ttl
+++ b/1.1/examples/shacl/S12-valid.ttl
@@ -1,0 +1,8 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:isSimple true ;
+    ] ;
+.

--- a/1.1/examples/shacl/S13-invalid.ttl
+++ b/1.1/examples/shacl/S13-invalid.ttl
@@ -1,0 +1,9 @@
+# Invalid: More than one dimension property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:spatialDimension 2, 3 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S13-valid.ttl
+++ b/1.1/examples/shacl/S13-valid.ttl
@@ -1,0 +1,9 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:spatialDimension 2 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S14-invalid-01.ttl
+++ b/1.1/examples/shacl/S14-invalid-01.ttl
@@ -1,0 +1,9 @@
+# Invalid: More than one hasSpatialResolution property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:hasSpatialResolution 25.3 , 50.2 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S14-invalid-01.ttl
+++ b/1.1/examples/shacl/S14-invalid-01.ttl
@@ -1,9 +1,17 @@
 # Invalid: More than one hasSpatialResolution property
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <feature-x>
     geo:hasGeometry [
-        geo:hasSpatialResolution 25.3 , 50.2 ;
-        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+        geo:hasSpatialResolution [
+            qudt:numericValue "25.5"^^xsd:double ;
+            qudt:unit <http://qudt.org/vocab/unit/M> ;  # metre
+        ]; 
+        geo:hasSpatialResolution [
+            qudt:numericValue "2550"^^xsd:double ;
+            qudt:unit <http://qudt.org/vocab/unit/CentiM> ;  # centimetre
+        ];
     ] ;
 .

--- a/1.1/examples/shacl/S14-invalid-02.ttl
+++ b/1.1/examples/shacl/S14-invalid-02.ttl
@@ -3,7 +3,6 @@
 
 <feature-x>
     geo:hasGeometry [
-        geo:hasMetricSpatialResolution 25.3 , 50.2 ;
-        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+        geo:hasMetricSpatialResolution 25.5 , 50 ;
     ] ;
 .

--- a/1.1/examples/shacl/S14-invalid-02.ttl
+++ b/1.1/examples/shacl/S14-invalid-02.ttl
@@ -1,0 +1,9 @@
+# Invalid: More than one hasMetricSpatialResolution property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:hasMetricSpatialResolution 25.3 , 50.2 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S14-valid.ttl
+++ b/1.1/examples/shacl/S14-valid.ttl
@@ -1,9 +1,14 @@
-# Valid
+# Valid: having both a spatial resolution and a metric spatial resolution are fine, just not more than one fo each
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <feature-x>
     geo:hasGeometry [
-        geo:hasSpatialResolution 25.3 ;
-        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+        geo:hasSpatialResolution [
+            qudt:numericValue "25.5"^^xsd:double ;
+            qudt:unit <http://qudt.org/vocab/unit/M> ;  # metre
+        ];
+        geo:hasMetricSpatialResolution 25.5 ;
     ] ;
 .

--- a/1.1/examples/shacl/S14-valid.ttl
+++ b/1.1/examples/shacl/S14-valid.ttl
@@ -1,0 +1,9 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:hasSpatialResolution 25.3 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S15-invalid-01.ttl
+++ b/1.1/examples/shacl/S15-invalid-01.ttl
@@ -1,4 +1,4 @@
-# Invalid: More than one hasSpatialResolution property
+# Invalid: More than one hasSpatialAccuracy property
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix qudt: <http://qudt.org/schema/qudt/> .
 

--- a/1.1/examples/shacl/S15-invalid-01.ttl
+++ b/1.1/examples/shacl/S15-invalid-01.ttl
@@ -1,0 +1,9 @@
+# Invalid: More than one hasSpatialResolution property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:hasSpatialResolution 25.3 , 50.2 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S15-invalid-01.ttl
+++ b/1.1/examples/shacl/S15-invalid-01.ttl
@@ -1,9 +1,16 @@
 # Invalid: More than one hasSpatialResolution property
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
 
 <feature-x>
     geo:hasGeometry [
-        geo:hasSpatialResolution 25.3 , 50.2 ;
-        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+        geo:hasSpatialAccuracy [
+            qudt:numericValue 25.5 ;
+            qudt:unit <http://qudt.org/vocab/unit/M> ;  # metre
+        ];
+        geo:hasSpatialAccuracy [
+            qudt:numericValue 25500 ;
+            qudt:unit <http://qudt.org/vocab/unit/MilliM> ;  # millimetre
+        ];
     ] ;
 .

--- a/1.1/examples/shacl/S15-invalid-02.ttl
+++ b/1.1/examples/shacl/S15-invalid-02.ttl
@@ -1,9 +1,8 @@
-# Invalid: More than one hasMetricSpatialResolution property
+# Invalid: More than one hasMetricSpatialAccuracy property
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 
 <feature-x>
     geo:hasGeometry [
-        geo:hasMetricSpatialResolution 25.3 , 50.2 ;
-        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+        geo:hasMetricSpatialAccuracy 25.3 , 50.2 ;
     ] ;
 .

--- a/1.1/examples/shacl/S15-invalid-02.ttl
+++ b/1.1/examples/shacl/S15-invalid-02.ttl
@@ -1,0 +1,9 @@
+# Invalid: More than one hasMetricSpatialResolution property
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:hasMetricSpatialResolution 25.3 , 50.2 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S15-valid.ttl
+++ b/1.1/examples/shacl/S15-valid.ttl
@@ -1,9 +1,13 @@
 # Valid
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <feature-x>
     geo:hasGeometry [
-        geo:hasSpatialResolution 25.3 ;
-        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+        geo:hasSpatialAccuracy [
+            qudt:numericValue "25.5"^^xsd:double ;
+            qudt:unit <http://qudt.org/vocab/unit/M> ;  # metre
+        ];
     ] ;
 .

--- a/1.1/examples/shacl/S15-valid.ttl
+++ b/1.1/examples/shacl/S15-valid.ttl
@@ -1,0 +1,9 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:hasSpatialResolution 25.3 ;
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S16-invalid.ttl
+++ b/1.1/examples/shacl/S16-invalid.ttl
@@ -1,0 +1,8 @@
+# Invalid: WKT literal starts with an unexpected character
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asWKT "xPOINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S16-valid.ttl
+++ b/1.1/examples/shacl/S16-valid.ttl
@@ -1,0 +1,8 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
+    ] ;
+.

--- a/1.1/examples/shacl/S17-invalid.ttl
+++ b/1.1/examples/shacl/S17-invalid.ttl
@@ -1,0 +1,8 @@
+# Invalid: GML literal starts with an unexpected character
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asGML """{"type": "Point", "coordinates": [-83.38,33.95]}"""^^<http://www.opengis.net/ont/geosparql#gmlLiteral>
+    ] ;
+.

--- a/1.1/examples/shacl/S17-invalid.ttl
+++ b/1.1/examples/shacl/S17-invalid.ttl
@@ -3,6 +3,6 @@
 
 <feature-x>
     geo:hasGeometry [
-        geo:asGML """{"type": "Point", "coordinates": [-83.38,33.95]}"""^^<http://www.opengis.net/ont/geosparql#gmlLiteral>
+        geo:asGML """{"type": "Point", "coordinates": [-83.38,33.95]}"""^^geo:gmlLiteral ;
     ] ;
 .

--- a/1.1/examples/shacl/S17-valid.ttl
+++ b/1.1/examples/shacl/S17-valid.ttl
@@ -3,12 +3,11 @@
 
 <feature-x>
     geo:hasGeometry [
-        geo:asGML """
-                <gml:Point
-                        srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"
-                        xmlns:gml=\"http://www.opengis.net/ont/gml\">
-                    <gml:pos>-83.38 33.95</gml:pos>
-                </gml:Point>
-                """^^<http://www.opengis.net/ont/geosparql#gmlLiteral>
+        geo:asGML """<gml:Point
+                       srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"
+                       xmlns:gml=\"http://www.opengis.net/ont/gml\">
+                   <gml:pos>-83.38 33.95</gml:pos>
+               </gml:Point>"""^^geo:gmlLiteral ;
+        #geo:asGML """<gml:Point srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\" xmlns:gml=\"http://www.opengis.net/ont/gml\"><gml:pos>-83.38 33.95</gml:pos></gml:Point>"""^^geo:gmlLiteral ;                
     ] ;
 .

--- a/1.1/examples/shacl/S17-valid.ttl
+++ b/1.1/examples/shacl/S17-valid.ttl
@@ -1,0 +1,14 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asGML """
+                <gml:Point
+                        srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"
+                        xmlns:gml=\"http://www.opengis.net/ont/gml\">
+                    <gml:pos>-83.38 33.95</gml:pos>
+                </gml:Point>
+                """^^<http://www.opengis.net/ont/geosparql#gmlLiteral>
+    ] ;
+.

--- a/1.1/examples/shacl/S18-invalid.ttl
+++ b/1.1/examples/shacl/S18-invalid.ttl
@@ -1,0 +1,14 @@
+# Invalid: GeoJSON literal starts with an unexpected character
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asGeoJSON """
+            <gml:Point
+                    srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"
+                    xmlns:gml=\"http://www.opengis.net/ont/gml\">
+                <gml:pos>-83.38 33.95</gml:pos>
+            </gml:Point>
+            """^^geo:geoJSONLiteral
+    ] ;
+.

--- a/1.1/examples/shacl/S18-valid.ttl
+++ b/1.1/examples/shacl/S18-valid.ttl
@@ -1,0 +1,8 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asGeoJSON """{"type": "Point", "coordinates": [-83.38,33.95]}"""^^geo:geoJSONLiteral
+    ] ;
+.

--- a/1.1/examples/shacl/S18-valid.ttl
+++ b/1.1/examples/shacl/S18-valid.ttl
@@ -3,6 +3,8 @@
 
 <feature-x>
     geo:hasGeometry [
-        geo:asGeoJSON """{"type": "Point", "coordinates": [-83.38,33.95]}"""^^geo:geoJSONLiteral
+        geo:asGeoJSON """
+            {"type": "Point", "coordinates": [-83.38,33.95]}
+            """^^geo:geoJSONLiteral
     ] ;
 .

--- a/1.1/examples/shacl/S19-invalid.ttl
+++ b/1.1/examples/shacl/S19-invalid.ttl
@@ -1,0 +1,8 @@
+# Invalid: KML literal starts with an unexpected character
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asKML """{"type": "Point", "coordinates": [-83.38,33.95]}"""^^geo:kmlLiteral
+    ] ;
+.

--- a/1.1/examples/shacl/S19-valid.ttl
+++ b/1.1/examples/shacl/S19-valid.ttl
@@ -1,0 +1,12 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asKML """
+            <Point xmlns=\"http://www.opengis.net/kml/2.2\">
+                <coordinates>-83.38,33.95</coordinates>
+            </Point>
+            """^^geo:kmlLiteral
+    ] ;
+.

--- a/1.1/examples/shacl/S20-valid.ttl
+++ b/1.1/examples/shacl/S20-valid.ttl
@@ -1,0 +1,8 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:asDGGS """xxxxxxx"""^^geo:dggsLiteral
+    ] ;
+.

--- a/1.1/examples/shacl/S21-invalid.ttl
+++ b/1.1/examples/shacl/S21-invalid.ttl
@@ -1,0 +1,9 @@
+# Invalid: geo:dimension greater than geo:coordinateDimension
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:dimension 3 ;
+        geo:coordinateDimension 2 ;
+    ] ;
+.

--- a/1.1/examples/shacl/S21-valid.ttl
+++ b/1.1/examples/shacl/S21-valid.ttl
@@ -1,0 +1,9 @@
+# Valid: geo:dimension should be less than or equal to the value of geo:coordinateDimension
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+
+<feature-x>
+    geo:hasGeometry [
+        geo:dimension 2 ;
+        geo:coordinateDimension 2 ;
+    ] ;
+.

--- a/1.1/examples/shacl/S22-invalid-01.ttl
+++ b/1.1/examples/shacl/S22-invalid-01.ttl
@@ -1,0 +1,5 @@
+# Invalid: the geo:FeatureCollection instance node has no outgoing rdfs:member relations
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<featureCollection-x> a geo:FeatureCollection .

--- a/1.1/examples/shacl/S22-invalid-02.ttl
+++ b/1.1/examples/shacl/S22-invalid-02.ttl
@@ -1,0 +1,12 @@
+# Invalid: the geo:FeatureCollection instance node has one outgoing rdfs:member relation to a geo:Feature node and another to a geo:Geometry node
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<featureCollection-x> 
+    a geo:FeatureCollection ;
+    rdfs:member <featureCollection-x> , <geometry-x> ;
+.
+
+<feature-x> geo:hasGeometry <feature-x-geom1> .
+
+<geometry-x> a geo:Geometry .	

--- a/1.1/examples/shacl/S22-valid.ttl
+++ b/1.1/examples/shacl/S22-valid.ttl
@@ -1,0 +1,13 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<featureCollection-x> 
+    a geo:FeatureCollection ;
+    rdfs:member <feature-x> ;
+.
+
+<feature-x>
+    a geo:Feature ;
+    geo:hasGeometry <feature-x-geom1> ;
+.

--- a/1.1/examples/shacl/S23-invalid-01.ttl
+++ b/1.1/examples/shacl/S23-invalid-01.ttl
@@ -1,0 +1,5 @@
+# Invalid: the geo:GeometryCollection instance node has no outgoing rdfs:member relations
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<geometryCollection-x> a geo:GeometryCollection .

--- a/1.1/examples/shacl/S23-invalid-02.ttl
+++ b/1.1/examples/shacl/S23-invalid-02.ttl
@@ -1,0 +1,10 @@
+# Invalid: the geo:GeometryCollection instance node has one outgoing rdfs:member relation to geo:Geometry node and one to a non-geo:Geometry node (a geo:Feature)
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<geometryCollection-x> 
+    a geo:GeometryCollection ;
+    rdfs:member <geometry-x> , <feature-x> ;
+.
+
+<feature-x> geo:hasGeometry <geometry-x> .

--- a/1.1/examples/shacl/S23-valid.ttl
+++ b/1.1/examples/shacl/S23-valid.ttl
@@ -1,0 +1,10 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<geometryCollection-x> 
+    a geo:GeometryCollection ;
+    rdfs:member <geometry-x> ;
+.
+        
+<feature-x> geo:hasGeometry <geometry-x> .

--- a/1.1/examples/shacl/S24-invalid-01.ttl
+++ b/1.1/examples/shacl/S24-invalid-01.ttl
@@ -1,4 +1,4 @@
-# Invalid: the geo:SpatialObjectCollection instance node has no incoming rdfs:member relations
+# Invalid: the geo:SpatialObjectCollection instance node has no outgoing rdfs:member relations
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 

--- a/1.1/examples/shacl/S24-invalid-01.ttl
+++ b/1.1/examples/shacl/S24-invalid-01.ttl
@@ -1,0 +1,7 @@
+# Invalid: the geo:SpatialObjectCollection instance node has no incoming rdfs:member relations
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<spatialObjectCollection-x>
+    a geo:SpatialObjectCollection ;
+.

--- a/1.1/examples/shacl/S24-invalid-02.ttl
+++ b/1.1/examples/shacl/S24-invalid-02.ttl
@@ -1,0 +1,13 @@
+# Invalid: the geo:SpatialObjectCollection instance node has one outgoing rdfs:member relation to a geo:Geometry node, one outgoing rdfs:member relation to a geo:Feature node and a third outgoing rdfs:member relation from a node of another type (ex:Thing)
+@prefix ex: <http://example.com/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<spatialObjectCollection-x>
+    a geo:SpatialObjectCollection ;
+    rdfs:member <geometry-x> , <feature-y> , <thing-x> ;
+.
+
+<thing-x> a ex:Thing .
+<feature-x> geo:hasGeometry <geometry-x> .
+<feature-y> geo:hasGeometry <geometry-y> .

--- a/1.1/examples/shacl/S24-valid.ttl
+++ b/1.1/examples/shacl/S24-valid.ttl
@@ -1,0 +1,10 @@
+# Valid
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<spatialObjectCollection-x>
+    a geo:SpatialObjectCollection ;
+    rdfs:member <feature-x>
+.
+
+<feature-x> geo:hasGeometry <geometry-x> .

--- a/1.1/examples/shacl/test_shapes.py
+++ b/1.1/examples/shacl/test_shapes.py
@@ -27,6 +27,10 @@ Installing pytest results in a python script called pytest that can be used in t
 The --disable-pytest-warnings flag is to hide deeper Python warning messages not needed for general use.
 
 As long as you see no errors, things are working well! Warnings are OK.
+
+To see each file being processed, use the -s flag to allow the testing functions to print the file value:
+
+~$ pytest test_shapes.py --disable-pytest-warnings -s
 """
 import pytest
 from pathlib import Path
@@ -73,7 +77,8 @@ def validator_graph():
         Path(".") / "S24-valid.ttl",
     ]
 )
-def test_valid(validator_graph, data_file_path):      
+def test_valid(validator_graph, data_file_path):
+    print(f"\nTesting {data_file_path}...")
     v = validate(str(data_file_path), shacl_graph=validator_graph, allow_warnings=True, meta_shacl=True)
     assert v[0], f"File {data_file_path.name}, expected to be valid, failed validation with error messages:\n\n{v[2]}"
 
@@ -116,6 +121,7 @@ def test_valid(validator_graph, data_file_path):
         Path(".") / "S24-invalid-02.ttl",
     ]
 )
-def test_invalid(validator_graph, data_file_path):      
+def test_invalid(validator_graph, data_file_path):
+    print(f"\nTesting {data_file_path}...")
     v = validate(str(data_file_path), shacl_graph=validator_graph, allow_warnings=True, meta_shacl=True)
     assert not v[0], f"File {data_file_path.name}, expected to be invalid, failed validation with error messages:\n\n{v[2]}"

--- a/1.1/examples/shacl/test_shapes.py
+++ b/1.1/examples/shacl/test_shapes.py
@@ -1,9 +1,10 @@
 """
 This is a small test suite for GeoSPARQL's SHACL validator.
 
-This small Python script uses the pySHACL tool (https://pypi.org/project/pyshacl/) to test that example data in this
+This Python script uses the pySHACL tool (https://pypi.org/project/pyshacl/) to test that example data in this
 folder with the GeoSPARQL 1.1 SHACL validator (validator.ttl in the GeoSPARQL 1.1 repository). The data files indicate
-with comments in them and also with file naming conventions whether they are expected to pass or fail validation.
+with comments in them and also with file naming conventions whether they are expected to be valid or invalid - 
+pass or fail validation.
 
 Files ending _valid.ttl are expected to be valid. Files ending _invalid.ttl are expected to be _invalid_. The files
 start with the ID of the SHACL rule they are testing. The IDs are present in the IRIs of the SHACL shapes in the
@@ -43,7 +44,78 @@ def validator_graph():
         exit()
 
 
-def test_valid(validator_graph):
-    for f in Path(".").glob("*-valid.ttl"):
-        v = validate(str(f), shacl_graph=validator_graph, allow_warnings=True, meta_shacl=True)
-        assert v[0], f"File {f.name}, expected to be valid, failed validation with error messages:\n\n{v[2]}"
+@pytest.mark.parametrize(
+    "data_file_path", 
+    [
+        Path(".") / "S01-valid.ttl",
+        Path(".") / "S02-valid.ttl",
+        Path(".") / "S03-valid.ttl",
+        Path(".") / "S04-valid.ttl",
+        # Path(".") / "S05-valid.ttl", -- not tested
+        # Path(".") / "S06-valid.ttl", -- not tested
+        # Path(".") / "S07-valid.ttl", -- not tested
+        # Path(".") / "S08-valid.ttl", -- not tested
+        Path(".") / "S09-valid.ttl",
+        Path(".") / "S10-valid.ttl",
+        Path(".") / "S11-valid.ttl",
+        Path(".") / "S12-valid.ttl",
+        Path(".") / "S13-valid.ttl",
+        Path(".") / "S14-valid.ttl",
+        Path(".") / "S15-valid.ttl",
+        Path(".") / "S16-valid.ttl",
+        Path(".") / "S17-valid.ttl",
+        Path(".") / "S18-valid.ttl",
+        Path(".") / "S19-valid.ttl",
+        Path(".") / "S20-valid.ttl",
+        Path(".") / "S21-valid.ttl",
+        Path(".") / "S22-valid.ttl",
+        Path(".") / "S23-valid.ttl",
+        Path(".") / "S24-valid.ttl",
+    ]
+)
+def test_valid(validator_graph, data_file_path):      
+    v = validate(str(data_file_path), shacl_graph=validator_graph, allow_warnings=True, meta_shacl=True)
+    assert v[0], f"File {data_file_path.name}, expected to be valid, failed validation with error messages:\n\n{v[2]}"
+
+
+@pytest.mark.parametrize(
+    "data_file_path", 
+    [
+        Path(".") / "S01-invalid-01.ttl",
+        Path(".") / "S01-invalid-02.ttl",
+        Path(".") / "S01-invalid-03.ttl",
+        Path(".") / "S02-invalid-01.ttl",
+        Path(".") / "S02-invalid-02.ttl",
+        Path(".") / "S03-invalid.ttl",
+        Path(".") / "S04-invalid-01.ttl",
+        Path(".") / "S04-invalid-02.ttl",
+        # Path(".") / "S05-invalid.ttl", -- not tested
+        # Path(".") / "S06-invalid.ttl", -- not tested
+        # Path(".") / "S07-invalid.ttl", -- not tested
+        # Path(".") / "S08-invalid.ttl", -- not tested
+        Path(".") / "S09-invalid.ttl",
+        Path(".") / "S10-invalid.ttl",
+        Path(".") / "S11-invalid.ttl",
+        Path(".") / "S12-invalid.ttl",
+        Path(".") / "S13-invalid.ttl",
+        Path(".") / "S14-invalid-01.ttl",
+        Path(".") / "S14-invalid-02.ttl",
+        Path(".") / "S15-invalid-01.ttl",
+        Path(".") / "S15-invalid-02.ttl",
+        Path(".") / "S16-invalid.ttl",
+        Path(".") / "S17-invalid.ttl",
+        Path(".") / "S18-invalid.ttl",
+        Path(".") / "S19-invalid.ttl",
+        # Path(".") / "S20-invalid.ttl", -- no invalid example
+        Path(".") / "S21-invalid.ttl",
+        Path(".") / "S22-invalid-01.ttl",
+        Path(".") / "S22-invalid-02.ttl",
+        Path(".") / "S23-invalid-01.ttl",
+        Path(".") / "S23-invalid-02.ttl",
+        Path(".") / "S24-invalid-01.ttl",
+        Path(".") / "S24-invalid-02.ttl",
+    ]
+)
+def test_invalid(validator_graph, data_file_path):      
+    v = validate(str(data_file_path), shacl_graph=validator_graph, allow_warnings=True, meta_shacl=True)
+    assert not v[0], f"File {data_file_path.name}, expected to be invalid, failed validation with error messages:\n\n{v[2]}"

--- a/1.1/examples/shacl/test_shapes.py
+++ b/1.1/examples/shacl/test_shapes.py
@@ -1,0 +1,49 @@
+"""
+This is a small test suite for GeoSPARQL's SHACL validator.
+
+This small Python script uses the pySHACL tool (https://pypi.org/project/pyshacl/) to test that example data in this
+folder with the GeoSPARQL 1.1 SHACL validator (validator.ttl in the GeoSPARQL 1.1 repository). The data files indicate
+with comments in them and also with file naming conventions whether they are expected to pass or fail validation.
+
+Files ending _valid.ttl are expected to be valid. Files ending _invalid.ttl are expected to be _invalid_. The files
+start with the ID of the SHACL rule they are testing. The IDs are present in the IRIs of the SHACL shapes in the
+validator file.
+
+This script requires Python 3.7+ and a few standard Python distribution packages. Additionally, the following Python
+packages available on the Python Package Index (https://pypi.org) are needed:
+
+* pytest (https://pypi.org/project/pytest/) - a generic Python testing framework
+* pyshacl (https://pypi.org/project/pyshacl/) - an RDF validator tool
+
+Using a package manager, installation of just those two packages should allow you to execute these tests.
+
+Running the tests
+-----------------
+Installing pytest results in a python script called pytest that can be used in this directory like this:
+
+~$ pytest test_shapes.py --disable-pytest-warnings
+
+The --disable-pytest-warnings flag is to hide deeper Python warning messages not needed for general use.
+
+As long as you see no errors, things are working well! Warnings are OK.
+"""
+import pytest
+from pathlib import Path
+from pyshacl import validate
+from rdflib import Graph
+
+
+@pytest.fixture
+def validator_graph():
+    try:
+        return Graph().parse(Path(__file__).parent.parent.parent / "validator.ttl")
+    except FileNotFoundError:
+        print("ERROR: Cannot load the validator graph. "
+              "Please check that the path specified for the validator.ttl file is valid")
+        exit()
+
+
+def test_valid(validator_graph):
+    for f in Path(".").glob("*-valid.ttl"):
+        v = validate(str(f), shacl_graph=validator_graph, allow_warnings=True, meta_shacl=True)
+        assert v[0], f"File {f.name}, expected to be valid, failed validation with error messages:\n\n{v[2]}"

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -420,7 +420,7 @@
 		: ,
 		<http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/feature-properties> ;
 	skos:definition """The spatial resolution of a Geometry."""@en ;
-	skos:note """Spatial resolution specifies the level of detail of a Geometry. It the smallest dinstinguishable distance between spatially adjacent coordinates."""@en;
+	skos:note """Spatial resolution specifies the level of detail of a Geometry. It the smallest distinguishable distance between spatially adjacent coordinates."""@en;
 	skos:prefLabel "has spatial resolution"@en ;
 	skos:example
 		spec11:B.1.2.2 ;		

--- a/1.1/spec/02-Introduction.adoc
+++ b/1.1/spec/02-Introduction.adoc
@@ -42,7 +42,7 @@ The OGC GeoSPARQL standard supports representing and querying geospatial data on
 
 === GeoSPARQL Standard structure
 
-The GeoSPARQL standard comprises multiple parts, or _profile resources_. The comprehensive listing of them is given not here but in the standard's _profile definition, see http://www.opengis.net/def/geosparql. Here is an overview of the major parts:
+The GeoSPARQL standard comprises multiple parts, or _profile resources_. The comprehensive listing of them is given not here but in the standard's _profile definition_, see http://www.opengis.net/def/geosparql. Here is an overview of the major parts:
 
 1. _profile definition_
 ** http://www.opengis.net/def/geosparql

--- a/1.1/spec/18-Annex-C.adoc
+++ b/1.1/spec/18-Annex-C.adoc
@@ -271,7 +271,7 @@ eg:x
     skos:prefLabel "Feature X";
     geo:hasGeometry [
         geo:asWKT "<http://www.opengis.net/def/crs/EPSG/0/4326> MULTIPOLYGON (((149.06016 -35.23610, 149.060620 -35.236043, ... , 149.06016 -35.23610)))"^^geo:wktLiteral ;
-        geo:asDGGS "<https://w3id.org/dggs/aspix> CELLLIST ((R1234 R1235 R1236 ... R1256))"^^eg:auspixDggsLiteral ;
+        geo:asDGGS "CELLLIST ((R1234 R1235 R1236 ... R1256))"^^eg:auspixDggsLiteral ;
     ] ;
 .
 ```

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -419,69 +419,43 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:spatialDimension property."@en ;
 .	
 
-<S14a-many-hasSpatialResolution-one>
+<S14-many-hasSpatialResolution-one>
 	a sh:NodeShape ;
-	sh:property <S14a-many-hasSpatialResolution-one-sub> ;
+	sh:property <S14-many-hasSpatialResolution-one-sub> ;
 	sh:targetSubjectsOf geo:hasSpatialResolution ;
 .
 	
-<S14a-many-hasSpatialResolution-one-sub>
+<S14-many-hasSpatialResolution-one-sub>
 	a sh:PropertyShape ;
-	sh:path geo:hasSpatialResolution ;
+	sh:alternativePath ( geo:hasSpatialResolution geo:hasMetricSpatialResolution  ) ;
 	sh:maxCount 1 ;
-	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialResolution property."@en ;
+	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialResolution and one outgoing geo:hasMetricSpatialResolution property."@en ;
 .	
 
-<S14b-many-hasSpatialAccuracy-one>
+<S15-many-hasSpatialAccuracy-one>
 	a sh:NodeShape ;
-	sh:property <S14b-many-hasSpatialAccuracy-one-sub> ;
+	sh:property <S15-many-hasSpatialAccuracy-one-sub> ;
 	sh:targetSubjectsOf geo:hasSpatialAccuracy ;
 .
 	
-<S14b-many-hasSpatialAccuracy-one-sub>
+<S15-many-hasSpatialAccuracy-one-sub>
 	a sh:PropertyShape ;
-	sh:path geo:hasSpatialAccuracy ;
+	sh:alternativePath ( geo:hasSpatialAccuracy geo:hasMetricSpatialAccuracy  ) ;
 	sh:maxCount 1 ;
-	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialAccuracy property."@en ;
-.	
-
-<S14c-many-hasMetricSpatialAccuracy-one>
-	a sh:NodeShape ;
-	sh:property <S14c-many-hasMetricSpatialAccuracy-one-sub> ;
-	sh:targetSubjectsOf geo:hasMetricSpatialAccuracy ;
-.
-	
-<S14c-many-hasMetricSpatialAccuracy-one-sub>
-	a sh:PropertyShape ;
-	sh:path geo:hasMetricSpatialAccuracy ;
-	sh:maxCount 1 ;
-	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasMetricSpatialAccuracy property."@en ;
-.
-
-<S14d-many-hasMetricSpatialResolution-one>
-	a sh:NodeShape ;
-	sh:property <S14d-many-hasMetricSpatialResolution-one-sub> ;
-	sh:targetSubjectsOf geo:hasMetricSpatialResolution ;
-.
-	
-<S14d-many-hasMetricSpatialResolution-one-sub>
-	a sh:PropertyShape ;
-	sh:path geo:hasMetricSpatialResolution ;
-	sh:maxCount 1 ;
-	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasMetricSpatialResolution property."@en ;
+	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialAccuracy and one outgoing geo:hasMetricSpatialAccuracy property."@en ;
 .	
 
 #################################################
-# Shape 15-16-17-18-19 - basic geometry serialization pattern matching
+# Shape 16-17-18-19-20 - basic geometry serialization pattern matching
 #################################################
 
-<S15-wkt-content>
+<S16-wkt-content>
 	a sh:NodeShape ;
-	sh:property <S15-wkt-content-sub-start> ;
+	sh:property <S16-wkt-content-sub-start> ;
 	sh:targetSubjectsOf geo:asWKT ;
 .
 
-<S15-wkt-content-sub-start>
+<S16-wkt-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asWKT ;
 	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)" ; # starts with space, < or P, C etc.
@@ -489,54 +463,54 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	sh:message "The content of an RDF literal with an incoming geo:asWKT relation must conform to a well-formed WKT string, as defined by its official specification (Simple Features Access)."@en ;
 .
 
-<S16-gml-content>
+<S17-gml-content>
 	a sh:NodeShape ;
-	sh:property <S16-gml-content-sub-start> ;
+	sh:property <S17-gml-content-sub-start> ;
 	sh:targetSubjectsOf geo:asGML ;
 .
 
-<S16-gml-content-sub-start>
+<S17-gml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGML ;
 	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asGML relation must conform to a well-formed GML geometry XML string, as defined by its official specification."@en ;
 .
 
-<S17-geojson-content>
+<S18-geojson-content>
 	a sh:NodeShape ;
-	sh:property <S17-geojson-content-sub-start> ;
+	sh:property <S18-geojson-content-sub-start> ;
 	sh:targetSubjectsOf geo:asGeoJSON ;
 .
 
-<S17-geojson-content-sub-start>
+<S18-geojson-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGeoJSON ;
 	sh:pattern "^\\s*$|^\\s*({)(.*)(})\\s*$" ;  # starts with { ends with }
 	sh:message "The content of an RDF literal with an incoming geo:asGeoJSON relation must conform to a well-formed GeoJSON geometry string, as defined by its official specification."@en ;
 .
 
-<S18-kml-content>
+<S19-kml-content>
 	a sh:NodeShape ;
-	sh:property <S18-kml-content-sub-start> ;
+	sh:property <S19-kml-content-sub-start> ;
 	sh:targetSubjectsOf geo:asKML ;
 .
 
-<S18-kml-content-sub-start>
+<S19-kml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asKML ;
 	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asKML relation must conform to a well-formed KML geometry XML string, as defined by its official specification."@en ;
 .
 
-<S19-dggs-content>
+<S20-dggs-content>
 	a sh:NodeShape ;
-	sh:property <S19-dggs-content-sub-start> ;
+	sh:property <S20-dggs-content-sub-start> ;
 	sh:targetSubjectsOf geo:asDGGS ;
 	sh:deactivated true ;
 	rdfs:comment "This shape is deactivated since the precise syntax of DGGS literals is now known"@en ;
 .
 
-<S19-dggs-content-sub-start>
+<S20-dggs-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asDGGS ;
 	sh:pattern "^$" ;
@@ -546,16 +520,16 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 20 - dimension checks
+# Shape 21 - dimension checks
 #################################################
 
-<S20-dimension-coordinateDimension>
+<S21-dimension-coordinateDimension>
 	a sh:NodeShape ;
-	sh:property <S20-dimension-coordinateDimension-sub> ;
+	sh:property <S21-dimension-coordinateDimension-sub> ;
 	sh:targetSubjectsOf geo:dimension ;
 .
 
-<S20-dimension-coordinateDimension-sub>
+<S21-dimension-coordinateDimension-sub>
 	a sh:PropertyShape ;
 	sh:path geo:coordinateDimension ;
 	sh:sparql [
@@ -600,16 +574,18 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 21 - geo:FeatureCollection
+# Shape 22 - geo:FeatureCollection
 #################################################
 
-<S21-FeatureCollectionClass-member-feature>
+<S22-FeatureCollectionClass-member-feature>
 	a sh:NodeShape ;
-	sh:property <S21-FeatureCollectionClass-minOneMember-feature-sub> , <S21-FeatureCollectionClass-member-onlyFeature-sub> ;
+	sh:property
+	    <S22-FeatureCollectionClass-minOneMember-feature-sub> ,
+	    <S22-FeatureCollectionClass-member-onlyFeature-sub> ;
 	sh:targetClass geo:FeatureCollection ;
 .
 
-<S21-FeatureCollectionClass-minOneMember-feature-sub>
+<S22-FeatureCollectionClass-minOneMember-feature-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:minCount 1 ;
@@ -639,7 +615,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S21-FeatureCollectionClass-member-onlyFeature-sub>
+<S22-FeatureCollectionClass-member-onlyFeature-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:sparql [
@@ -689,18 +665,18 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 22 - geo:GeometryCollection
+# Shape 23 - geo:GeometryCollection
 #################################################
 
-<S22-GeometryCollectionClass-member-geometry>
+<S23-GeometryCollectionClass-member-geometry>
 	a sh:NodeShape ;
 	sh:property 
-		<S22-GeometryCollectionClass-minOneMember-geometry-sub> , 
-		<S22-GeometryCollectionClass-member-onlyGeometry-sub> ;
+		<S23-GeometryCollectionClass-minOneMember-geometry-sub> ,
+		<S23-GeometryCollectionClass-member-onlyGeometry-sub> ;
 	sh:targetClass geo:GeometryCollection ;
 .
 
-<S22-GeometryCollectionClass-minOneMember-geometry-sub>
+<S23-GeometryCollectionClass-minOneMember-geometry-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:minCount 1 ;
@@ -727,7 +703,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S22-GeometryCollectionClass-member-onlyGeometry-sub>
+<S23-GeometryCollectionClass-member-onlyGeometry-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:sparql [
@@ -772,18 +748,18 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 23 - geo:SpatialObjectCollection
+# Shape 24 - geo:SpatialObjectCollection
 #################################################
 
-<S23-SpatialObjectCollection-member-spatialObject>
+<S24-SpatialObjectCollection-member-spatialObject>
 	a sh:NodeShape ;
 	sh:property 
-		<S23-SpatialObjectCollection-minOneMember-spatialObject-sub> , 
-		<S23-SpatialObjectCollection-member-onlySpatialObject-sub> ;
+		<S24-SpatialObjectCollection-minOneMember-spatialObject-sub> ,
+		<S24-SpatialObjectCollection-member-onlySpatialObject-sub> ;
 	sh:targetClass geo:SpatialObjectCollection ;
 .
 
-<S23-SpatialObjectCollection-minOneMember-spatialObject-sub>
+<S24-SpatialObjectCollection-minOneMember-spatialObject-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:minCount 1 ;
@@ -812,7 +788,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S23-SpatialObjectCollection-member-onlySpatialObject-sub>
+<S24-SpatialObjectCollection-member-onlySpatialObject-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:sparql [

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -40,6 +40,12 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		geo:hasGeometry , 
 		geo:hasDefaultGeometry ,
 		geo:defaultGeometry ;
+	sh:targetSubjectsOf 
+		geo:asWKT ,
+		geo:asGML ,
+		geo:asGeoJSON ,
+		geo:asKML ,
+		geo:asDGGS ;
 	sh:property 
 		<S1-a-hasGeometry-hasSerialization-sub> , 
 		<S1-b-hasGeometry-hasSerialization-sub> , 
@@ -304,25 +310,31 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S8-asDGGS-dggsLiteral>
 	a sh:NodeShape ;
 	sh:targetObjectsOf geo:asDGGS ;
-	sh:not [
+	sh:property [
 		a sh:PropertyShape ;
 		sh:path geo:asDGGS ;
-		sh:datatype geo:wktLiteral ;
-	] ,
-	[
-		a sh:PropertyShape ;
-		sh:path geo:asDGGS ;
-		sh:datatype geo:gmlLiteral ;
-	] ,
-	[
-		a sh:PropertyShape ;
-		sh:path geo:asDGGS ;
-		sh:datatype geo:geoJSONLiteral ;
-	] ,
-	[
-		a sh:PropertyShape ;
-		sh:path geo:asDGGS ;
-		sh:datatype geo:asKML ;
+		sh:and (
+			[
+				sh:not [
+					sh:datatype geo:wktLiteral ;
+				] 
+			]
+			[
+				sh:not [
+					sh:datatype geo:gmlLiteral ;
+				] 
+			]
+			[
+				sh:not [
+					sh:datatype geo:geoJSONLiteral ;
+				] 
+			]
+			[
+				sh:not [
+					sh:datatype geo:asKML ;
+				] 
+			]						
+		 ) ;
 	] ;		
 	sh:message "The target of a geo:asDGGS property must not be an RDF literal with datatype of one of the other non-DGGS geometry literal types. It must be eithr geo:dggsLiteral or specialised version of geo:dggsLiteral but this is un-testable so only the excluded type test is performed."@en ;
 .
@@ -421,28 +433,50 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 
 <S14-many-hasSpatialResolution-one>
 	a sh:NodeShape ;
-	sh:property <S14-many-hasSpatialResolution-one-sub> ;
-	sh:targetSubjectsOf geo:hasSpatialResolution ;
+	sh:property 
+		<S14-many-hasSpatialResolution-one-sub> ,
+		<S14-many-hasMetricSpatialResolution-one-sub> ;
+	sh:targetSubjectsOf 
+		geo:hasSpatialResolution ,
+		geo:hasMetricSpatialResolution ;
 .
 	
 <S14-many-hasSpatialResolution-one-sub>
 	a sh:PropertyShape ;
-	sh:alternativePath ( geo:hasSpatialResolution geo:hasMetricSpatialResolution  ) ;
+	sh:path geo:hasSpatialResolution ;
 	sh:maxCount 1 ;
-	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialResolution and one outgoing geo:hasMetricSpatialResolution property."@en ;
-.	
+	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialResolution property."@en ;
+.
+
+<S14-many-hasMetricSpatialResolution-one-sub>
+	a sh:PropertyShape ;
+	sh:path geo:hasMetricSpatialResolution ;
+	sh:maxCount 1 ;
+	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasMetricSpatialResolution property."@en ;
+.
 
 <S15-many-hasSpatialAccuracy-one>
 	a sh:NodeShape ;
-	sh:property <S15-many-hasSpatialAccuracy-one-sub> ;
-	sh:targetSubjectsOf geo:hasSpatialAccuracy ;
+	sh:property 
+		<S15-many-hasSpatialAccuracy-one-sub> ,
+		<S15-many-hasMetricSpatialAccuracy-one-sub> ;
+	sh:targetSubjectsOf 
+		geo:hasSpatialAccuracy ,
+		geo:hasMetricSpatialAccuracy ;
 .
 	
 <S15-many-hasSpatialAccuracy-one-sub>
 	a sh:PropertyShape ;
-	sh:alternativePath ( geo:hasSpatialAccuracy geo:hasMetricSpatialAccuracy  ) ;
+	sh:path geo:hasSpatialAccuracy ; 
 	sh:maxCount 1 ;
-	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialAccuracy and one outgoing geo:hasMetricSpatialAccuracy property."@en ;
+	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialAccuracy property."@en ;
+.
+
+<S15-many-hasMetricSpatialAccuracy-one-sub>
+	a sh:PropertyShape ;
+	sh:path geo:hasMetricSpatialAccuracy ; 
+	sh:maxCount 1 ;
+	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasMetricSpatialAccuracy."@en ;
 .	
 
 #################################################
@@ -458,8 +492,8 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S16-wkt-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asWKT ;
-	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)" ; # starts with space, < or P, C etc.
-	sh:flags "i" ;
+	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<|p|c|s|l|t)" ; # starts with space, < or P, C etc.
+	sh:flags "m" ;
 	sh:message "The content of an RDF literal with an incoming geo:asWKT relation must conform to a well-formed WKT string, as defined by its official specification (Simple Features Access)."@en ;
 .
 
@@ -473,6 +507,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	a sh:PropertyShape ;
 	sh:path geo:asGML ;
 	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
+	sh:flags "m" ;
 	sh:message "The content of an RDF literal with an incoming geo:asGML relation must conform to a well-formed GML geometry XML string, as defined by its official specification."@en ;
 .
 
@@ -486,6 +521,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	a sh:PropertyShape ;
 	sh:path geo:asGeoJSON ;
 	sh:pattern "^\\s*$|^\\s*({)(.*)(})\\s*$" ;  # starts with { ends with }
+	sh:flags "s" ;
 	sh:message "The content of an RDF literal with an incoming geo:asGeoJSON relation must conform to a well-formed GeoJSON geometry string, as defined by its official specification."@en ;
 .
 
@@ -499,6 +535,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	a sh:PropertyShape ;
 	sh:path geo:asKML ;
 	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
+	sh:flags "m" ;
 	sh:message "The content of an RDF literal with an incoming geo:asKML relation must conform to a well-formed KML geometry XML string, as defined by its official specification."@en ;
 .
 

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -11,8 +11,8 @@
 
 <http://www.opengis.net/def/geosparql/validator>
 	a owl:Ontology ;
-  	dcterms:title "GeoSPARQL RDF Shapes Validator"@en ;
-	dcterms:description """This is a [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/) file that specifies constraints for RDF data. It can be used to test the conformance of data to the GeoSPARQL standard.
+  	skos:prefLabel "GeoSPARQL RDF Shapes Validator"@en ;
+	skos:definition """This is a [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/) file that specifies constraints for RDF data. It can be used to test the conformance of data to the GeoSPARQL standard.
 	
 As of GeoSPARQL 1.1, this validator is not normative, only informative, however this is likely to be the basis of future, normative, validators."""@en ;
 	dcterms:publisher [
@@ -24,7 +24,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	dcterms:created "2021-06-13"^^xsd:date ;
 	dcterms:modified "2022-03-10"^^xsd:date ;
     dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
-	dcterms:rights "(c) 2021 Open Geospatial Consortium" ; 	
+	dcterms:rights "(c) 2022 Open Geospatial Consortium" ; 	
 	owl:versionInfo "OGC GeoSPARQL 1.1" ;
 	owl:versionIRI <http://www.opengis.net/def/geosparql/validator/1.1> ;
 .

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -22,7 +22,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	] ;
 	dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
 	dcterms:created "2021-06-13"^^xsd:date ;
-	dcterms:modified "2021-08-12"^^xsd:date ;
+	dcterms:modified "2022-03-10"^^xsd:date ;
     dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
 	dcterms:rights "(c) 2021 Open Geospatial Consortium" ; 	
 	owl:versionInfo "OGC GeoSPARQL 1.1" ;
@@ -36,25 +36,43 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S1-Geometry>
 	a sh:NodeShape ;
 	sh:targetClass geo:Geometry ;
-	sh:property <S1-a-hasGeometry-hasSerialization-sub> , <S1-b-hasGeometry-hasSerialization-sub> , <S1-c-hasGeometry-hasSerialization-sub> , <S1-d-hasGeometry-hasSerialization-sub> ;
+	sh:property 
+		<S1-a-hasGeometry-hasSerialization-sub> , 
+		<S1-b-hasGeometry-hasSerialization-sub> , 
+		<S1-c-hasGeometry-hasSerialization-sub> , 
+		<S1-d-hasGeometry-hasSerialization-sub> ,
+		<S1-e-hasGeometry-hasSerialization-sub> ;
 .
 
 <S1-hasGeometry-hasSerialization>
     a sh:NodeShape ;
 	sh:targetObjectsOf geo:hasGeometry ;
-	sh:property <S1-a-hasGeometry-hasSerialization-sub> , <S1-b-hasGeometry-hasSerialization-sub> , <S1-c-hasGeometry-hasSerialization-sub> , <S1-d-hasGeometry-hasSerialization-sub> ;
+	sh:property 
+		<S1-a-hasGeometry-hasSerialization-sub> , 
+		<S1-b-hasGeometry-hasSerialization-sub> , 
+		<S1-c-hasGeometry-hasSerialization-sub> , 
+		<S1-d-hasGeometry-hasSerialization-sub> ,
+		<S1-e-hasGeometry-hasSerialization-sub> ;
 .
 
 <S1-hasDefaultGeometry-hasSerialization>
     a sh:NodeShape ;
 	sh:targetObjectsOf geo:hasDefaultGeometry ;
-	sh:property <S1-a-hasGeometry-hasSerialization-sub> , <S1-b-hasGeometry-hasSerialization-sub> , <S1-c-hasGeometry-hasSerialization-sub> , <S1-d-hasGeometry-hasSerialization-sub> ;
+		<S1-a-hasGeometry-hasSerialization-sub> , 
+		<S1-b-hasGeometry-hasSerialization-sub> , 
+		<S1-c-hasGeometry-hasSerialization-sub> , 
+		<S1-d-hasGeometry-hasSerialization-sub> ,
+		<S1-e-hasGeometry-hasSerialization-sub> ;
 .
 
 <S1-cefaultGeometry-hasSerialization>
     a sh:NodeShape ;
 	sh:targetObjectsOf geo:defaultGeometry ;
-	sh:property <S1-a-hasGeometry-hasSerialization-sub> , <S1-b-hasGeometry-hasSerialization-sub> , <S1-c-hasGeometry-hasSerialization-sub> , <S1-d-hasGeometry-hasSerialization-sub> ;
+		<S1-a-hasGeometry-hasSerialization-sub> , 
+		<S1-b-hasGeometry-hasSerialization-sub> , 
+		<S1-c-hasGeometry-hasSerialization-sub> , 
+		<S1-d-hasGeometry-hasSerialization-sub> ,
+		<S1-e-hasGeometry-hasSerialization-sub> ;
 .
 
 <S1-a-hasGeometry-hasSerialization-sub>
@@ -116,6 +134,13 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	sh:path geo:asKML ;
 	sh:maxCount 1 ;
 	sh:message "Each Geometry node can have a maximum of one outgoing geo:asKML relation."@en ;
+.
+
+<S1-e-hasGeometry-hasSerialization-sub>
+	a sh:PropertyShape ;
+	sh:path geo:asDGGS ;
+	sh:maxCount 1 ;
+	sh:message "Each Geometry node can have a maximum of one outgoing geo:asDGGS relation."@en ;
 .
 
 #################################################

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -30,44 +30,17 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 1 (1a-1d)
+# Shape 1 (1a-1d) - geometry serialization uniqueness
 #################################################
-
-<S1-Geometry>
-	a sh:NodeShape ;
-	sh:targetClass geo:Geometry ;
-	sh:property 
-		<S1-a-hasGeometry-hasSerialization-sub> , 
-		<S1-b-hasGeometry-hasSerialization-sub> , 
-		<S1-c-hasGeometry-hasSerialization-sub> , 
-		<S1-d-hasGeometry-hasSerialization-sub> ,
-		<S1-e-hasGeometry-hasSerialization-sub> ;
-.
 
 <S1-hasGeometry-hasSerialization>
     a sh:NodeShape ;
-	sh:targetObjectsOf geo:hasGeometry ;
+	sh:targetClass geo:Geometry ;
+	sh:targetObjectsOf 
+		geo:hasGeometry , 
+		geo:hasDefaultGeometry ,
+		geo:defaultGeometry ;
 	sh:property 
-		<S1-a-hasGeometry-hasSerialization-sub> , 
-		<S1-b-hasGeometry-hasSerialization-sub> , 
-		<S1-c-hasGeometry-hasSerialization-sub> , 
-		<S1-d-hasGeometry-hasSerialization-sub> ,
-		<S1-e-hasGeometry-hasSerialization-sub> ;
-.
-
-<S1-hasDefaultGeometry-hasSerialization>
-    a sh:NodeShape ;
-	sh:targetObjectsOf geo:hasDefaultGeometry ;
-		<S1-a-hasGeometry-hasSerialization-sub> , 
-		<S1-b-hasGeometry-hasSerialization-sub> , 
-		<S1-c-hasGeometry-hasSerialization-sub> , 
-		<S1-d-hasGeometry-hasSerialization-sub> ,
-		<S1-e-hasGeometry-hasSerialization-sub> ;
-.
-
-<S1-cefaultGeometry-hasSerialization>
-    a sh:NodeShape ;
-	sh:targetObjectsOf geo:defaultGeometry ;
 		<S1-a-hasGeometry-hasSerialization-sub> , 
 		<S1-b-hasGeometry-hasSerialization-sub> , 
 		<S1-c-hasGeometry-hasSerialization-sub> , 
@@ -144,34 +117,34 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 3 + 3b + 3c
+# Shape 2 (2a-2d) - Geometry / Feature disjoint
 #################################################
 
-<S3-Geometry>
+<S2-a-Geometry>
 	a sh:NodeShape ;
 	sh:targetClass geo:Geometry ;
-	sh:property <S3-hasGeometry-hasGeometry-sub> ;
+	sh:property <S2-hasGeometry-hasGeometry-sub> ;
 .
 
-<S3-hasGeometry-hasGeometry>
+<S2-b-hasGeometry-hasGeometry>
     a sh:NodeShape ;
 	sh:targetObjectsOf geo:hasGeometry ;
-	sh:property <S3-hasGeometry-hasGeometry-sub> ;
+	sh:property <S2-hasGeometry-hasGeometry-sub> ;
 .
 
-<S3-b-hasDefaultGeometry-hasGeometry>
+<S2-c-hasDefaultGeometry-hasGeometry>
     a sh:NodeShape ;
 	sh:targetObjectsOf geo:hasDefaultGeometry ;
-	sh:property <S3-hasGeometry-hasGeometry-sub> ;
+	sh:property <S2-hasGeometry-hasGeometry-sub> ;
 .
 
-<S3-c-defaultGeometry-hasGeometry>
+<S2-d-defaultGeometry-hasGeometry>
     a sh:NodeShape ;
 	sh:targetObjectsOf geo:defaultGeometry ;
-	sh:property <S3-hasGeometry-hasGeometry-sub> ;
+	sh:property <S2-hasGeometry-hasGeometry-sub> ;
 .
 
-<S3-hasGeometry-hasGeometry-sub>
+<S2-hasGeometry-hasGeometry-sub>
 	a sh:PropertyShape ;
 	sh:path [ 
 		sh:alternativePath (
@@ -228,10 +201,10 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 4
+# Shape 3 - serializations must be literals
 #################################################
 
-<S4-hasSerialization-literal>
+<S3-hasSerialization-literal>
 	a sh:NodeShape ;
 	sh:targetObjectsOf
 		geo:hasSerialization ,
@@ -266,10 +239,10 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 5-6-7-8-9
+# Shape 4-5-6-7-8 - serialization datatypes match indicating properties
 #################################################
 
-<S5-asWKT-wktLiteral>
+<S4-asWKT-wktLiteral>
 	a sh:NodeShape ;
 	sh:targetObjectsOf geo:asWKT ;
 	sh:datatype geo:wktLiteral ;
@@ -307,61 +280,64 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S6-asGML-gmlLiteral>
+<S5-asGML-gmlLiteral>
 	a sh:NodeShape ;
 	sh:targetObjectsOf geo:asGML ;
 	sh:datatype geo:gmlLiteral ;
 	sh:message "The target of a geo:asGML property should be an RDF literal with datatype geo:gmlLiteral."@en ;
 .
 
-<S7-asGeoJSON-geoJSONLiteral>
+<S6-asGeoJSON-geoJSONLiteral>
 	a sh:NodeShape ;
 	sh:targetObjectsOf geo:asGeoJSON ;
 	sh:datatype geo:geoJSONLiteral ;
 	sh:message "The target of a geo:asGeoJSON property should be an RDF literal with datatype geo:geoJSONLiteral."@en ;
 .
 
-<S8-asKML-kmlLiteral>
+<S7-asKML-kmlLiteral>
 	a sh:NodeShape ;
 	sh:targetObjectsOf geo:asKML ;
 	sh:datatype geo:kmlLiteral ;
 	sh:message "The target of a geo:asKML property should be an RDF literal with datatype geo:kmlLiteral."@en ;
 .
 
-<S9-asDGGS-dggsLiteral>
+<S8-asDGGS-dggsLiteral>
 	a sh:NodeShape ;
 	sh:targetObjectsOf geo:asDGGS ;
 	sh:not [
 		a sh:PropertyShape ;
+		sh:path geo:asDGGS ;
 		sh:datatype geo:wktLiteral ;
 	] ,
 	[
 		a sh:PropertyShape ;
+		sh:path geo:asDGGS ;
 		sh:datatype geo:gmlLiteral ;
 	] ,
 	[
 		a sh:PropertyShape ;
+		sh:path geo:asDGGS ;
 		sh:datatype geo:geoJSONLiteral ;
 	] ,
 	[
 		a sh:PropertyShape ;
+		sh:path geo:asDGGS ;
 		sh:datatype geo:asKML ;
 	] ;		
 	sh:message "The target of a geo:asDGGS property must not be an RDF literal with datatype of one of the other non-DGGS geometry literal types. It must be eithr geo:dggsLiteral or specialised version of geo:dggsLiteral but this is un-testable so only the excluded type test is performed."@en ;
 .
 
 #################################################
-# Shape 10-11-12-13-14-15 (15a-15d)
+# Shape 9-10-11-12-13-14 (14a-14d) - geometry metadata properties can only exist once
 #################################################
-# each metadata property on geo:Geometry can exist only once
 
-<S10-many-coordinateDimension-one>
+<S09-many-coordinateDimension-one>
 	a sh:NodeShape ;
-	sh:property <S9-many-coordinateDimension-one-sub> ;
+	sh:property <S09-many-coordinateDimension-one-sub> ;
 	sh:targetSubjectsOf geo:coordinateDimension ;
 .
 	
-<S10-many-coordinateDimension-one-sub>
+<S09-many-coordinateDimension-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:coordinateDimension ;
 	sh:maxCount 1 ;
@@ -391,105 +367,104 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .	
 	
-<S11-many-dimension-one>
+<S10-many-dimension-one>
 	a sh:NodeShape ;
 	sh:property <S10-many-dimension-one-sub> ;
 	sh:targetSubjectsOf geo:dimension ;
 .
 	
-<S11-many-dimension-one-sub>
+<S10-many-dimension-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:dimension ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:dimension property."@en ;
 .	
 
-<S12-many-isEmpty-one>
+<S11-many-isEmpty-one>
 	a sh:NodeShape ;
 	sh:property <S11-many-isEmpty-one-sub> ;
 	sh:targetSubjectsOf geo:isEmpty ;
 .
 	
-<S12-many-isEmpty-one-sub>
+<S11-many-isEmpty-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:isEmpty ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:isEmpty property."@en ;
 .	
 
-<S13-many-isSimple-one>
+<S12-many-isSimple-one>
 	a sh:NodeShape ;
 	sh:property <S12-many-isSimple-one-sub> ;
 	sh:targetSubjectsOf geo:isSimple ;
 .
 	
-<S13-many-isSimple-one-sub>
+<S12-many-isSimple-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:isSimple ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have a maximum one outgoing geo:isSimple property."@en ;
 .	
 
-<S14-many-spatialDimension-one>
+<S13-many-spatialDimension-one>
 	a sh:NodeShape ;
 	sh:property <S13-many-spatialDimension-one-sub> ;
 	sh:targetSubjectsOf geo:spatialDimension ;
 .
 	
-<S14-many-spatialDimension-one-sub>
+<S13-many-spatialDimension-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:spatialDimension ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:spatialDimension property."@en ;
 .	
 
-
-<S15a-many-hasSpatialResolution-one>
+<S14a-many-hasSpatialResolution-one>
 	a sh:NodeShape ;
-	sh:property <S15a-many-hasSpatialResolution-one-sub> ;
+	sh:property <S14a-many-hasSpatialResolution-one-sub> ;
 	sh:targetSubjectsOf geo:hasSpatialResolution ;
 .
 	
-<S15a-many-hasSpatialResolution-one-sub>
+<S14a-many-hasSpatialResolution-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:hasSpatialResolution ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialResolution property."@en ;
 .	
 
-<S15b-many-hasSpatialAccuracy-one>
+<S14b-many-hasSpatialAccuracy-one>
 	a sh:NodeShape ;
-	sh:property <S15b-many-hasSpatialAccuracy-one-sub> ;
+	sh:property <S14b-many-hasSpatialAccuracy-one-sub> ;
 	sh:targetSubjectsOf geo:hasSpatialAccuracy ;
 .
 	
-<S15b-many-hasSpatialAccuracy-one-sub>
+<S14b-many-hasSpatialAccuracy-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:hasSpatialAccuracy ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialAccuracy property."@en ;
 .	
 
-<S15c-many-hasMetricSpatialAccuracy-one>
+<S14c-many-hasMetricSpatialAccuracy-one>
 	a sh:NodeShape ;
-	sh:property <S15c-many-hasMetricSpatialAccuracy-one-sub> ;
+	sh:property <S14c-many-hasMetricSpatialAccuracy-one-sub> ;
 	sh:targetSubjectsOf geo:hasMetricSpatialAccuracy ;
 .
 	
-<S15c-many-hasMetricSpatialAccuracy-one-sub>
+<S14c-many-hasMetricSpatialAccuracy-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:hasMetricSpatialAccuracy ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasMetricSpatialAccuracy property."@en ;
 .
 
-<S15d-many-hasMetricSpatialResolution-one>
+<S14d-many-hasMetricSpatialResolution-one>
 	a sh:NodeShape ;
-	sh:property <S15d-many-hasMetricSpatialResolution-one-sub> ;
+	sh:property <S14d-many-hasMetricSpatialResolution-one-sub> ;
 	sh:targetSubjectsOf geo:hasMetricSpatialResolution ;
 .
 	
-<S15d-many-hasMetricSpatialResolution-one-sub>
+<S14d-many-hasMetricSpatialResolution-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:hasMetricSpatialResolution ;
 	sh:maxCount 1 ;
@@ -497,92 +472,71 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .	
 
 #################################################
-# Shape 16-17-18-19-20
+# Shape 15-16-17-18-19 - basic geometry serialization pattern matching
 #################################################
-# regex to check if content of WKT/GeoJSON/KML/GML literals complies with the basic patterns of such geometries, if possible (check start and/or end to find e.g. copy/paste errors with GeoSPARQL properties and datatypes, not to check if the content of a literal is fully compliant to the geometry format specification)
 
-<S16-wkt-content>
+<S15-wkt-content>
 	a sh:NodeShape ;
-	sh:property <S16-wkt-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
+	sh:property <S15-wkt-content-sub-start> ;
 	sh:targetSubjectsOf geo:asWKT ;
 .
 
-<S16-wkt-content-sub-start>
+<S15-wkt-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asWKT ;
-	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)" ;  # starts with P, C, S, L, T, or < for Point, TIN etc. or IRI
+	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)"
+	sh:flags "i" ;
 	sh:message "The content of an RDF literal with an incoming geo:asWKT relation must conform to a well-formed WKT string, as defined by its official specification (Simple Features Access)."@en ;
-	skos:example 
-		"""
-		# A valid example: the RDF literal with an incoming geo:asWKT has a well-formed WKT string as its content
-		@prefix geo: <http://www.opengis.net/ont/geosparql#> .
-
-		<feature-x>
-			geo:hasGeometry [
-				geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
-			] ;
-		.
-		""" ,
-		"""
-		# An invalid example: the RDF literal with an incoming geo:asWKT does not have a well-formed WKT string as its content, but rather a GeoJSON string
-		@prefix geo: <http://www.opengis.net/ont/geosparql#> .
-
-		<feature-x>
-			geo:hasGeometry [
-				geo:asWKT "{ \"type\": \"Point\", \"coordinates\": [149.06017784, -35.23612321] }"^^geo:wktLiteral ;
-			] ;
-		.
-		""" ;
 .
 
-<S17-gml-content>
+<S16-gml-content>
 	a sh:NodeShape ;
-	sh:property <S17-gml-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
+	sh:property <S16-gml-content-sub-start> ;
 	sh:targetSubjectsOf geo:asGML ;
 .
 
-<S17-gml-content-sub-start>
+<S16-gml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGML ;
 	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asGML relation must conform to a well-formed GML geometry XML string, as defined by its official specification."@en ;
 .
 
-<S18-geojson-content>
+<S17-geojson-content>
 	a sh:NodeShape ;
-	sh:property <S18-geojson-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
+	sh:property <S17-geojson-content-sub-start> ;
 	sh:targetSubjectsOf geo:asGeoJSON ;
 .
 
-<S18-geojson-content-sub-start>
+<S17-geojson-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGeoJSON ;
 	sh:pattern "^\\s*$|^\\s*({)(.*)(})\\s*$" ;  # starts with { ends with }
 	sh:message "The content of an RDF literal with an incoming geo:asGeoJSON relation must conform to a well-formed GeoJSON geometry string, as defined by its official specification."@en ;
 .
 
-<S19-kml-content>
+<S18-kml-content>
 	a sh:NodeShape ;
-	sh:property <S18-kml-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
+	sh:property <S18-kml-content-sub-start> ;
 	sh:targetSubjectsOf geo:asKML ;
 .
 
-<S19-kml-content-sub-start>
+<S18-kml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asKML ;
 	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asKML relation must conform to a well-formed KML geometry XML string, as defined by its official specification."@en ;
 .
 
-<S20-dggs-content>
+<S19-dggs-content>
 	a sh:NodeShape ;
-	sh:property <S20-dggs-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
+	sh:property <S19-dggs-content-sub-start> ;
 	sh:targetSubjectsOf geo:asDGGS ;
 	sh:deactivated true ;
 	rdfs:comment "This shape is deactivated since the precise syntax of DGGS literals is now known"@en ;
 .
 
-<S20-dggs-content-sub-start>
+<S19-dggs-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asDGGS ;
 	sh:pattern "^$" ;
@@ -592,16 +546,16 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 21
+# Shape 20 - dimension checks
 #################################################
 
-<S21-dimension-coordinateDimension>
+<S20-dimension-coordinateDimension>
 	a sh:NodeShape ;
-	sh:property <S21-dimension-coordinateDimension-sub> ;
+	sh:property <S20-dimension-coordinateDimension-sub> ;
 	sh:targetSubjectsOf geo:dimension ;
 .
 
-<S21-dimension-coordinateDimension-sub>
+<S20-dimension-coordinateDimension-sub>
 	a sh:PropertyShape ;
 	sh:path geo:coordinateDimension ;
 	sh:sparql [
@@ -645,18 +599,17 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-
 #################################################
-# Shape 22 - geo:FeatureCollection
+# Shape 21 - geo:FeatureCollection
 #################################################
 
-<S22-FeatureCollectionClass-member-feature>
+<S21-FeatureCollectionClass-member-feature>
 	a sh:NodeShape ;
-	sh:property <S22-FeatureCollectionClass-minOneMember-feature-sub> , <S22-FeatureCollectionClass-member-onlyFeature-sub> ;
+	sh:property <S21-FeatureCollectionClass-minOneMember-feature-sub> , <S21-FeatureCollectionClass-member-onlyFeature-sub> ;
 	sh:targetClass geo:FeatureCollection ;
 .
 
-<S22-FeatureCollectionClass-minOneMember-feature-sub>
+<S21-FeatureCollectionClass-minOneMember-feature-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:minCount 1 ;
@@ -686,7 +639,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S22-FeatureCollectionClass-member-onlyFeature-sub>
+<S21-FeatureCollectionClass-member-onlyFeature-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:sparql [
@@ -736,18 +689,18 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 23 - geo:GeometryCollection
+# Shape 22 - geo:GeometryCollection
 #################################################
 
-<S23-GeometryCollectionClass-member-geometry>
+<S22-GeometryCollectionClass-member-geometry>
 	a sh:NodeShape ;
 	sh:property 
-		<S23-GeometryCollectionClass-minOneMember-geometry-sub> , 
-		<S23-GeometryCollectionClass-member-onlyGeometry-sub> ;
+		<S22-GeometryCollectionClass-minOneMember-geometry-sub> , 
+		<S22-GeometryCollectionClass-member-onlyGeometry-sub> ;
 	sh:targetClass geo:GeometryCollection ;
 .
 
-<S23-GeometryCollectionClass-minOneMember-geometry-sub>
+<S22-GeometryCollectionClass-minOneMember-geometry-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:minCount 1 ;
@@ -774,7 +727,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S23-GeometryCollectionClass-member-onlyGeometry-sub>
+<S22-GeometryCollectionClass-member-onlyGeometry-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:sparql [
@@ -819,18 +772,18 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 24 - geo:SpatialObjectCollection
+# Shape 23 - geo:SpatialObjectCollection
 #################################################
 
-<S24-SpatialObjectCollection-member-spatialObject>
+<S23-SpatialObjectCollection-member-spatialObject>
 	a sh:NodeShape ;
 	sh:property 
-		<S24-SpatialObjectCollection-minOneMember-spatialObject-sub> , 
-		<S24-SpatialObjectCollection-member-onlySpatialObject-sub> ;
+		<S23-SpatialObjectCollection-minOneMember-spatialObject-sub> , 
+		<S23-SpatialObjectCollection-member-onlySpatialObject-sub> ;
 	sh:targetClass geo:SpatialObjectCollection ;
 .
 
-<S24-SpatialObjectCollection-minOneMember-spatialObject-sub>
+<S23-SpatialObjectCollection-minOneMember-spatialObject-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:minCount 1 ;
@@ -859,7 +812,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S24-SpatialObjectCollection-member-onlySpatialObject-sub>
+<S23-SpatialObjectCollection-member-onlySpatialObject-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:sparql [

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -350,7 +350,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		<feature-x>
 			geo:hasGeometry [
 				geo:coordinateDimension 2 ;
-				geo:asWKT "POINT (153.084230 -27.322738)"^^geo:dggsLiteral ;
+				geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
 			] ;
 		.
 		""" ,
@@ -361,7 +361,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		<feature-y>
 			geo:hasGeometry [
 				geo:coordinateDimension 2 , 3 ;
-				geo:asWKT "POINT (153.084230 -27.322738)"^^geo:dggsLiteral ;
+				geo:asWKT "POINT (153.084230 -27.322738)"^^geo:wktLiteral ;
 			] ;
 		.
 		""" ;
@@ -484,7 +484,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S15-wkt-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asWKT ;
-	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)"
+	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)" ; # starts with space, < or P, C etc.
 	sh:flags "i" ;
 	sh:message "The content of an RDF literal with an incoming geo:asWKT relation must conform to a well-formed WKT string, as defined by its official specification (Simple Features Access)."@en ;
 .

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -492,7 +492,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 <S16-wkt-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asWKT ;
-	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<|p|c|s|l|t)" ; # starts with space, < or P, C etc.
+	sh:pattern "^\\s*$|^\\s*(M|P|C|S|L|T|<m||p|c|s|l|t)" ; # starts with space, < or P, C etc.
 	sh:flags "m" ;
 	sh:message "The content of an RDF literal with an incoming geo:asWKT relation must conform to a well-formed WKT string, as defined by its official specification (Simple Features Access)."@en ;
 .

--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -181,7 +181,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		)
 	] ;
 	sh:maxCount 0 ;
-	sh:message "A Geometry node cannot have an outgoing geo:hasGeometry property, or a specialization of it, at the same time (a geo:Feature cannot be a geo:Geometry at the same time)"@en ;
+	sh:message "A Geometry node cannot have an outgoing geo:hasGeometry property, or a specialization of it, since a geo:Geometry cannot be a geo:Feature and entialment of geo:hasGeometry would make it so."@en ;
 	skos:example 
 		"""
 		# A valid example: the Resource instance <resource-x-geom1> has an incoming geo:hasGeometry property and no outgoing geo:hasGeometry or specialization of it
@@ -266,7 +266,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 5-6-7-8
+# Shape 5-6-7-8-9
 #################################################
 
 <S5-asWKT-wktLiteral>
@@ -328,18 +328,40 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 	sh:message "The target of a geo:asKML property should be an RDF literal with datatype geo:kmlLiteral."@en ;
 .
 
+<S9-asDGGS-dggsLiteral>
+	a sh:NodeShape ;
+	sh:targetObjectsOf geo:asDGGS ;
+	sh:not [
+		a sh:PropertyShape ;
+		sh:datatype geo:wktLiteral ;
+	] ,
+	[
+		a sh:PropertyShape ;
+		sh:datatype geo:gmlLiteral ;
+	] ,
+	[
+		a sh:PropertyShape ;
+		sh:datatype geo:geoJSONLiteral ;
+	] ,
+	[
+		a sh:PropertyShape ;
+		sh:datatype geo:asKML ;
+	] ;		
+	sh:message "The target of a geo:asDGGS property must not be an RDF literal with datatype of one of the other non-DGGS geometry literal types. It must be eithr geo:dggsLiteral or specialised version of geo:dggsLiteral but this is un-testable so only the excluded type test is performed."@en ;
+.
+
 #################################################
-# Shape 9-10-11-12-13-14 (14a-14d)
+# Shape 10-11-12-13-14-15 (15a-15d)
 #################################################
 # each metadata property on geo:Geometry can exist only once
 
-<S9-many-coordinateDimension-one>
+<S10-many-coordinateDimension-one>
 	a sh:NodeShape ;
 	sh:property <S9-many-coordinateDimension-one-sub> ;
 	sh:targetSubjectsOf geo:coordinateDimension ;
 .
 	
-<S9-many-coordinateDimension-one-sub>
+<S10-many-coordinateDimension-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:coordinateDimension ;
 	sh:maxCount 1 ;
@@ -369,52 +391,52 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .	
 	
-<S10-many-dimension-one>
+<S11-many-dimension-one>
 	a sh:NodeShape ;
 	sh:property <S10-many-dimension-one-sub> ;
 	sh:targetSubjectsOf geo:dimension ;
 .
 	
-<S10-many-dimension-one-sub>
+<S11-many-dimension-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:dimension ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:dimension property."@en ;
 .	
 
-<S11-many-isEmpty-one>
+<S12-many-isEmpty-one>
 	a sh:NodeShape ;
 	sh:property <S11-many-isEmpty-one-sub> ;
 	sh:targetSubjectsOf geo:isEmpty ;
 .
 	
-<S11-many-isEmpty-one-sub>
+<S12-many-isEmpty-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:isEmpty ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:isEmpty property."@en ;
 .	
 
-<S12-many-isSimple-one>
+<S13-many-isSimple-one>
 	a sh:NodeShape ;
 	sh:property <S12-many-isSimple-one-sub> ;
 	sh:targetSubjectsOf geo:isSimple ;
 .
 	
-<S12-many-isSimple-one-sub>
+<S13-many-isSimple-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:isSimple ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have a maximum one outgoing geo:isSimple property."@en ;
 .	
 
-<S13-many-spatialDimension-one>
+<S14-many-spatialDimension-one>
 	a sh:NodeShape ;
 	sh:property <S13-many-spatialDimension-one-sub> ;
 	sh:targetSubjectsOf geo:spatialDimension ;
 .
 	
-<S13-many-spatialDimension-one-sub>
+<S14-many-spatialDimension-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:spatialDimension ;
 	sh:maxCount 1 ;
@@ -422,52 +444,52 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .	
 
 
-<S14a-many-hasSpatialResolution-one>
+<S15a-many-hasSpatialResolution-one>
 	a sh:NodeShape ;
-	sh:property <S14a-many-hasSpatialResolution-one-sub> ;
+	sh:property <S15a-many-hasSpatialResolution-one-sub> ;
 	sh:targetSubjectsOf geo:hasSpatialResolution ;
 .
 	
-<S14a-many-hasSpatialResolution-one-sub>
+<S15a-many-hasSpatialResolution-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:hasSpatialResolution ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialResolution property."@en ;
 .	
 
-<S14b-many-hasSpatialAccuracy-one>
+<S15b-many-hasSpatialAccuracy-one>
 	a sh:NodeShape ;
-	sh:property <S14b-many-hasSpatialAccuracy-one-sub> ;
+	sh:property <S15b-many-hasSpatialAccuracy-one-sub> ;
 	sh:targetSubjectsOf geo:hasSpatialAccuracy ;
 .
 	
-<S14b-many-hasSpatialAccuracy-one-sub>
+<S15b-many-hasSpatialAccuracy-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:hasSpatialAccuracy ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasSpatialAccuracy property."@en ;
 .	
 
-<S14c-many-hasMetricSpatialAccuracy-one>
+<S15c-many-hasMetricSpatialAccuracy-one>
 	a sh:NodeShape ;
-	sh:property <S14c-many-hasMetricSpatialAccuracy-one-sub> ;
+	sh:property <S15c-many-hasMetricSpatialAccuracy-one-sub> ;
 	sh:targetSubjectsOf geo:hasMetricSpatialAccuracy ;
 .
 	
-<S14c-many-hasMetricSpatialAccuracy-one-sub>
+<S15c-many-hasMetricSpatialAccuracy-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:hasMetricSpatialAccuracy ;
 	sh:maxCount 1 ;
 	sh:message "A geo:Geometry node should have maximum of one outgoing geo:hasMetricSpatialAccuracy property."@en ;
 .
 
-<S14d-many-hasMetricSpatialResolution-one>
+<S15d-many-hasMetricSpatialResolution-one>
 	a sh:NodeShape ;
-	sh:property <S14d-many-hasMetricSpatialResolution-one-sub> ;
+	sh:property <S15d-many-hasMetricSpatialResolution-one-sub> ;
 	sh:targetSubjectsOf geo:hasMetricSpatialResolution ;
 .
 	
-<S14d-many-hasMetricSpatialResolution-one-sub>
+<S15d-many-hasMetricSpatialResolution-one-sub>
 	a sh:PropertyShape ;
 	sh:path geo:hasMetricSpatialResolution ;
 	sh:maxCount 1 ;
@@ -475,17 +497,17 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .	
 
 #################################################
-# Shape 15-16-17-18-19
+# Shape 16-17-18-19-20
 #################################################
 # regex to check if content of WKT/GeoJSON/KML/GML literals complies with the basic patterns of such geometries, if possible (check start and/or end to find e.g. copy/paste errors with GeoSPARQL properties and datatypes, not to check if the content of a literal is fully compliant to the geometry format specification)
 
-<S15-wkt-content>
+<S16-wkt-content>
 	a sh:NodeShape ;
-	sh:property <S15-wkt-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
+	sh:property <S16-wkt-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
 	sh:targetSubjectsOf geo:asWKT ;
 .
 
-<S15-wkt-content-sub-start>
+<S16-wkt-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asWKT ;
 	sh:pattern "^\\s*$|^\\s*(P|C|S|L|T|<)" ;  # starts with P, C, S, L, T, or < for Point, TIN etc. or IRI
@@ -513,56 +535,73 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S16-gml-content>
+<S17-gml-content>
 	a sh:NodeShape ;
-	sh:property <S16-gml-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
+	sh:property <S17-gml-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
 	sh:targetSubjectsOf geo:asGML ;
 .
 
-<S16-gml-content-sub-start>
+<S17-gml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGML ;
 	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asGML relation must conform to a well-formed GML geometry XML string, as defined by its official specification."@en ;
 .
 
-<S17-geojson-content>
+<S18-geojson-content>
 	a sh:NodeShape ;
-	sh:property <S17-geojson-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
+	sh:property <S18-geojson-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
 	sh:targetSubjectsOf geo:asGeoJSON ;
 .
 
-<S17-geojson-content-sub-start>
+<S18-geojson-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asGeoJSON ;
 	sh:pattern "^\\s*$|^\\s*({)(.*)(})\\s*$" ;  # starts with { ends with }
 	sh:message "The content of an RDF literal with an incoming geo:asGeoJSON relation must conform to a well-formed GeoJSON geometry string, as defined by its official specification."@en ;
 .
 
-<S18-kml-content>
+<S19-kml-content>
 	a sh:NodeShape ;
 	sh:property <S18-kml-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
 	sh:targetSubjectsOf geo:asKML ;
 .
 
-<S18-kml-content-sub-start>
+<S19-kml-content-sub-start>
 	a sh:PropertyShape ;
 	sh:path geo:asKML ;
 	sh:pattern "^\\s*$|^\\s*(<)(.+)(>)\\s*$" ;  # starts with < ends with >
 	sh:message "The content of an RDF literal with an incoming geo:asKML relation must conform to a well-formed KML geometry XML string, as defined by its official specification."@en ;
 .
 
+<S20-dggs-content>
+	a sh:NodeShape ;
+	sh:property <S20-dggs-content-sub-start> ; # the example in the SHACL spec (https://www.w3.org/TR/shacl/#constraints) refers to two property shapes: one for the start and one for the end
+	sh:targetSubjectsOf geo:asDGGS ;
+	sh:deactivated true ;
+	rdfs:comment "This shape is deactivated since the precise syntax of DGGS literals is now known"@en ;
+.
+
+<S20-dggs-content-sub-start>
+	a sh:PropertyShape ;
+	sh:path geo:asDGGS ;
+	sh:pattern "^$" ;
+	sh:message "The content of an RDF literal with an incoming geo:asDGGS relation must conform to DGGS literals, as defined by their specifications."@en ;
+	sh:deactivated true ;
+	rdfs:comment "This shape is deactivated since the precise syntax of DGGS literals is now known"@en ;
+.
+
 #################################################
-# Shape 20
+# Shape 21
 #################################################
 
-<S20-dimension-coordinateDimension>
+<S21-dimension-coordinateDimension>
 	a sh:NodeShape ;
-	sh:property <S20-dimension-coordinateDimension-sub> ;
+	sh:property <S21-dimension-coordinateDimension-sub> ;
 	sh:targetSubjectsOf geo:dimension ;
 .
 
-<S20-dimension-coordinateDimension-sub>
+<S21-dimension-coordinateDimension-sub>
 	a sh:PropertyShape ;
 	sh:path geo:coordinateDimension ;
 	sh:sparql [
@@ -608,16 +647,16 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 
 
 #################################################
-# Shape 21 - geo:FeatureCollection
+# Shape 22 - geo:FeatureCollection
 #################################################
 
-<S21-FeatureCollectionClass-member-feature>
+<S22-FeatureCollectionClass-member-feature>
 	a sh:NodeShape ;
-	sh:property <S21-FeatureCollectionClass-minOneMember-feature-sub> , <S21-FeatureCollectionClass-member-onlyFeature-sub> ;
+	sh:property <S22-FeatureCollectionClass-minOneMember-feature-sub> , <S22-FeatureCollectionClass-member-onlyFeature-sub> ;
 	sh:targetClass geo:FeatureCollection ;
 .
 
-<S21-FeatureCollectionClass-minOneMember-feature-sub>
+<S22-FeatureCollectionClass-minOneMember-feature-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:minCount 1 ;
@@ -647,7 +686,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S21-FeatureCollectionClass-member-onlyFeature-sub>
+<S22-FeatureCollectionClass-member-onlyFeature-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:sparql [
@@ -697,16 +736,18 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 22 - geo:GeometryCollection
+# Shape 23 - geo:GeometryCollection
 #################################################
 
-<S22-GeometryCollectionClass-member-geometry>
+<S23-GeometryCollectionClass-member-geometry>
 	a sh:NodeShape ;
-	sh:property <S22-GeometryCollectionClass-minOneMember-geometry-sub> , <S22-GeometryCollectionClass-member-onlyGeometry-sub> ;
+	sh:property 
+		<S23-GeometryCollectionClass-minOneMember-geometry-sub> , 
+		<S23-GeometryCollectionClass-member-onlyGeometry-sub> ;
 	sh:targetClass geo:GeometryCollection ;
 .
 
-<S22-GeometryCollectionClass-minOneMember-geometry-sub>
+<S23-GeometryCollectionClass-minOneMember-geometry-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:minCount 1 ;
@@ -733,7 +774,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S22-GeometryCollectionClass-member-onlyGeometry-sub>
+<S23-GeometryCollectionClass-member-onlyGeometry-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:sparql [
@@ -778,16 +819,18 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 .
 
 #################################################
-# Shape 23 - geo:SpatialObjectCollection
+# Shape 24 - geo:SpatialObjectCollection
 #################################################
 
-<S23-SpatialObjectCollection-member-spatialObject>
+<S24-SpatialObjectCollection-member-spatialObject>
 	a sh:NodeShape ;
-	sh:property <S23-SpatialObjectCollection-minOneMember-spatialObject-sub> , <S23-SpatialObjectCollection-member-onlySpatialObject-sub> ;
+	sh:property 
+		<S24-SpatialObjectCollection-minOneMember-spatialObject-sub> , 
+		<S24-SpatialObjectCollection-member-onlySpatialObject-sub> ;
 	sh:targetClass geo:SpatialObjectCollection ;
 .
 
-<S23-SpatialObjectCollection-minOneMember-spatialObject-sub>
+<S24-SpatialObjectCollection-minOneMember-spatialObject-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:minCount 1 ;
@@ -816,7 +859,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 		""" ;
 .
 
-<S23-SpatialObjectCollection-member-onlySpatialObject-sub>
+<S24-SpatialObjectCollection-member-onlySpatialObject-sub>
 	a sh:PropertyShape ;
 	sh:path rdfs:member ;
 	sh:sparql [


### PR DESCRIPTION
I have fund a few bugs with our SHACL files and I've even found a bug with the pySHACL tool I usually use for SAHCL validation, which I've now fixed.

To ensure we have confidence in our SHACL shapes, I've created a test suite for them which contains valid & invalid example data for each shape.

The SHACL file has change a lot but there's been no change in scope: I've only patched things I could show to be errors through the valid & invalid data files and added in some missing tests - various formats that weren't present in GeoSPARQL 1.1 when the first Shapes file version was made.