### PR TITLE
Replace srs with crs

### DIFF
--- a/1.1/spec/01-Preamble.adoc
+++ b/1.1/spec/01-Preamble.adoc
@@ -75,9 +75,11 @@ to
 |===
 
 === Major changes between versions 1.0 and 1.1
-Version 1.1 of GeoSPARQL was released approximately 9 years after version 1.0. It contains no breaking changes to 1.0, but does contain additions: whole new profile resources, new ontology elements and new functions. The major changes are given in the tables below.
+Version 1.1 of GeoSPARQL was released approximately 9 years after version 1.0. It contains no breaking changes to 1.0, but does contain additions annd clarifications. Profile resources, ontology elements and functions were added. The major changes are given in the tables below.
 
-These new profile resources are resources - documents - that are separate from this specification. The new _profile defintion_ lists all the GeoSPARQL 1.1 resources.
+==== Profile resources
+
+These new profile resources are resources - documents - that are separate from this specification. The new _profile definition_ lists all the GeoSPARQL 1.1 resources.
 
 |===
 |New resource | Location
@@ -86,6 +88,8 @@ These new profile resources are resources - documents - that are separate from t
 |GeoSPARQL Rules in RIF | http://www.opengis.net/def/geosparql-rifrules
 |RDF validation file | http://www.opengis.net/def/geosparql-shapes
 |===
+
+==== Ontology elements and functions
 
 These new ontology elements and new functions are normatively defined in this specification document.
 
@@ -149,6 +153,12 @@ These new ontology elements and new functions are normatively defined in this sp
 |aggConcaveHull | <<Function: geof:aggConcaveHull>>
 |aggUnion | <<Function: geof:aggUnion>>
 |===
+
+==== Clarifications
+* The terms Spatial Reference System (SRS) and Coordinate Reference System (CRS) are no longer interchangeable. Spatial Reference System is now taken to be a broader category than Coordinate Reference System, see the <<Terms and definitions>>.
+* Class definitions were updated to be more self-contained and easier to understand for people without a background in geoinformatics.
+* A section was added on <<Recommendation for specification of units of measurement,the specification of units of measurement>>.
+* A section was added on the <<Influence of Coordinate Reference Systems on geometric computations>>.
 
 == v. Changes to the OGC® Abstract Specification
 The OGC® Abstract Specification does not require changes to accommodate this OGC® standard.

--- a/1.1/spec/09-Part-06.adoc
+++ b/1.1/spec/09-Part-06.adoc
@@ -418,7 +418,7 @@ SELECT (COUNT(*) AS ?cnt)
 WHERE { :f1 geo:sfDisjoint :f1 }
 ```
 
-Such cases are application-specific data modeling errors and are therefore outside of the scope of the GeoSPARQL specification., however it is recommended that multiple geometries indicated with <<Property: geo:hasDefaultGeometry, `geo:hasDefaultGeometry`>> should be differentiated by `Geometry` class properties, perhaps relating to precision, SRS etc.
+Such cases are application-specific data modeling errors and are therefore outside of the scope of the GeoSPARQL specification., however it is recommended that multiple geometries indicated with <<Property: geo:hasDefaultGeometry, `geo:hasDefaultGeometry`>> should be differentiated by `Geometry` class properties, perhaps relating to precision, CRS etc.
 
 ==== Property: geo:hasBoundingBox
 

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -295,7 +295,7 @@ This section establishes the requirements for representing Geometry data in RDF 
 
 GeoSPARQL presents specializations of the `geo:hasSerialization` property for indicating particular serializations and specialized datatype literals for containing them but does not provide comprehensive definitions of their content since these are given in standards external to GeoSPARQL, all of which are referenced.
 
-GeoSPARQL does present some requirements for literal structure which extend the serialization-defining standards, for example the requirement to allow indications of spatial reference systems within WKT geometry representations.
+GeoSPARQL does present some requirements for literal structure which extend the serialization-defining standards, for example the requirement to allow indications of coordinate reference systems within WKT geometry representations.
 
 [[NOTE]]
 ====
@@ -336,29 +336,29 @@ opt-iri-and-space = "<" IRI ">" LWSP / ""
 
 The token `opt-iri-and-space` may be either an IRI and space or nothing (`""`), the token `IRI` (Internationalized Resource Identifier) is essentially a web address and is defined in <<IETF3987>> and the token `LWSP`, is one or more white space characters, as defined in <<IETF5234>>. `geometric-data` is the Well-Known Text representation of the Geometry, defined in <<ISO13249>>.
 
-In the absence of a leading spatial reference system IRI, the following spatial reference system IRI will be assumed: http://www.opengis.net/def/crs/OGC/1.3/CRS84[`+<http://www.opengis.net/def/crs/OGC/1.3/CRS84>+`]. This IRI denotes WGS 84 longitude-latitude.
+In the absence of a leading coordinate reference system IRI, the following coordinate reference system IRI will be assumed: http://www.opengis.net/def/crs/OGC/1.3/CRS84[`+<http://www.opengis.net/def/crs/OGC/1.3/CRS84>+`]. This IRI denotes WGS 84 longitude-latitude.
 
 [#req_geometry_extension_wkt-literal-default-srs]
 |===
-| *Req 16* The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[`+<http://www.opengis.net/def/crs/OGC/1.3/CRS84>+`] shall be assumed as the spatial reference system for <<RDFS Datatype: geo:wktLiteral, `geo:wktLiteral`>> instances that do not specify an explicit spatial reference system IRI.
+| *Req 16* The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[`+<http://www.opengis.net/def/crs/OGC/1.3/CRS84>+`] shall be assumed as the coordinate reference system for <<RDFS Datatype: geo:wktLiteral, `geo:wktLiteral`>> instances that do not specify an explicit coordinate reference system IRI.
 |http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-default-srs[`http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-literal-default-srs`]
 |===
 
-The OGC maintains a set of SRS IRIs under the `+http://www.opengis.net/def/crs/+` namespace and IRIs from this set are recommended for use, however others may also be used, as long as they are valid IRIs.
+The OGC maintains a set of CRS IRIs under the `+http://www.opengis.net/def/crs/+` namespace and IRIs from this set are recommended for use, however others may also be used, as long as they are valid IRIs.
 
 [#req_geometry_extension_wkt-axis-order]
 |===
-| *Req 17* Coordinate tuples within <<RDFS Datatype: geo:wktLiteral, `geo:wktLiteral`>> shall be interpreted using the axis order defined in the spatial reference system used.
+| *Req 17* Coordinate tuples within <<RDFS Datatype: geo:wktLiteral, `geo:wktLiteral`>> shall be interpreted using the axis order defined in the coordinate reference system used.
 |http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-axis-order[`http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/wkt-axis-order`]
 |===
 
-The example <<RDFS Datatype: geo:wktLiteral, WKT Literal>> below encodes a point Geometry using the default WGS84 geodetic longitude-latitude spatial reference system:
+The example <<RDFS Datatype: geo:wktLiteral, WKT Literal>> below encodes a point Geometry using the default WGS84 geodetic longitude-latitude coordinate reference system:
 
 ```turtle
 "Point(-83.38 33.95)"^^<http://www.opengis.net/ont/geosparql#wktLiteral>
 ```
 
-A second example below encodes the same point as encoded in the example above but using a SRS identified by http://www.opengis.net/def/SRS/EPSG/0/4326[`+http://www.opengis.net/def/SRS/EPSG/0/4326+`]: a WGS 84 geodetic latitude-longitude spatial reference system (note that this spatial reference system defines a different axis order):
+A second example below encodes the same point as encoded in the example above but using a CRS identified by http://www.opengis.net/def/SRS/EPSG/0/4326[`+http://www.opengis.net/def/SRS/EPSG/0/4326+`]: a WGS 84 geodetic latitude-longitude coordinate reference system (note that this coordinate reference system defines a different axis order):
 
 ```turtle
 "<http://www.opengis.net/def/crs/EPSG/0/4326> Point(33.95 -83.38)"^^<http://www.opengis.net/ont/geosparql#wktLiteral>
@@ -433,7 +433,7 @@ Valid <<RDFS Datatype: geo:gmlLiteral, GML Literal>> instances are formed by enc
 |http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal[`http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/gml-literal`]
 |===
 
-The example <<RDFS Datatype: geo:gmlLiteral, GML Literal>> below encodes a point Geometry in the WGS 84 geodetic longitude-latitude spatial reference system using GML version 3.2:
+The example <<RDFS Datatype: geo:gmlLiteral, GML Literal>> below encodes a point Geometry in the WGS 84 geodetic longitude-latitude coordinate reference system using GML version 3.2:
 
 ```turtle
 """
@@ -519,11 +519,11 @@ Valid <<RDFS Datatype: geo:geoJSONLiteral, GeoJSON Literal>> instances are forme
 
 [#req_geometry_extension_geojson-literal-srs]
 |===
-| *Req 27* RDFS Literals of type <<RDFS Datatype: geo:geoJSONLiteral, `geo:geoJSONLiteral`>> do not contain a SRS definition. All literals of this type shall, according to the GeoJSON specification, be encoded only in, and be assumed to use, the WGS84 geodetic longitude-latitude spatial reference system (http://www.opengis.net/def/crs/OGC/1.3/CRS84[`http://www.opengis.net/def/crs/OGC/1.3/CRS84`]).
+| *Req 27* RDFS Literals of type <<RDFS Datatype: geo:geoJSONLiteral, `geo:geoJSONLiteral`>> do not contain a CRS definition. All literals of this type shall, according to the GeoJSON specification, be encoded only in, and be assumed to use, the WGS84 geodetic longitude-latitude coordinate reference system (http://www.opengis.net/def/crs/OGC/1.3/CRS84[`http://www.opengis.net/def/crs/OGC/1.3/CRS84`]).
 |http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-srs[`http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geojson-literal-srs`]
 |===
 
-The example <<RDFS Datatype: geo:geoJSONLiteral, GeoJSON Literal>> below encodes a point Geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:
+The example <<RDFS Datatype: geo:geoJSONLiteral, GeoJSON Literal>> below encodes a point Geometry using the default WGS84 geodetic longitude-latitude coordinate reference system for Simple Features 1.0:
 
 ```turtle
 """
@@ -602,11 +602,11 @@ Valid <<RDFS Datatype: geo:kmlLiteral, KML Literal>> instances are formed by enc
 
 [#req_geometry_extension_kml-literal-srs]
 |===
-| *Req 32* RDFS Literals of type <<RDFS Datatype: geo:kmlLiteral, `geo:kmlLiteral`>> do not contain a SRS definition. All literals of this type shall according to the KML specification only be encoded in and assumed to use the WGS84 geodetic longitude-latitude spatial reference system (http://www.opengis.net/def/crs/OGC/1.3/CRS84[`http://www.opengis.net/def/crs/OGC/1.3/CRS84`]).
+| *Req 32* RDFS Literals of type <<RDFS Datatype: geo:kmlLiteral, `geo:kmlLiteral`>> do not contain a CRS definition. All literals of this type shall according to the KML specification only be encoded in and assumed to use the WGS84 geodetic longitude-latitude coordinate reference system (http://www.opengis.net/def/crs/OGC/1.3/CRS84[`http://www.opengis.net/def/crs/OGC/1.3/CRS84`]).
 |http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-srs[`http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/kml-literal-srs`]
 |===
 
-The example <<RDFS Datatype: geo:kmlLiteral, KML Literal>> below encodes a point Geometry using the default WGS84 geodetic longitude-latitude spatial reference system for Simple Features 1.0:
+The example <<RDFS Datatype: geo:kmlLiteral, KML Literal>> below encodes a point Geometry using the default WGS84 geodetic longitude-latitude coordinate reference system for Simple Features 1.0:
 
 ```turtle
 """
@@ -828,7 +828,7 @@ An invocation of any of the following functions with invalid arguments produces 
 * An argument of an unexpected type
 * An invalid geometry literal value
 * An non-fitting geometry type for the given function
-* A geometry literal from a spatial reference system that is incompatible with the spatial reference system used for calculations
+* A geometry literal from a coordinate reference system that is incompatible with the coordinate reference system used for calculations
 * An invalid units IRI
 
 A more detailed description of expected inputs and expected outputs of the given functions is shown in Annex B.
@@ -865,7 +865,7 @@ Returns the area of `geom1` in square meters. Must return zero for all geometry 
 geof:boundary (geom1: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns the closure of the boundary of `geom1`. Calculations are in the spatial reference system of `geom1`.
+This function returns the closure of the boundary of `geom1`. Calculations are in the coordinate reference system of `geom1`.
 
 ==== Function: geof:buffer
 
@@ -875,7 +875,7 @@ geof:buffer (geom: ogc:geomLiteral,
              units: xsd:anyURI): ogc:geomLiteral
 ```
 
-Returns a geometric object that represents all Points whose distance from `geom1` is less than or equal to the `radius` measured in `units`. Calculations are in the spatial reference system of `geom1`.
+Returns a geometric object that represents all Points whose distance from `geom1` is less than or equal to the `radius` measured in `units`. Calculations are in the coordinate reference system of `geom1`.
 NOTE: See the <<Recommendation for specification of units of measurement>>.
 
 ==== Function: geof:convexHull
@@ -884,7 +884,7 @@ NOTE: See the <<Recommendation for specification of units of measurement>>.
 geof:convexHull (geom1: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-The function http://www.opengis.net/def/function/geosparql/convexHull[`geof:convexHull`] returns a geometric object that represents all Points in the convex hull of `geom1`. Calculations are in the spatial reference system of `geom1`.
+The function http://www.opengis.net/def/function/geosparql/convexHull[`geof:convexHull`] returns a geometric object that represents all Points in the convex hull of `geom1`. Calculations are in the coordinate reference system of `geom1`.
 
 ==== Function: geof:coordinateDimension
 
@@ -901,7 +901,7 @@ geof:difference (geom1: ogc:geomLiteral,
                  geom2: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns a geometric object that represents all Points in the set difference of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
+This function returns a geometric object that represents all Points in the set difference of `geom1` with `geom2`. Calculations are in the coordinate reference system of `geom1`.
 
 ==== Function: geof:dimension
 
@@ -919,7 +919,7 @@ geof:distance (geom1: ogc:geomLiteral,
                units: xsd:anyURI): xsd:double
 ```
 
-Returns the shortest distance in `units` between any two Points in the two geometric objects. Calculations are in spatial reference system of `geom1`.
+Returns the shortest distance in `units` between any two Points in the two geometric objects. Calculations are in coordinate reference system of `geom1`.
 NOTE: See the <<Recommendation for specification of units of measurement>>.
 
 ==== Function: geof:envelope
@@ -928,7 +928,7 @@ NOTE: See the <<Recommendation for specification of units of measurement>>.
 geof:envelope (geom1: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns the minimum bounding box - a rectangle - of `geom1`. Calculations are in the spatial reference system of `geom1`.
+This function returns the minimum bounding box - a rectangle - of `geom1`. Calculations are in the coordinate reference system of `geom1`.
 
 ==== Function: geof:geometryN
 
@@ -952,7 +952,7 @@ Returns the name of the subtype of Geometry of which this geometric object is an
 geof:getSRID (geom: ogc:geomLiteral): xsd:anyURI
 ```
 
-Returns the spatial reference system IRI for `geom`.
+Returns the coordinate reference system IRI for `geom`.
 
 ==== Function: geof:intersection
 
@@ -961,7 +961,7 @@ geof:intersection (geom1: ogc:geomLiteral,
                    geom2: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-Returns a geometric object that represents all Points in the intersection of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
+Returns a geometric object that represents all Points in the intersection of `geom1` with `geom2`. Calculations are in the coordinate reference system of `geom1`.
 
 ==== Function: geof:is3D
 
@@ -1090,15 +1090,15 @@ geof:symDifference (geom1: ogc:geomLiteral,
                     geom2: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns a geometric object that represents all Points in the set symmetric difference of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
+This function returns a geometric object that represents all Points in the set symmetric difference of `geom1` with `geom2`. Calculations are in the coordinate reference system of `geom1`.
 
 ==== Function: geof:transform
 
 ```
-geof:transform (geom: ogc:geomLiteral, srsIRI: xsd:anyURI): ogc:geomLiteral
+geof:transform (geom: ogc:geomLiteral, crsIRI: xsd:anyURI): ogc:geomLiteral
 ```
 
-http://www.opengis.net/def/function/geosparql/transform[geof:transform] converts `geom` to a spatial reference system defined by srsIRI. The function raises an error if a transformation is not mathematically possible.
+http://www.opengis.net/def/function/geosparql/transform[geof:transform] converts `geom` to a coordinate reference system defined by crsIRI. The function raises an error if a transformation is not mathematically possible.
 
 NOTE: We recommend that implementers use the same literal type as a result of this function that is passed as a parameter to this function.
 
@@ -1109,7 +1109,7 @@ geof:union (geom1: ogc:geomLiteral,
             geom2: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns a geometric object that represents all Points in the union of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
+This function returns a geometric object that represents all Points in the union of `geom1` with `geom2`. Calculations are in the coordinate reference system of `geom1`.
 
 [#req_geometry_extension_srid-function]
 |===

--- a/1.1/spec/12-Part-09.adoc
+++ b/1.1/spec/12-Part-09.adoc
@@ -34,7 +34,7 @@ geof:relate (geom1: ogc:geomLiteral,
              pattern-matrix: xsd:string): xsd:boolean
 ```
 
-Returns `true` if the spatial relationship between `geom1` and `geom2` corresponds to one with acceptable values for the specified pattern-matrix. Otherwise, this function returns `false`. `pattern-matrix` represents a DE-9IM intersection pattern consisting of `T` (true) and `F` (false) values. The spatial reference system for `geom1` is used for spatial calculations.
+Returns `true` if the spatial relationship between `geom1` and `geom2` corresponds to one with acceptable values for the specified pattern-matrix. Otherwise, this function returns `false`. `pattern-matrix` represents a DE-9IM intersection pattern consisting of `T` (true) and `F` (false) values. The coordinate reference system for `geom1` is used for spatial calculations.
 
 === Simple Features Relation Family (relation_family=Simple Features)
 
@@ -55,7 +55,7 @@ as SPARQL extension functions, consistent with their corresponding DE-9IM inters
 |http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/sf-query-functions[`http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/sf-query-functions`]
 |===
 
-Boolean query functions defined for the Simple Features relation family, along with their associated DE-9IM intersection patterns, are shown in <<simple_features_query_functions>> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (`geom1` and `geom2`) of the geometry literal _serialization_ type _specified_ by serialization and version. Each function returns an http://www.w3.org/2001/XMLSchema#boolean[`xsd:boolean`] value of `true` if the specified relation exists between `geom1` and `geom2` and returns false otherwise. In each case, the spatial reference system of `geom1` is used for spatial calculations.
+Boolean query functions defined for the Simple Features relation family, along with their associated DE-9IM intersection patterns, are shown in <<simple_features_query_functions>> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (`geom1` and `geom2`) of the geometry literal _serialization_ type _specified_ by serialization and version. Each function returns an http://www.w3.org/2001/XMLSchema#boolean[`xsd:boolean`] value of `true` if the specified relation exists between `geom1` and `geom2` and returns false otherwise. In each case, the coordinate reference system of `geom1` is used for spatial calculations.
 
 [#simple_features_query_functions]
 .Simple Features Query Functions
@@ -99,7 +99,7 @@ as SPARQL extension functions, consistent with their corresponding DE-9IM inters
 |http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/eh-query-functions[`http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/eh-query-functions`]
 |===
 
-Boolean query functions defined for the _Egenhofer_ relation family, along with their associated DE-9IM intersection patterns, are shown in <<egenhofer_query_functions>> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (`geom1` and `geom2`) of the geometry literal serialization type specified by _serialization_ and _version_. Each function returns an http://www.w3.org/2001/XMLSchema#boolean[`xsd:boolean`] value of `true` if the specified relation exists between `geom1` and `geom2` and returns `false` otherwise. In each case, the spatial reference system of geom1 is used for spatial calculations.
+Boolean query functions defined for the _Egenhofer_ relation family, along with their associated DE-9IM intersection patterns, are shown in <<egenhofer_query_functions>> below. Multi-row intersection patterns should be interpreted as a logical OR of each row. Each function accepts two arguments (`geom1` and `geom2`) of the geometry literal serialization type specified by _serialization_ and _version_. Each function returns an http://www.w3.org/2001/XMLSchema#boolean[`xsd:boolean`] value of `true` if the specified relation exists between `geom1` and `geom2` and returns `false` otherwise. In each case, the coordinate reference system of geom1 is used for spatial calculations.
 
 [#egenhofer_query_functions]
 .Egenhofer Query Functions
@@ -143,7 +143,7 @@ as SPARQL extension functions, consistent with their corresponding DE-9IM inters
 |http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/rcc8-query-functions[`http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/rcc8-query-functions`]
 |===
 
-Boolean query functions defined for the _RCC8_ relation family, along with their associated DE-9IM intersection patterns, are shown in <<rcc8_query_functions>> below. Each function accepts two arguments (`geom1` and `geom2`) of the geometry literal serialization type specified by _serialization_ and _version_. Each function returns an http://www.w3.org/2001/XMLSchema#boolean[`xsd:boolean`] value of `true` if the specified relation exists between `geom1` and `geom2` and returns `false` otherwise. In each case, the spatial reference system of geom1 is used for spatial calculations.
+Boolean query functions defined for the _RCC8_ relation family, along with their associated DE-9IM intersection patterns, are shown in <<rcc8_query_functions>> below. Each function accepts two arguments (`geom1` and `geom2`) of the geometry literal serialization type specified by _serialization_ and _version_. Each function returns an http://www.w3.org/2001/XMLSchema#boolean[`xsd:boolean`] value of `true` if the specified relation exists between `geom1` and `geom2` and returns `false` otherwise. In each case, the coordinate reference system of geom1 is used for spatial calculations.
 
 [#rcc8_query_functions]
 .RCC8 Query Functions

--- a/1.1/spec/16-Annex-A.adoc
+++ b/1.1/spec/16-Annex-A.adoc
@@ -315,17 +315,17 @@ All RDFS Literals of type <<RDFS Datatype: geo:wktLiteral, `geo:wktLiteral`>> sh
 ==== A.3.2.2 `/conf/geometry-extension/wkt-literal-default-srs`
 *Requirement*: `/req/geometry-extension/wkt-literal-default-srs`
 
-The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[`+<http://www.opengis.net/def/crs/OGC/1.3/CRS84>+`] shall be assumed as the spatial reference system for <<RDFS Datatype: geo:wktLiteral, `geo:wktLiteral`>> instances that do not specify an explicit spatial reference system IRI.
+The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[`+<http://www.opengis.net/def/crs/OGC/1.3/CRS84>+`] shall be assumed as the coordinate reference system for <<RDFS Datatype: geo:wktLiteral, `geo:wktLiteral`>> instances that do not specify an explicit coordinate reference system IRI.
 
 .. *Test purpose*: Check conformance with this requirement
-.. *Test method*: Verify that queries involving  <<RDFS Datatype: geo:wktLiteral, WKT Literal>> values without an explicit encoded SRS IRI return the correct result for a test dataset.
+.. *Test method*: Verify that queries involving  <<RDFS Datatype: geo:wktLiteral, WKT Literal>> values without an explicit encoded CRS IRI return the correct result for a test dataset.
 .. *Reference*: <<_rdfs_datatype_geowktliteral>>
 .. *Test Type*: Capabilities
 
 ==== A.3.2.3 `/conf/geometry-extension/wkt-axis-order`
 *Requirement*: `/req/geometry-extension/wkt-axis-order`
 
-Coordinate tuples within <<RDFS Datatype: geo:wktLiteral, WKT Literal>> instances shall be interpreted using the axis order defined in the SRS used.
+Coordinate tuples within <<RDFS Datatype: geo:wktLiteral, WKT Literal>> instances shall be interpreted using the axis order defined in the CRS used.
 
 .. *Test purpose*: Check conformance with this requirement
 .. *Test method*: Verify that queries involving  <<RDFS Datatype: geo:wktLiteral, WKT Literal>> values return the correct result for a test dataset.
@@ -427,10 +427,10 @@ All <<RDFS Datatype: geo:geoJSONLiteral, `geo:geoJSONLiteral`>> instances shall 
 ==== A.3.4.2 `/req/geometry-extension/geojson-literal-srs`
 *Requirement*: `/req/geometry-extension/geojson-literal-default-srs`
 
-The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def/crs/OGC/1.3/CRS84>] shall be assumed as the SRS for <<RDFS Datatype: geo:geoJSONLiteral, `geo:geoJSONLiteral`>> instances that do not specify an explicit SRS IRI.
+The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def/crs/OGC/1.3/CRS84>] shall be assumed as the CRS for <<RDFS Datatype: geo:geoJSONLiteral, `geo:geoJSONLiteral`>> instances that do not specify an explicit CRS IRI.
 
 .. *Test purpose*: Check conformance with this requirement
-.. *Test method*: Verify that queries involving <<RDFS Datatype: geo:geoJSONLiteral, `geo:geoJSONLiteral`>> values without an explicit encoded SRS IRI return the correct result for a test dataset.
+.. *Test method*: Verify that queries involving <<RDFS Datatype: geo:geoJSONLiteral, `geo:geoJSONLiteral`>> values without an explicit encoded CRS IRI return the correct result for a test dataset.
 .. *Reference*: <<_rdfs_datatype_geogeojsonliteral>>
 .. *Test Type*: Capabilities
 
@@ -478,10 +478,10 @@ All <<RDFS Datatype: geo:kmlLiteral, `geo:kmlLiteral`>> instances shall consist 
 ==== A.3.5.2 `/req/geometry-extension/kml-literal-srs`
 *Requirement*: `/req/geometry-extension/kml-literal-default-srs`
 
-The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def/crs/OGC/1.3/CRS84>] shall be assumed as the SRS for <<RDFS Datatype: geo:kmlLiteral, `geo:kmlLiteral`>> instances that do not specify an explicit SRS IRI.
+The IRI http://www.opengis.net/def/crs/OGC/1.3/CRS84[<http://www.opengis.net/def/crs/OGC/1.3/CRS84>] shall be assumed as the CRS for <<RDFS Datatype: geo:kmlLiteral, `geo:kmlLiteral`>> instances that do not specify an explicit CRS IRI.
 
 .. *Test purpose*: Check conformance with this requirement
-.. *Test method*: Verify that queries involving <<RDFS Datatype: geo:kmlLiteral, `geo:kmlLiteral`>>  values without an explicit encoded SRS IRI return the correct result for a test dataset.
+.. *Test method*: Verify that queries involving <<RDFS Datatype: geo:kmlLiteral, `geo:kmlLiteral`>>  values without an explicit encoded CRS IRI return the correct result for a test dataset.
 .. *Reference*: <<_rdfs_datatype_geomklliteral>>
 .. *Test Type*: Capabilities
 


### PR DESCRIPTION
This PR should replace all occurrences of "SRS" and "spatial reference system" in the specification document with "CRS" and "coordinate reference system", where appropriate. Fixes [issue 272](https://github.com/opengeospatial/ogc-geosparql/issues/272).