### PR TITLE
updated and reduced references to 19107; updated GML reference

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -995,7 +995,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 		<http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/geometry-class> ,
 		<http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-class> ;
 	skos:definition """A coherent set of direct positions in space. The positions are held within a Spatial Reference System (SRS)."""@en ;
-	skos:note """Geometry can be used as a representation of the shape, extent or location of a Feature, or can exist as a self-contained entity."""@en ;
+	skos:note """Geometry can be used as a representation of the shape, extent or location of a Feature and may exist as a self-contained entity."""@en ;
 	skos:prefLabel "Geometry"@en ;
 	skos:example 
 		spec11:B.1.1.2.2 , 

--- a/1.1/spec/02-Introduction.adoc
+++ b/1.1/spec/02-Introduction.adoc
@@ -59,7 +59,7 @@ The GeoSPARQL standard comprises multiple parts, or _profile resources_. The com
 3. domain model RDF/OWL <<RDF>>,<<OWL2>> ontology
 ** http://www.opengis.net/ont/geosparql
 ** for geographic information representation
-** based on the General Feature Model <<ISO19109>>, Simple Features Access <<OGCSFACA>> <<ISO19125-1>>, Feature Geometry <<ISO19107>> and SQL MM <<ISO13249>>
+** based on the General Feature Model <<ISO19109>>, Simple Features Access <<OGCSFACA>> <<ISO19125-1>>, Geography Markup Language <<GML>> and SQL MM <<ISO13249>>
 ** defined within the specification document and delivered in RDF also
 4. Functions & Rules vocabulary
 ** http://www.opengis.net/def/geosparql/funcsrules

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -62,7 +62,7 @@ geo:Geometry
     skos:definition "A coherent set of direct positions in space. The positions 
                     are held within a Spatial Reference System (SRS)."@en ;
     skos:note "Geometry can be used as a representation of the shape, extent or 
-              location of a Featureand may exist as a self-contained entity."""@en ;
+              location of a Feature and may exist as a self-contained entity."""@en ;
 .
 ```
 

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -50,7 +50,7 @@ One container class is defined: <<Class: geo:GeometryCollection, Geometry Collec
 
 ==== Class: geo:Geometry
 
-The class http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`] is equivalent to `GM_Object` <<ISO19107>> and is defined by the following:
+The class http://www.opengis.net/ont/geosparql#Geometry[`geo:Geometry`] is conceptually derived from UML class `Geometry` in <<ISO19107>> which is that standard's "root class of the geometric object taxonomy and supports interfaces common to all geographically referenced geometric objects". `geo:Geometry` is defined by the following:
 
 ```turtle
 geo:Geometry 
@@ -62,7 +62,7 @@ geo:Geometry
     skos:definition "A coherent set of direct positions in space. The positions 
                     are held within a Spatial Reference System (SRS)."@en ;
     skos:note "Geometry can be used as a representation of the shape, extent or 
-              location of a Feature, or can exist as a self-contained entity."""@en ;
+              location of a Featureand may exist as a self-contained entity."""@en ;
 .
 ```
 

--- a/1.1/spec/22-Bibliography.adoc
+++ b/1.1/spec/22-Bibliography.adoc
@@ -15,7 +15,7 @@
 
 * [[[ISO19105]]] International Organization for Standardization, _ISO 19105: Geographic information — Conformance and testing_ (2000)
 
-* [[[ISO19107]]] International Organization for Standardization, _ISO 19107: Geographic information — Spatial schema_ (2003)
+* [[[ISO19107]]] International Organization for Standardization, _ISO 19107: Geographic information — Spatial schema_ (2018)
 
 * [[[ISO19109]]] International Organization for Standardization, _ISO 19109: Geographic information — Rules for application schemas_ (2005)
 
@@ -29,7 +29,7 @@
 
 * [[[GEOJSON]]] Internet Engineering Task Force, _RFC 7946: The GeoJSON Format_. IETF Request for Comment (August 2016). https://tools.ietf.org/html/rfc7946
 
-* [[[OGC07-036]]] Open Geospatial Consortium, _OGC 07-036: Geography Markup Language (GML) Encoding Standard_, Version 3.2.1 (27 August 2007). http://www.opengis.net/doc/is/gml/3.2.1
+* [[[OGC07-036]]] Open Geospatial Consortium, _OGC 07-036r1: OpenGIS Geography Markup Language (GML) Encoding Standard - with corrigendum_, Version 3.2.2 (05 December 2016). https://www.ogc.org/standards/gml
 
 * [[[OGCKML]]] Open Geospatial Consortium, _OGC KML 2.3_. OGC Implementation Standard (04 August 2015). http://www.opengis.net/doc/IS/kml/2.3
 


### PR DESCRIPTION
I have:

* updated the 19107 reference to the latest
* reduced the references to 19107 to just one: a non-normative, comparative, reference for Geometry class
* updated references to GML from 3.2.1 to 3.2.2 to capture ISO alignment and remove a direct 19107 reference

Closes #357 