### PR TITLE
replace en dash with hyphen

### DIFF
--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -83,7 +83,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	dcterms:description "An RDF/OWL vocabulary for representing spatial information"@en ;
 	dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
 	dcterms:rights "(c) 2021 Open Geospatial Consortium" ;
-	dcterms:source <http://www.opengis.net/doc/IS/geosparql/1.1> , "OGC GeoSPARQL – A Geographic Query Language for RDF Data OGC 11-052r5"@en ;
+	dcterms:source <http://www.opengis.net/doc/IS/geosparql/1.1> , "OGC GeoSPARQL - A Geographic Query Language for RDF Data OGC 11-052r5"@en ;
 	rdfs:seeAlso <http://www.opengis.net/doc/IS/geosparql/1.1> ;
 	owl:versionInfo "OGC GeoSPARQL 1.1" ;
 .


### PR DESCRIPTION
Replaced character U+2013 (en dash) with U+002d (hyphen) to avoid ttl parse problem. A user of I think topquadrant brought this to my attention.