### PR TITLE
remove all refs to aggConcatLines

### DIFF
--- a/1.1/sa_functions.ttl
+++ b/1.1/sa_functions.ttl
@@ -21,7 +21,6 @@
         geof:aggBoundingBox,
         geof:aggBoundingCircle,
         geof:aggCentroid,
-        geof:aggConcatLines,
         geof:aggConcaveHull,
         geof:aggConvexHull,
         geof:aggUnion ;
@@ -48,17 +47,6 @@ geof:aggCentroid a skos:Concept ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A spatial aggregate function that calculates a centroid of a set of geometries."@en ;
     skos:prefLabel "centroid"@en .
-
-geof:aggConcatLines a skos:Concept ;
-    dcterms:contributor "Timo Homburg" ;
-    dcterms:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
-    dcterms:date "2021-02-25"^^xsd:date ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A spatial aggregate function that calculates a concatenated line of a set of lines."@en ;
-    skos:prefLabel "concat lines"@en .
 
 geof:aggConcaveHull a skos:Concept ;
     dcterms:contributor "Timo Homburg" ;

--- a/1.1/spec/01-Preamble.adoc
+++ b/1.1/spec/01-Preamble.adoc
@@ -145,7 +145,6 @@ These new ontology elements and new functions are normatively defined in this sp
 |aggBoundingBox | <<Function: geof:aggBoundingBox>>
 |aggBoundingCircle | <<Function: geof:aggBoundingCircle>>
 |aggCentroid | <<Function: geof:aggCentroid>>
-|aggConcatLines | <<Function: geof:aggConcatLines>>
 |aggConcaveHull | <<Function: geof:aggConcaveHull>>
 |aggUnion | <<Function: geof:aggUnion>>
 |===

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -1169,7 +1169,6 @@ This clause defines SPARQL functions for performing spatial aggregations of data
 <<Function: geof:aggBoundingBox,`geof:aggBoundingBox`>>, 
 <<Function: geof:aggBoundingCircle,`geof:aggBoundingCircle`>>, 
 <<Function: geof:aggCentroid,`geof:aggCentroid`>>, 
-<<Function: geof:aggConcatLines,`geof:aggConcatLines`>>, 
 <<Function: geof:aggConcaveHull,`geof:aggConcaveHull`>>, 
 <<Function: geof:aggConvexHull,`geof:aggConvexHull`>> and 
 <<Function: geof:aggUnion,`geof:aggUnion`>>

--- a/1.1/spec/16-Annex-A.adoc
+++ b/1.1/spec/16-Annex-A.adoc
@@ -289,7 +289,6 @@ Implementations shall support
 <<Function: geof:aggBoundingBox,`geof:boundingBox`>>, 
 <<Function: geof:aggBoundingCircle,`geof:boundingCircle`>>, 
 <<Function: geof:aggCentroid,`geof:centroid`>>, 
-<<Function: geof:aggConcatLines,`geof:concatLines`>>, 
 <<Function: geof:aggConcaveHull,`geof:concaveHull`>>, 
 <<Function: geof:aggConvexHull,`geof:convexHull`>> and 
 <<Function: geof:aggUnion,`geof:union2`>>

--- a/1.1/spec/17-Annex-B.adoc
+++ b/1.1/spec/17-Annex-B.adoc
@@ -48,9 +48,6 @@ CellList(DGGS) | Yes | Yes
 | aggCentroid | 1 or more ogc:geomLiteral | | ogc:geomLiteral | Point(not DGGS),
 
 Cell(DGGS) | Yes | Yes
-| aggConcatLines | 1 or more ogc:geomLiteral | | ogc:geomLiteral | square LineString(not DGGS) 
-
-OrderedCellList(DGGS) | Yes | Yes
 | aggConcaveHull | 1 or more ogc:geomLiteral | | ogc:geomLiteral | Polygon(not DGGS),
 
 CellList(DGGS) | Yes | Yes


### PR DESCRIPTION
Closes #343

Just removes all refs to aggConcatLines that should have been removed before.