### PR TITLE
Update E.13 Ordnance Survey mapping

### DIFF
--- a/1.1/spec/20-Annex-E.adoc
+++ b/1.1/spec/20-Annex-E.adoc
@@ -328,7 +328,8 @@ https://github.com/openplannerteam/routable-tiles-ontology
 |===
 
 == E.13 Ordnance Survey UK Spatial Ontology
-
+Note: these two ontologies will be withdrawn during 2022.
+"We are pleased to have contributed to the discussion some ten years ago but recognise that the subject area has moved on. We would not recommend people starting to relate to our ontology now, and we look forward to migrating to some more authoritative one in due course."
 Source: http://www.ordnancesurvey.co.uk/legacy/ontologies/spatialrelations.owl
 http://www.ordnancesurvey.co.uk/legacy/ontologies/geometry.owl
 
@@ -336,9 +337,9 @@ http://www.ordnancesurvey.co.uk/legacy/ontologies/geometry.owl
 | From Element | Mapping relation | To Element | Notes 
 | `spatialuk:contains` | `owl:equivalentProperty` | `geo:sfContains` |
 | `spatialuk:disjoint` | `owl:equivalentProperty` | `geo:sfDisjoint` |
-| `spatialuk:easting` | `owl:equivalentProperty` | - | Easting describes a latitude coordinate east of the national UK grid
+| `spatialuk:easting` | `owl:equivalentProperty` | - | Distance in metres east of National Grid origin
 | `spatialuk:equals` | `owl:equivalentProperty` | `geo:sfEquals` |
-| `spatialuk:northing` | `owl:equivalentProperty` | - | Easting describes a longitude coordinate north of the national UK grid
+| `spatialuk:northing` | `owl:equivalentProperty` | - | Distance in metres north of National Grid origin
 | `spatialuk:touches` | `owl:equivalentProperty` | `geo:sfTouches` |
 | `spatialuk:within` | `owl:equivalentProperty` | `geo:sfWithin` |
 | `spatialukgeom:AbstractGeometry` | `owl:equivalentProperty` | `geo:Geometry` |


### PR DESCRIPTION
We are pleased to have contributed to the discussion some ten years ago but recognise that the subject area has moved on. We would not recommend people starting to relate to our ontology now, and we look forward to migrating to some more authoritative one in due course.

Also, eastings & northings are best not confused with latitudes & longitudes. I have put in the definitions from the OS ontology: they are metres from an origin, in a defined "flat & square" projection.

I'm glad you've ignored the grid square classes in our ontologies!