### PR TITLE
Update S22-FeatureCollectionClass-member...

### DIFF
--- a/1.1/validator.ttl
+++ b/1.1/validator.ttl
@@ -664,7 +664,7 @@ As of GeoSPARQL 1.1, this validator is not normative, only informative, however 
 			WHERE {
 				$this rdfs:member ?feature .
 				FILTER NOT EXISTS {
-					?feature geo:hasGeometry ?geometry .
+					?feature a geo:Feature .
 				}
 			}
 		""" ;


### PR DESCRIPTION
An instance of geo:FeatureCollection should only have outgoing rdfs:member going to geo:Feature instances
SPARQL rule changed from:
```			SELECT $this
			WHERE {
				$this rdfs:member ?feature .
				FILTER NOT EXISTS {
					?feature geo:hasGeometry geo:Geometry .
				}
			}```
to
```			SELECT $this
			WHERE {
				$this rdfs:member ?feature .
				FILTER NOT EXISTS {
					?feature a geo:Feature .
				}
			}```