### PR TITLE
Updating Submitting Organizations section

### DIFF
--- a/1.1/spec/01-Preamble.adoc
+++ b/1.1/spec/01-Preamble.adoc
@@ -16,20 +16,15 @@ This document has the role of _specification_ and authoritatively defines many o
 The following organizations submitted this Implementation Specification to the Open Geospatial Consortium Inc.:
 
 [loweralpha]
-.. Australian Bureau of Meteorology
-.. Bentley Systems, Inc.
+.. Australian Bureau of Meteorology (To be confirmed)
+.. Bentley Systems, Inc. (To be confirmed)
 .. CSIRO
-.. Defence Geospatial Information Working Group (DGIWG)
-.. GeoConnections - Natural Resources Canada
-.. Interactive Instruments GmbH
-.. GeoScape Australia
+.. Geoscape Australia
 .. Mainz University Of Applied Sciences
 .. Oracle America
-.. Ordnance Survey
-.. Raytheon Company
+.. Ordnance Survey (To be confirmed)
 .. SURROUND Australia Pty Ltd.
-.. Traverse Technologies, Inc.
-.. US Geological Survey (USGS)
+.. US Geological Survey (USGS) (To be confirmed)
 
 
 === iii. Submission contact points


### PR DESCRIPTION
This PR changes the Submitting Organizations section to
remove previous Submitting Orgs who have indicated a desire
not to be listed as such this time around.

Emails have gone out to all previous Submitting Organizations.
Some new organizations are yet to be listed.