### PR TITLE
Changed wrong GML namespace in GML example

### DIFF
--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -441,7 +441,7 @@ The example <<RDFS Datatype: geo:gmlLiteral, GML Literal>> below encodes a point
 """
 <gml:Point 
         srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\" 
-        xmlns:gml=\"http://www.opengis.net/ont/gml\">
+        xmlns:gml=\"http://www.opengis.net/gml/3.2\">
     <gml:pos>-83.38 33.95</gml:pos>
 </gml:Point>
 """^^<http://www.opengis.net/ont/geosparql#gmlLiteral>


### PR DESCRIPTION
Changes a wrong namespace in the GML example as discovered by #330 

Closes #330 