### PR TITLE
Remove geof:projectTo

### DIFF
--- a/1.1/spec/01-Preamble.adoc
+++ b/1.1/spec/01-Preamble.adoc
@@ -138,7 +138,6 @@ These new ontology elements and new functions are normatively defined in this sp
 |minY | <<Function: geof:minY>>
 |minZ | <<Function: geof:minZ>>
 |numGeometries | <<Function: geof:>>
-|projectTo | <<Function: geof:projectTo>>
 |spatialDimension | <<Function: geof:spatialDimension>>
 |transform | <<Function: geof:transform>>
 2+|_**Spatial Aggregate Functions**_

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -801,9 +801,8 @@ as SPARQL extension functions, consistent with definitions of these functions in
 <<Function: geof:maxZ, `geof:maxZ`>>,  
 <<Function: geof:minX, `geof:minX`>>, 
 <<Function: geof:minY, `geof:minY`>>,
-<<Function: geof:minZ, `geof:minZ`>>,
-<<Function: geof:numGeometries, `geof:numGeometries`>> and
-<<Function: geof:projectTo, `geof:projectTo`>>, 
+<<Function: geof:minZ, `geof:minZ`>> and
+<<Function: geof:numGeometries, `geof:numGeometries`>>
 as SPARQL extension functions which are defined in this standard, for non-DGGS geometry literals
 |http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions-non-sf[`http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions-non-sf`]
 |===
@@ -1101,22 +1100,6 @@ geof:numGeometries (geom: ogc:geomLiteral): xsd:integer
 ```
 
 Returns the number of geometries of `geom`.
-
-==== Function: geof:projectTo
-
-```
-geof:projectTo (geom:  ogc:geomLiteral,
-                dimVec: xsd:integer): ogc:geomLiteral
-```
-
-Projects the elements of geometry `geom` to the dimensions specified by the `dimVec` "dimensional vector". 
-
-`dimVec` is a binary number indicating which dimensions to project to (retain) from the `geom`, for example, using dimensions x, y & z:
-
-* "010" projects to the y dimension, only
-* "110" projects to the x and y dimensions
-
-A projection may only occur from a geometry to a geometry of equal or fewer dimensions and, so far, GeoSPARQL only allos 1-, 2- & 3-dimensional objects, thus `projectTo` can only be specified from 3 to 2, 2 to 1 or 1 to 0 dimensions.
 
 ==== Function: geof:spatialDimension
 

--- a/1.1/spec/17-Annex-B.adoc
+++ b/1.1/spec/17-Annex-B.adoc
@@ -98,7 +98,6 @@ CellList(DGGS) | Yes | Yes
 | isSimple | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#boolean[xsd:boolean] | | Yes | Yes
 | length | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#double[xsd:double] | http://www.w3.org/2001/XMLSchema#double[xsd:double] | Yes | No
 | numGeometries | 1x ogc:geomLiteral | Geometry(not DGGS) | http://www.w3.org/2001/XMLSchema#double[xsd:double] | http://www.w3.org/2001/XMLSchema#double[xsd:double] | Yes | No
-| projectTo | 1x ogc:geomLiteral | Geometry | geo:gmlLiteral | | Yes | Yes
 | spatialDimension | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#integer[xsd:integer] | | Yes | Yes
 | symDifference | 2x ogc:geomLiteral | 2x Geometry | ogc:geomLiteral | (Multi)Polygon(not DGGS),
 
@@ -161,8 +160,7 @@ Where the Simple Features Access function has the same name as the GeoSPARQL fun
 | minX | | x | 
 | minY | | x | 
 | minZ | | x | 
-| numGeometries | | x | 
-| projectTo | | x | 
+| numGeometries | | x |  
 | spatialDimension | | x | x 
 | symDifference | x | x | x
 | transform | | x | x


### PR DESCRIPTION
This PR removes the projectTo function, see [issue 338](https://github.com/opengeospatial/ogc-geosparql/issues/338). 
Funcsrules.ttl does not need to be changed; it does not have anything on projectTo.