### PR TITLE
RDF versions

### DIFF
--- a/1.0/funcsrules.ttl
+++ b/1.0/funcsrules.ttl
@@ -4,151 +4,163 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX policy: <http://www.opengis.net/def/metamodel/ogc-na/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX rules: <http://www.opengis.net/def/rule/geosparql/>
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX status: <http://www.opengis.net/def/status/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX sd: <http://www.w3.org/ns/sparql-service-description#> 
 
+funcs:
+    a skos:Collection ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.0> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
+    skos:member
+        funcs:boundary ,
+        funcs:buffer ,
+        funcs:convexHull ,
+        funcs:difference ,
+        funcs:distance ,
+        funcs:ehContains ,
+        funcs:ehCoveredBy ,
+        funcs:ehCovers ,
+        funcs:ehDisjoint ,
+        funcs:ehEquals ,
+        funcs:ehInside ,
+        funcs:ehMeet ,
+        funcs:ehOverlap ,
+        funcs:envelope ,
+        funcs:getSRID ,
+        funcs:intersection ,
+        funcs:rcc8dc ,
+        funcs:rcc8ec ,
+        funcs:rcc8eq ,
+        funcs:rcc8ntpp ,
+        funcs:rcc8ntppi ,
+        funcs:rcc8po ,
+        funcs:rcc8tpp ,
+        funcs:rcc8tppi ,
+        funcs:relate ,
+        funcs:sfContains ,
+        funcs:sfCrosses ,
+        funcs:sfDisjoint ,
+        funcs:sfEquals ,
+        funcs:sfIntersects ,
+        funcs:sfOverlaps ,
+        funcs:sfTouches ,
+        funcs:sfWithin ,
+        funcs:symDifference ,
+        funcs:union ;
+    skos:prefLabel "GeoSPARQL Functions" ;
+.
 
-<http://www.opengis.net/def/geosparql/funcsrules> 
-    a owl:Ontology , skos:ConceptScheme ;
+<http://www.opengis.net/def/geosparql/funcsrules>
+    a
+        owl:Ontology ,
+        skos:ConceptScheme ;
     dcterms:modified "2020-11-20"^^xsd:date ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     owl:imports <http://www.opengis.net/def/ogc-na> ;
-    owl:versionInfo "OGC GeoSPARQL 1.0" ;
     owl:versionIRI <http://www.opengis.net/def/geosparql/funcsrules/1.0> ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
     skos:definition "A vocabulary (taxonomy) of the functions and rules defined within the GeoSPARQL 1.0 ontology"@en ;
-    skos:hasTopConcept funcs:boundary,
-        funcs:buffer,
-        funcs:convexHull,
-        funcs:difference,
-        funcs:distance,
-        funcs:ehContains,
-        funcs:ehCoveredBy,
-        funcs:ehCovers,
-        funcs:ehDisjoint,
-        funcs:ehEquals,
-        funcs:ehInside,
-        funcs:ehMeet,
-        funcs:ehOverlap,
-        funcs:envelope,
-        funcs:getSRID,
-        funcs:intersection,
-        funcs:rcc8dc,
-        funcs:rcc8ec,
-        funcs:rcc8eq,
-        funcs:rcc8ntpp,
-        funcs:rcc8ntppi,
-        funcs:rcc8po,
-        funcs:rcc8tpp,
-        funcs:rcc8tppi,
-        funcs:relate,
-        funcs:sfContains,
-        funcs:sfCrosses,
-        funcs:sfDisjoint,
-        funcs:sfEquals,
-        funcs:sfIntersects,
-        funcs:sfOverlaps,
-        funcs:sfTouches,
-        funcs:sfWithin,
-        funcs:symDifference,
-        funcs:union,
-        rules:ehContains,
-        rules:ehCoveredBy,
-        rules:ehCovers,
-        rules:ehDisjoint,
-        rules:ehEquals,
-        rules:ehInside,
-        rules:ehMeet,
-        rules:ehOverlap,
-        rules:rcc8dc,
-        rules:rcc8ec,
-        rules:rcc8eq,
-        rules:rcc8ntpp,
-        rules:rcc8ntppi,
-        rules:rcc8po,
-        rules:rcc8tpp,
-        rules:rcc8tppi,
-        rules:sfContains,
-        rules:sfCrosses,
-        rules:sfDisjoint,
-        rules:sfEquals,
-        rules:sfIntersects,
-        rules:sfOverlaps,
-        rules:sfTouches,
+    skos:hasTopConcept
+        funcs:boundary ,
+        funcs:buffer ,
+        funcs:convexHull ,
+        funcs:difference ,
+        funcs:distance ,
+        funcs:ehContains ,
+        funcs:ehCoveredBy ,
+        funcs:ehCovers ,
+        funcs:ehDisjoint ,
+        funcs:ehEquals ,
+        funcs:ehInside ,
+        funcs:ehMeet ,
+        funcs:ehOverlap ,
+        funcs:envelope ,
+        funcs:getSRID ,
+        funcs:intersection ,
+        funcs:rcc8dc ,
+        funcs:rcc8ec ,
+        funcs:rcc8eq ,
+        funcs:rcc8ntpp ,
+        funcs:rcc8ntppi ,
+        funcs:rcc8po ,
+        funcs:rcc8tpp ,
+        funcs:rcc8tppi ,
+        funcs:relate ,
+        funcs:sfContains ,
+        funcs:sfCrosses ,
+        funcs:sfDisjoint ,
+        funcs:sfEquals ,
+        funcs:sfIntersects ,
+        funcs:sfOverlaps ,
+        funcs:sfTouches ,
+        funcs:sfWithin ,
+        funcs:symDifference ,
+        funcs:union ,
+        rules:ehContains ,
+        rules:ehCoveredBy ,
+        rules:ehCovers ,
+        rules:ehDisjoint ,
+        rules:ehEquals ,
+        rules:ehInside ,
+        rules:ehMeet ,
+        rules:ehOverlap ,
+        rules:rcc8dc ,
+        rules:rcc8ec ,
+        rules:rcc8eq ,
+        rules:rcc8ntpp ,
+        rules:rcc8ntppi ,
+        rules:rcc8po ,
+        rules:rcc8tpp ,
+        rules:rcc8tppi ,
+        rules:sfContains ,
+        rules:sfCrosses ,
+        rules:sfDisjoint ,
+        rules:sfEquals ,
+        rules:sfIntersects ,
+        rules:sfOverlaps ,
+        rules:sfTouches ,
         rules:sfWithin ;
-    skos:prefLabel "GeoSPARQL Functions and Rules Register" .
+    skos:prefLabel "GeoSPARQL Functions and Rules Register" ;
+.
 
-funcs: a skos:Collection ;
+rules:
+    a skos:Collection ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
-    skos:member funcs:boundary,
-        funcs:buffer,
-        funcs:convexHull,
-        funcs:difference,
-        funcs:distance,
-        funcs:ehContains,
-        funcs:ehCoveredBy,
-        funcs:ehCovers,
-        funcs:ehDisjoint,
-        funcs:ehEquals,
-        funcs:ehInside,
-        funcs:ehMeet,
-        funcs:ehOverlap,
-        funcs:envelope,
-        funcs:getSRID,
-        funcs:intersection,
-        funcs:rcc8dc,
-        funcs:rcc8ec,
-        funcs:rcc8eq,
-        funcs:rcc8ntpp,
-        funcs:rcc8ntppi,
-        funcs:rcc8po,
-        funcs:rcc8tpp,
-        funcs:rcc8tppi,
-        funcs:relate,
-        funcs:sfContains,
-        funcs:sfCrosses,
-        funcs:sfDisjoint,
-        funcs:sfEquals,
-        funcs:sfIntersects,
-        funcs:sfOverlaps,
-        funcs:sfTouches,
-        funcs:sfWithin,
-        funcs:symDifference,
-        funcs:union ;
-    skos:prefLabel "GeoSPARQL Functions" .
-
-rules: a skos:Collection ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.0> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
-    skos:member rules:ehContains,
-        rules:ehCoveredBy,
-        rules:ehCovers,
-        rules:ehDisjoint,
-        rules:ehEquals,
-        rules:ehInside,
-        rules:ehMeet,
-        rules:ehOverlap,
-        rules:rcc8dc,
-        rules:rcc8ec,
-        rules:rcc8eq,
-        rules:rcc8ntpp,
-        rules:rcc8ntppi,
-        rules:rcc8po,
-        rules:rcc8tpp,
-        rules:rcc8tppi,
-        rules:sfContains,
-        rules:sfCrosses,
-        rules:sfDisjoint,
-        rules:sfEquals,
-        rules:sfIntersects,
-        rules:sfOverlaps,
-        rules:sfTouches,
+    skos:member
+        rules:ehContains ,
+        rules:ehCoveredBy ,
+        rules:ehCovers ,
+        rules:ehDisjoint ,
+        rules:ehEquals ,
+        rules:ehInside ,
+        rules:ehMeet ,
+        rules:ehOverlap ,
+        rules:rcc8dc ,
+        rules:rcc8ec ,
+        rules:rcc8eq ,
+        rules:rcc8ntpp ,
+        rules:rcc8ntppi ,
+        rules:rcc8po ,
+        rules:rcc8tpp ,
+        rules:rcc8tppi ,
+        rules:sfContains ,
+        rules:sfCrosses ,
+        rules:sfDisjoint ,
+        rules:sfEquals ,
+        rules:sfIntersects ,
+        rules:sfOverlaps ,
+        rules:sfTouches ,
         rules:sfWithin ;
-    skos:prefLabel "GeoSPARQL Rules" .
+    skos:prefLabel "GeoSPARQL Rules" ;
+.
 
-funcs:boundary a skos:Concept, sd:Function ;
+funcs:boundary
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -157,9 +169,13 @@ funcs:boundary a skos:Concept, sd:Function ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns the boundary of the input geometry."@en ;
-    skos:prefLabel "boundary"@en .
+    skos:prefLabel "boundary"@en ;
+.
 
-funcs:buffer a skos:Concept, sd:Function  ;
+funcs:buffer
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -168,9 +184,13 @@ funcs:buffer a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns a buffer around the input geometry."@en ;
-    skos:prefLabel "buffer"@en .
+    skos:prefLabel "buffer"@en ;
+.
 
-funcs:convexHull a skos:Concept, sd:Function  ;
+funcs:convexHull
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -179,9 +199,13 @@ funcs:convexHull a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns the convex hull of the input geometry."@en ;
-    skos:prefLabel "convex hull"@en .
+    skos:prefLabel "convex hull"@en ;
+.
 
-funcs:difference a skos:Concept, sd:Function  ;
+funcs:difference
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -190,9 +214,13 @@ funcs:difference a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns a geometry consisting of all points that are part of the first geometry but not the second geometry."@en ;
-    skos:prefLabel "difference"@en .
+    skos:prefLabel "difference"@en ;
+.
 
-funcs:distance a skos:Concept, sd:Function  ;
+funcs:distance
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -201,9 +229,13 @@ funcs:distance a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns the distance between the two closest points of the input geometries."@en ;
-    skos:prefLabel "distance"@en .
+    skos:prefLabel "distance"@en ;
+.
 
-funcs:ehContains a skos:Concept, sd:Function  ;
+funcs:ehContains
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -214,9 +246,13 @@ funcs:ehContains a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument. 
       
 DE-9IM: T*TFF*FF*"""@en ;
-    skos:prefLabel "contains"@en .
+    skos:prefLabel "contains"@en ;
+.
 
-funcs:ehCoveredBy a skos:Concept, sd:Function  ;
+funcs:ehCoveredBy
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -227,9 +263,13 @@ funcs:ehCoveredBy a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument is spatially covered by the second geometry argument.
 
 DE-9IM: TFF*TFT**"""@en ;
-    skos:prefLabel "covered by"@en .
+    skos:prefLabel "covered by"@en ;
+.
 
-funcs:ehCovers a skos:Concept, sd:Function  ;
+funcs:ehCovers
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -240,9 +280,13 @@ funcs:ehCovers a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument spatially covers the second geometry argument.
 
 DE-9IM: T*TFT*FF*"""@en ;
-    skos:prefLabel "covers"@en .
+    skos:prefLabel "covers"@en ;
+.
 
-funcs:ehDisjoint a skos:Concept, sd:Function  ;
+funcs:ehDisjoint
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -253,9 +297,13 @@ funcs:ehDisjoint a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries are disjoint. 
 
 DE-9IM: FF*FF****"""@en ;
-    skos:prefLabel "disjoint"@en .
+    skos:prefLabel "disjoint"@en ;
+.
 
-funcs:ehEquals a skos:Concept, sd:Function  ;
+funcs:ehEquals
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -266,9 +314,13 @@ funcs:ehEquals a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries are equal. 
 
 DE-9IM: TFFFTFFFT"""@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-funcs:ehInside a skos:Concept, sd:Function  ;
+funcs:ehInside
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -279,9 +331,13 @@ funcs:ehInside a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument is spatially inside the second geometry argument.
 
 DE-9IM: TFF*FFT**"""@en ;
-    skos:prefLabel "inside"@en .
+    skos:prefLabel "inside"@en ;
+.
 
-funcs:ehMeet a skos:Concept, sd:Function  ;
+funcs:ehMeet
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -292,9 +348,13 @@ funcs:ehMeet a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries meet.
 
 DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
-    skos:prefLabel "meet"@en .
+    skos:prefLabel "meet"@en ;
+.
 
-funcs:ehOverlap a skos:Concept, sd:Function  ;
+funcs:ehOverlap
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -305,9 +365,13 @@ funcs:ehOverlap a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries overlap.
 
 DE-9IM: T*T***T**"""@en ;
-    skos:prefLabel "overlap"@en .
+    skos:prefLabel "overlap"@en ;
+.
 
-funcs:envelope a skos:Concept, sd:Function  ;
+funcs:envelope
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -316,9 +380,13 @@ funcs:envelope a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns the minimum bounding rectangle of the input geometry."@en ;
-    skos:prefLabel "envelope"@en .
+    skos:prefLabel "envelope"@en ;
+.
 
-funcs:getSRID a skos:Concept, sd:Function  ;
+funcs:getSRID
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -327,9 +395,13 @@ funcs:getSRID a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns the spatial reference system URI of the input geometry."@en ;
-    skos:prefLabel "getSRID"@en .
+    skos:prefLabel "getSRID"@en ;
+.
 
-funcs:intersection a skos:Concept, sd:Function  ;
+funcs:intersection
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -338,9 +410,13 @@ funcs:intersection a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns a geometry consisting of all points that are part of both input geometries."@en ;
-    skos:prefLabel "intersection"@en .
+    skos:prefLabel "intersection"@en ;
+.
 
-funcs:rcc8dc a skos:Concept, sd:Function  ;
+funcs:rcc8dc
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -351,9 +427,13 @@ funcs:rcc8dc a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries are disjoint. 
 
 DE-9IM: FFTFFTTTT"""@en ;
-    skos:prefLabel "disconnected"@en .
+    skos:prefLabel "disconnected"@en ;
+.
 
-funcs:rcc8ec a skos:Concept, sd:Function  ;
+funcs:rcc8ec
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -364,9 +444,13 @@ funcs:rcc8ec a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries meet. 
 
 DE-9IM: FFTFTTTTT"""@en ;
-    skos:prefLabel "externally connected"@en .
+    skos:prefLabel "externally connected"@en ;
+.
 
-funcs:rcc8eq a skos:Concept, sd:Function  ;
+funcs:rcc8eq
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -377,9 +461,13 @@ funcs:rcc8eq a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries are equal. 
       
 DE-9IM: TFFFTFFFT"""@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-funcs:rcc8ntpp a skos:Concept, sd:Function  ;
+funcs:rcc8ntpp
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -390,9 +478,13 @@ funcs:rcc8ntpp a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument is spatially inside the second geometry argument.
 
 DE-9IM: TFFTFFTTT"""@en ;
-    skos:prefLabel "non-tangential proper part"@en .
+    skos:prefLabel "non-tangential proper part"@en ;
+.
 
-funcs:rcc8ntppi a skos:Concept, sd:Function  ;
+funcs:rcc8ntppi
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -403,9 +495,13 @@ funcs:rcc8ntppi a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument.
 
 DE-9IM: TTTFFTFFT"""@en ;
-    skos:prefLabel "non-tangential proper part inverse"@en .
+    skos:prefLabel "non-tangential proper part inverse"@en ;
+.
 
-funcs:rcc8po a skos:Concept, sd:Function  ;
+funcs:rcc8po
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -416,9 +512,13 @@ funcs:rcc8po a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries overlap.
 
 DE-9IM: TTTTTTTTT"""@en ;
-    skos:prefLabel "partially overlapping"@en .
+    skos:prefLabel "partially overlapping"@en ;
+.
 
-funcs:rcc8tpp a skos:Concept, sd:Function  ;
+funcs:rcc8tpp
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -429,9 +529,13 @@ funcs:rcc8tpp a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument is spatially covered by the second geometry argument.
 
 DE-9IM: TFFTTFTTT"""@en ;
-    skos:prefLabel "tangential proper part"@en .
+    skos:prefLabel "tangential proper part"@en ;
+.
 
-funcs:rcc8tppi a skos:Concept, sd:Function  ;
+funcs:rcc8tppi
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -442,9 +546,13 @@ funcs:rcc8tppi a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument spatially covers the second geometry argument.
 
 DE-9IM: TTTFTTFFT"""@en ;
-    skos:prefLabel "tangential proper part inverse"@en .
+    skos:prefLabel "tangential proper part inverse"@en ;
+.
 
-funcs:relate a skos:Concept, sd:Function  ;
+funcs:relate
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -453,9 +561,13 @@ funcs:relate a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns true if the spatial relationship between the two input geometries corresponds to one with acceptable values for the specified DE-9IM pattern matrix."@en ;
-    skos:prefLabel "relate"@en .
+    skos:prefLabel "relate"@en ;
+.
 
-funcs:sfContains a skos:Concept, sd:Function  ;
+funcs:sfContains
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -466,9 +578,13 @@ funcs:sfContains a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument.
 
 DE-9IM: T*****FF*"""@en ;
-    skos:prefLabel "contains"@en .
+    skos:prefLabel "contains"@en ;
+.
 
-funcs:sfCrosses a skos:Concept, sd:Function  ;
+funcs:sfCrosses
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -479,9 +595,13 @@ funcs:sfCrosses a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument spatially crosses the second geometry argument.
 
 DE-9IM: T*T***T**"""@en ;
-    skos:prefLabel "crosses"@en .
+    skos:prefLabel "crosses"@en ;
+.
 
-funcs:sfDisjoint a skos:Concept, sd:Function  ;
+funcs:sfDisjoint
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:date "2011-06-16"^^xsd:date ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.0> ;
     policy:status status:valid ;
@@ -490,9 +610,13 @@ funcs:sfDisjoint a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries are disjoint. 
       
 DE-9IM: FF*FF****"""@en ;
-    skos:prefLabel "disjoint"@en .
+    skos:prefLabel "disjoint"@en ;
+.
 
-funcs:sfEquals a skos:Concept, sd:Function  ;
+funcs:sfEquals
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -503,9 +627,13 @@ funcs:sfEquals a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries are equal. 
 
 DE-9IM: TFFFTFFFT"""@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-funcs:sfIntersects a skos:Concept, sd:Function  ;
+funcs:sfIntersects
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -516,9 +644,13 @@ funcs:sfIntersects a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries intersect.
 
 DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T**** """@en ;
-    skos:prefLabel "intersects"@en .
+    skos:prefLabel "intersects"@en ;
+.
 
-funcs:sfOverlaps a skos:Concept, sd:Function  ;
+funcs:sfOverlaps
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -529,9 +661,13 @@ funcs:sfOverlaps a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument spatially overlaps the second geometry argument.
 
 DE-9IM: T*T***T** """@en ;
-    skos:prefLabel "overlaps"@en .
+    skos:prefLabel "overlaps"@en ;
+.
 
-funcs:sfTouches a skos:Concept, sd:Function  ;
+funcs:sfTouches
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -542,9 +678,13 @@ funcs:sfTouches a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the input geometries touch.
 
 DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
-    skos:prefLabel "touches"@en .
+    skos:prefLabel "touches"@en ;
+.
 
-funcs:sfWithin a skos:Concept, sd:Function  ;
+funcs:sfWithin
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -555,9 +695,13 @@ funcs:sfWithin a skos:Concept, sd:Function  ;
     skos:definition """A query function that returns true if the first geometry argument is spatially within the second geometry argument. 
 
 DE-9IM: T*F**F***"""@en ;
-    skos:prefLabel "within"@en .
+    skos:prefLabel "within"@en ;
+.
 
-funcs:symDifference a skos:Concept, sd:Function  ;
+funcs:symDifference
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -566,9 +710,13 @@ funcs:symDifference a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns a geometry consisting of all points that are part of only one input geometry."@en ;
-    skos:prefLabel "symmetric difference"@en .
+    skos:prefLabel "symmetric difference"@en ;
+.
 
-funcs:union a skos:Concept, sd:Function  ;
+funcs:union
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -577,9 +725,11 @@ funcs:union a skos:Concept, sd:Function  ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query function that returns a geometry consisting of all points that are part of at least one input geometry."@en ;
-    skos:prefLabel "union"@en .
+    skos:prefLabel "union"@en ;
+.
 
-rules:ehContains a skos:Concept ;
+rules:ehContains
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -588,9 +738,11 @@ rules:ehContains a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object contains another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "contains"@en .
+    skos:prefLabel "contains"@en ;
+.
 
-rules:ehCoveredBy a skos:Concept ;
+rules:ehCoveredBy
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -599,9 +751,11 @@ rules:ehCoveredBy a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is covered by another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "covered by"@en .
+    skos:prefLabel "covered by"@en ;
+.
 
-rules:ehCovers a skos:Concept ;
+rules:ehCovers
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -610,9 +764,11 @@ rules:ehCovers a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object covers another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "covers"@en .
+    skos:prefLabel "covers"@en ;
+.
 
-rules:ehDisjoint a skos:Concept ;
+rules:ehDisjoint
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -621,9 +777,11 @@ rules:ehDisjoint a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are disjoint based on their associated primary geometry objects."@en ;
-    skos:prefLabel "disjoint"@en .
+    skos:prefLabel "disjoint"@en ;
+.
 
-rules:ehEquals a skos:Concept ;
+rules:ehEquals
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -632,9 +790,11 @@ rules:ehEquals a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are equal based on their associated primary geometry objects."@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-rules:ehInside a skos:Concept ;
+rules:ehInside
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -643,9 +803,11 @@ rules:ehInside a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is inside another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "inside"@en .
+    skos:prefLabel "inside"@en ;
+.
 
-rules:ehMeet a skos:Concept ;
+rules:ehMeet
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -654,9 +816,11 @@ rules:ehMeet a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects meet based on their associated primary geometry objects."@en ;
-    skos:prefLabel "meet"@en .
+    skos:prefLabel "meet"@en ;
+.
 
-rules:ehOverlap a skos:Concept ;
+rules:ehOverlap
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -665,9 +829,11 @@ rules:ehOverlap a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects overlap based on their associated primary geometry objects."@en ;
-    skos:prefLabel "overlap"@en .
+    skos:prefLabel "overlap"@en ;
+.
 
-rules:rcc8dc a skos:Concept ;
+rules:rcc8dc
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -676,9 +842,11 @@ rules:rcc8dc a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are disjoint based on their associated primary geometry objects."@en ;
-    skos:prefLabel "disconnected"@en .
+    skos:prefLabel "disconnected"@en ;
+.
 
-rules:rcc8ec a skos:Concept ;
+rules:rcc8ec
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -687,9 +855,11 @@ rules:rcc8ec a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are externally connected based on their associated primary geometry objects."@en ;
-    skos:prefLabel "externally connected"@en .
+    skos:prefLabel "externally connected"@en ;
+.
 
-rules:rcc8eq a skos:Concept ;
+rules:rcc8eq
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -698,9 +868,11 @@ rules:rcc8eq a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine two spatial objects are equal based on their associated primary geometry objects."@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-rules:rcc8ntpp a skos:Concept ;
+rules:rcc8ntpp
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -709,9 +881,11 @@ rules:rcc8ntpp a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is a non-tangential proper part of another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "non-tangential proper part"@en .
+    skos:prefLabel "non-tangential proper part"@en ;
+.
 
-rules:rcc8ntppi a skos:Concept ;
+rules:rcc8ntppi
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -720,9 +894,11 @@ rules:rcc8ntppi a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is a non-tangential proper part inverse of another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "non-tangential proper part inverse"@en .
+    skos:prefLabel "non-tangential proper part inverse"@en ;
+.
 
-rules:rcc8po a skos:Concept ;
+rules:rcc8po
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -731,9 +907,11 @@ rules:rcc8po a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects partially overlap based on their associated primary geometry objects."@en ;
-    skos:prefLabel "partially overlapping"@en .
+    skos:prefLabel "partially overlapping"@en ;
+.
 
-rules:rcc8tpp a skos:Concept ;
+rules:rcc8tpp
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -742,9 +920,11 @@ rules:rcc8tpp a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is a tangential proper part of another spatial object based on their associated geometry objects."@en ;
-    skos:prefLabel "tangential proper part"@en .
+    skos:prefLabel "tangential proper part"@en ;
+.
 
-rules:rcc8tppi a skos:Concept ;
+rules:rcc8tppi
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -753,9 +933,11 @@ rules:rcc8tppi a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is a tangential proper part inverse of another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "tangential proper part inverse"@en .
+    skos:prefLabel "tangential proper part inverse"@en ;
+.
 
-rules:sfContains a skos:Concept ;
+rules:sfContains
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -764,9 +946,11 @@ rules:sfContains a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object contains another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "contains"@en .
+    skos:prefLabel "contains"@en ;
+.
 
-rules:sfCrosses a skos:Concept ;
+rules:sfCrosses
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -775,9 +959,11 @@ rules:sfCrosses a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects cross based their associated primary geometry objects."@en ;
-    skos:prefLabel "crosses"@en .
+    skos:prefLabel "crosses"@en ;
+.
 
-rules:sfDisjoint a skos:Concept ;
+rules:sfDisjoint
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -786,9 +972,11 @@ rules:sfDisjoint a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are disjoint based on their associated primary geometry objects."@en ;
-    skos:prefLabel "disjoint"@en .
+    skos:prefLabel "disjoint"@en ;
+.
 
-rules:sfEquals a skos:Concept ;
+rules:sfEquals
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -797,9 +985,11 @@ rules:sfEquals a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are equal based on their associated primary geometry objects."@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-rules:sfIntersects a skos:Concept ;
+rules:sfIntersects
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -808,9 +998,11 @@ rules:sfIntersects a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects intersect based on their associated primary geometry objects."@en ;
-    skos:prefLabel "intersects"@en .
+    skos:prefLabel "intersects"@en ;
+.
 
-rules:sfOverlaps a skos:Concept ;
+rules:sfOverlaps
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -819,9 +1011,11 @@ rules:sfOverlaps a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects overlap based on their associated primary geometry objects."@en ;
-    skos:prefLabel "overlaps"@en .
+    skos:prefLabel "overlaps"@en ;
+.
 
-rules:sfTouches a skos:Concept ;
+rules:sfTouches
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -830,9 +1024,11 @@ rules:sfTouches a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects touch based on their associated primary geometry objects."@en ;
-    skos:prefLabel "touches"@en .
+    skos:prefLabel "touches"@en ;
+.
 
-rules:sfWithin a skos:Concept ;
+rules:sfWithin
+    a skos:Concept ;
     dcterms:contributor "Matthew Perry" ;
     dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
     dcterms:date "2011-06-16"^^xsd:date ;
@@ -841,5 +1037,5 @@ rules:sfWithin a skos:Concept ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.0> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is within another spatial object based on their associated geometry objects."@en ;
-    skos:prefLabel "within"@en .
-
+    skos:prefLabel "within"@en ;
+.

--- a/1.0/funcsrules.ttl
+++ b/1.0/funcsrules.ttl
@@ -15,7 +15,8 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
     dcterms:modified "2020-11-20"^^xsd:date ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.0> ;
     owl:imports <http://www.opengis.net/def/ogc-na> ;
-    owl:versionIRI <http://defs-dev.opengis.net/static/definitions/conceptschemes/functions_geosparql.ttl> ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/funcsrules/1.0> ;
     skos:definition "A vocabulary (taxonomy) of the functions and rules defined within the GeoSPARQL 1.0 ontology"@en ;
     skos:hasTopConcept funcs:boundary,
         funcs:buffer,

--- a/1.0/geo.ttl
+++ b/1.0/geo.ttl
@@ -1,1217 +1,1255 @@
-@prefix : <http://www.opengis.net/ont/geosparql#> .
-@prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+PREFIX : <http://www.opengis.net/ont/geosparql#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<http://www.opengis.net/ont/geosparql> a owl:Ontology ;
-    dc:title "GeoSPARQL Ontology" ;
-	dc:creator "Open Geospatial Consortium" ;
-	dc:date "2012-04-30"^^xsd:date ;
-	dc:description "An RDF/OWL vocabulary for representing spatial information" ;
-	dc:source <http://www.opengis.net/doc/IS/geosparql/1.0> , "OGC GeoSPARQL – A Geographic Query Language for RDF Data OGC 11-052r5" ;
-	rdfs:seeAlso <http://www.opengis.net/def/function/ogc-geosparql/1.0> , <http://www.opengis.net/def/rule/ogc-geosparql/1.0> , <http://www.opengis.net/doc/IS/geosparql/1.0> ;
-	owl:versionInfo "OGC GeoSPARQL 1.0" ;
-	owl:versionIRI <http://www.opengis.net/ont/geosparql/1.0> ;
+dc:contributor
+    a owl:AnnotationProperty ;
+    rdfs:label "Contributor"@en ;
+    dcterms:description "Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#contributor-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "An entity responsible for making contributions to the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
 .
 
-# 
-# 
-# #################################################################
-# #
-# #    Annotation properties
-# #
-# #################################################################
-# 
-# 
-# http://purl.org/dc/elements/1.1/contributor
+dc:coverage
+    rdfs:label "Coverage"@en ;
+    dcterms:description "Spatial topic and spatial applicability may be a named place or a location specified by its geographic coordinates. Temporal topic may be a named period, date, or date range. A jurisdiction may be a named administrative entity or a geographic place to which the resource applies. Recommended best practice is to use a controlled vocabulary such as the Thesaurus of Geographic Names [TGN]. Where appropriate, named places or time periods can be used in preference to numeric identifiers such as sets of coordinates or date ranges."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#coverage-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "The spatial or temporal topic of the resource, the spatial applicability of the resource, or the jurisdiction under which the resource is relevant."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-dc:contributor a owl:AnnotationProperty ;
-	<http://purl.org/dc/terms/description> "Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity."@en ;
-	<http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#contributor-006> ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	rdfs:comment "An entity responsible for making contributions to the resource."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	rdfs:label "Contributor"@en ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en .
-# 
-# http://purl.org/dc/elements/1.1/creator
+dc:creator
+    a owl:AnnotationProperty ;
+    rdfs:label "Creator"@en ;
+    dcterms:description "Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#creator-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "An entity primarily responsible for making the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-dc:creator a owl:AnnotationProperty ;
-	<http://purl.org/dc/terms/description> "Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity."@en ;
-	<http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#creator-006> ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	rdfs:comment "An entity primarily responsible for making the resource."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	rdfs:label "Creator"@en ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en .
-# 
-# http://purl.org/dc/elements/1.1/date
+dc:date
+    a owl:AnnotationProperty ;
+    rdfs:label "Date"@en ;
+    dcterms:description "Date may be used to express temporal information at any level of granularity.  Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#date-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "A point or period of time associated with an event in the lifecycle of the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-dc:date a owl:AnnotationProperty ;
-	<http://purl.org/dc/terms/description> "Date may be used to express temporal information at any level of granularity.  Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
-	<http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#date-006> ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	rdfs:comment "A point or period of time associated with an event in the lifecycle of the resource."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	rdfs:label "Date"@en ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en .
-# 
-# http://purl.org/dc/elements/1.1/description
+dc:description
+    a owl:AnnotationProperty ;
+    rdfs:label "Description"@en ;
+    dcterms:description "Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#description-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "An account of the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-dc:description a owl:AnnotationProperty ;
-	<http://purl.org/dc/terms/description> "Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource."@en ;
-	<http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#description-006> ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	rdfs:comment "An account of the resource."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	rdfs:label "Description"@en ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en .
-# 
-# http://purl.org/dc/elements/1.1/source
+dc:format
+    rdfs:label "Format"@en ;
+    dcterms:description "Examples of dimensions include size and duration. Recommended best practice is to use a controlled vocabulary such as the list of Internet Media Types [MIME]."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#format-007> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "The file format, physical medium, or dimensions of the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-dc:source <http://purl.org/dc/terms/description> "The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system."@en ;
-	<http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#source-006> ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	rdfs:comment "A related resource from which the described resource is derived."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	rdfs:label "Source"@en ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en .
-# 
-# http://purl.org/dc/terms/description
+dc:identifier
+    rdfs:label "Identifier"@en ;
+    dcterms:description "Recommended best practice is to identify the resource by means of a string conforming to a formal identification system. "@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#identifier-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "An unambiguous reference to the resource within a given context."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-<http://purl.org/dc/terms/description> a owl:AnnotationProperty .
-# 
-# http://purl.org/dc/terms/hasVersion
+dc:language
+    rdfs:label "Language"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as RFC 4646 [RFC4646]."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#language-007> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "A language of the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    rdfs:seeAlso <http://www.ietf.org/rfc/rfc4646.txt> ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-<http://purl.org/dc/terms/hasVersion> a owl:AnnotationProperty .
-# 
-# http://purl.org/dc/terms/issued
+dc:publisher
+    rdfs:label "Publisher"@en ;
+    dcterms:description "Examples of a Publisher include a person, an organization, or a service. Typically, the name of a Publisher should be used to indicate the entity."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#publisher-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "An entity responsible for making the resource available."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-<http://purl.org/dc/terms/issued> a owl:AnnotationProperty .
-# 
-# http://purl.org/dc/terms/modified
+dc:relation
+    rdfs:label "Relation"@en ;
+    dcterms:description "Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system. "@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#relation-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "A related resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-<http://purl.org/dc/terms/modified> a owl:AnnotationProperty .
-# 
-# http://purl.org/dc/terms/publisher
+dc:rights
+    rdfs:label "Rights"@en ;
+    dcterms:description "Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#rights-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "Information about rights held in and over the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-<http://purl.org/dc/terms/publisher> a owl:AnnotationProperty .
-# 
-# http://purl.org/dc/terms/title
+dc:source
+    rdfs:label "Source"@en ;
+    dcterms:description "The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#source-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "A related resource from which the described resource is derived."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-<http://purl.org/dc/terms/title> a owl:AnnotationProperty .
-# 
-# http://www.w3.org/2004/02/skos/core#definition
+dc:subject
+    rdfs:label "Subject"@en ;
+    dcterms:description "Typically, the subject will be represented using keywords, key phrases, or classification codes. Recommended best practice is to use a controlled vocabulary."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#subject-007> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2012-06-14"^^xsd:date ;
+    rdfs:comment "The topic of the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-skos:definition a owl:AnnotationProperty .
-# 
-# http://www.w3.org/2004/02/skos/core#note
+dc:title
+    rdfs:label "Title"@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#title-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "A name given to the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-skos:note a owl:AnnotationProperty .
-# 
-# http://www.w3.org/2004/02/skos/core#prefLabel
+dc:type
+    rdfs:label "Type"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical medium, or dimensions of the resource, use the Format element."@en ;
+    dcterms:hasVersion <http://dublincore.org/usage/terms/history/#type-006> ;
+    dcterms:issued "1999-07-02"^^xsd:date ;
+    dcterms:modified "2008-01-14"^^xsd:date ;
+    rdfs:comment "The nature or genre of the resource."@en ;
+    rdfs:isDefinedBy dc: ;
+    skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
+.
 
-skos:prefLabel a owl:AnnotationProperty .
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Datatypes
-# #
-# #################################################################
-# 
-# 
-# http://www.opengis.net/ont/geosparql#gmlLiteral
+dcterms:description
+    a owl:AnnotationProperty ;
+.
 
-:gmlLiteral a rdfs:Datatype ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      A GML serialization of a geometry object.
-    """@en ;
-	rdfs:comment """
-      A GML serialization of a geometry object.
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "GML Literal"@en ;
-	skos:definition """
-      A GML serialization of a geometry object.
-    """@en ;
-	skos:prefLabel "GML Literal"@en .
-# 
-# http://www.opengis.net/ont/geosparql#wktLiteral
+dcterms:hasVersion
+    a owl:AnnotationProperty ;
+.
 
-:wktLiteral a rdfs:Datatype ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      A Well-known Text serialization of a geometry object.
-    """@en ;
-	rdfs:comment """
-      A Well-known Text serialization of a geometry object.
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "Well-known Text Literal"@en ;
-	skos:definition """
-      A Well-known Text serialization of a geometry object.
-    """@en ;
-	skos:prefLabel "Well-known Text Literal"@en .
-# 
-# http://www.w3.org/2001/XMLSchema#date
+dcterms:issued
+    a owl:AnnotationProperty ;
+.
 
-xsd:date a rdfs:Datatype .
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Object Properties
-# #
-# #################################################################
-# 
-# 
-# http://www.opengis.net/ont/geosparql#defaultGeometry
+dcterms:modified
+    a owl:AnnotationProperty ;
+.
 
-:defaultGeometry a owl:ObjectProperty ;
-	rdfs:subPropertyOf :hasGeometry ;
-	rdfs:domain :Feature ;
-	rdfs:range :Geometry ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The default geometry to be used in spatial calculations.
-      It is Usually the most detailed geometry.
-    """@en ;
-	rdfs:comment """
-      The default geometry to be used in spatial calculations.
-      It is Usually the most detailed geometry.
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "defaultGeometry"@en ;
-	skos:definition """
-      The default geometry to be used in spatial calculations.
-      It is Usually the most detailed geometry.
-    """@en ;
-	skos:prefLabel "defaultGeometry"@en .
-# 
-# http://www.opengis.net/ont/geosparql#ehContains
+dcterms:publisher
+    a owl:AnnotationProperty ;
+.
 
-:ehContains a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*TFF*FF*
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*TFF*FF*
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "contains"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*TFF*FF*
-    """@en ;
-	skos:prefLabel "contains"@en .
-# 
-# http://www.opengis.net/ont/geosparql#ehCoveredBy
+dcterms:title
+    a owl:AnnotationProperty ;
+.
 
-:ehCoveredBy a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFF*TFT**
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFF*TFT**
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "coveredBy"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFF*TFT**
-    """@en ;
-	skos:prefLabel "coveredBy"@en .
-# 
-# http://www.opengis.net/ont/geosparql#ehCovers
-
-:ehCovers a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: T*TFT*FF*
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: T*TFT*FF*
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "covers"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: T*TFT*FF*
-    """@en ;
-	skos:prefLabel "covers"@en .
-# 
-# http://www.opengis.net/ont/geosparql#ehDisjoint
-
-:ehDisjoint a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "disjoint"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
-	skos:prefLabel "disjoint"@en .
-# 
-# http://www.opengis.net/ont/geosparql#ehEquals
-
-:ehEquals a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "equals"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	skos:prefLabel "equals"@en .
-# 
-# http://www.opengis.net/ont/geosparql#ehInside
-
-:ehInside a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFF*FFT**
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFF*FFT**
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "inside"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFF*FFT**
-    """@en ;
-	skos:prefLabel "inside"@en .
-# 
-# http://www.opengis.net/ont/geosparql#ehMeet
-
-:ehMeet a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "meet"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
-	skos:prefLabel "meet"@en .
-# 
-# http://www.opengis.net/ont/geosparql#ehOverlap
-
-:ehOverlap a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "overlap"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
-	skos:prefLabel "overlap"@en .
-# 
-# http://www.opengis.net/ont/geosparql#hasGeometry
-
-:hasGeometry a owl:ObjectProperty ;
-	rdfs:domain :Feature ;
-	rdfs:range :Geometry ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      A spatial representation for a given feature.
-    """@en ;
-	rdfs:comment """
-      A spatial representation for a given feature.
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "hasGeometry"@en ;
-	skos:definition """
-      A spatial representation for a given feature.
-    """@en ;
-	skos:prefLabel "hasGeometry"@en .
-# 
-# http://www.opengis.net/ont/geosparql#rcc8dc
-
-:rcc8dc a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FFTFFTTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FFTFFTTTT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "disconnected"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FFTFFTTTT
-    """@en ;
-	skos:prefLabel "disconnected"@en .
-# 
-# http://www.opengis.net/ont/geosparql#rcc8ec
-
-:rcc8ec a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject. DE-9IM: FFTFTTTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject. DE-9IM: FFTFTTTTT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "externally connected"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially meets the
-      object SpatialObject. DE-9IM: FFTFTTTTT
-    """@en ;
-	skos:prefLabel "externally connected"@en .
-# 
-# http://www.opengis.net/ont/geosparql#rcc8eq
-
-:rcc8eq a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "equals"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	skos:prefLabel "equals"@en .
-# 
-# http://www.opengis.net/ont/geosparql#rcc8ntpp
-
-:rcc8ntpp a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFFTFFTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFFTFFTTT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "non-tangential proper part"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially inside
-      the object SpatialObject. DE-9IM: TFFTFFTTT
-    """@en ;
-	skos:prefLabel "non-tangential proper part"@en .
-# 
-# http://www.opengis.net/ont/geosparql#rcc8ntppi
-
-:rcc8ntppi a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: TTTFFTFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: TTTFFTFFT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "non-tangential proper part inverse"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: TTTFFTFFT
-    """@en ;
-	skos:prefLabel "non-tangential proper part inverse"@en .
-# 
-# http://www.opengis.net/ont/geosparql#rcc8po
-
-:rcc8po a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: TTTTTTTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: TTTTTTTTT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "partially overlapping"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: TTTTTTTTT
-    """@en ;
-	skos:prefLabel "partially overlapping"@en .
-# 
-# http://www.opengis.net/ont/geosparql#rcc8tpp
-
-:rcc8tpp a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFFTTFTTT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFFTTFTTT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "tangential proper part"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially covered
-      by the object SpatialObject. DE-9IM: TFFTTFTTT
-    """@en ;
-	skos:prefLabel "tangential proper part"@en .
-# 
-# http://www.opengis.net/ont/geosparql#rcc8tppi
-
-:rcc8tppi a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: TTTFTTFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: TTTFTTFFT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "tangential proper part inverse"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially covers the
-      object SpatialObject. DE-9IM: TTTFTTFFT
-    """@en ;
-	skos:prefLabel "tangential proper part inverse"@en .
-# 
-# http://www.opengis.net/ont/geosparql#sfContains
-
-:sfContains a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*****FF*
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*****FF*
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "contains"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially contains the
-      object SpatialObject. DE-9IM: T*****FF*
-    """@en ;
-	skos:prefLabel "contains"@en .
-# 
-# http://www.opengis.net/ont/geosparql#sfCrosses
-
-:sfCrosses a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially crosses the
-      object SpatialObject. DE-9IM: T*T******
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially crosses the
-      object SpatialObject. DE-9IM: T*T******
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "crosses"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially crosses the
-      object SpatialObject. DE-9IM: T*T******
-    """@en ;
-	skos:prefLabel "crosses"@en .
-# 
-# http://www.opengis.net/ont/geosparql#sfDisjoint
-
-:sfDisjoint a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "disjoint"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially disjoint
-      from the object SpatialObject. DE-9IM: FF*FF****
-    """@en ;
-	skos:prefLabel "disjoint"@en .
-# 
-# http://www.opengis.net/ont/geosparql#sfEquals
-
-:sfEquals a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "equals"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially equals the
-      object SpatialObject. DE-9IM: TFFFTFFFT
-    """@en ;
-	skos:prefLabel "equals"@en .
-# 
-# http://www.opengis.net/ont/geosparql#sfIntersects
-
-:sfIntersects a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is not spatially disjoint
-      from the object SpatialObject.
-      DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is not spatially disjoint
-      from the object SpatialObject.
-      DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "intersects"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is not spatially disjoint
-      from the object SpatialObject.
-      DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
-    """@en ;
-	skos:prefLabel "intersects"@en .
-# 
-# http://www.opengis.net/ont/geosparql#sfOverlaps
-
-:sfOverlaps a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "overlaps"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially overlaps the
-      object SpatialObject. DE-9IM: T*T***T**
-    """@en ;
-	skos:prefLabel "overlaps"@en .
-# 
-# http://www.opengis.net/ont/geosparql#sfTouches
-
-:sfTouches a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject spatially touches the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject spatially touches the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "touches"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject spatially touches the
-      object SpatialObject.
-      DE-9IM: FT******* ^ F**T***** ^ F***T****
-    """@en ;
-	skos:prefLabel "touches"@en .
-# 
-# http://www.opengis.net/ont/geosparql#sfWithin
-
-:sfWithin a owl:ObjectProperty ;
-	rdfs:domain :SpatialObject ;
-	rdfs:range :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Exists if the subject SpatialObject is spatially within the
-      object SpatialObject. DE-9IM: T*F**F***
-    """@en ;
-	rdfs:comment """
-      Exists if the subject SpatialObject is spatially within the
-      object SpatialObject. DE-9IM: T*F**F***
-    """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "within"@en ;
-	skos:definition """
-      Exists if the subject SpatialObject is spatially within the
-      object SpatialObject. DE-9IM: T*F**F***
-    """@en ;
-	skos:prefLabel "within"@en .
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Data properties
-# #
-# #################################################################
-# 
-# 
-# http://www.opengis.net/ont/geosparql#asGML
-
-:asGML a owl:DatatypeProperty ;
-	rdfs:subPropertyOf :hasSerialization ;
-	rdfs:domain :Geometry ;
-	rdfs:range :gmlLiteral ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
+:asGML
+    a owl:DatatypeProperty ;
+    rdfs:label "asGML"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
       The GML serialization of a geometry
     """@en ;
-	rdfs:comment """
+    rdfs:comment """
       The GML serialization of a geometry
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "asGML"@en ;
-	skos:definition """
+    rdfs:domain :Geometry ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :gmlLiteral ;
+    rdfs:subPropertyOf :hasSerialization ;
+    skos:definition """
       The GML serialization of a geometry
     """@en ;
-	skos:prefLabel "asGML"@en .
-# 
-# http://www.opengis.net/ont/geosparql#asWKT
+    skos:prefLabel "asGML"@en ;
+.
 
-:asWKT a owl:DatatypeProperty ;
-	rdfs:subPropertyOf :hasSerialization ;
-	rdfs:domain :Geometry ;
-	rdfs:range :wktLiteral ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
+:asWKT
+    a owl:DatatypeProperty ;
+    rdfs:label "asWKT"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
       The WKT serialization of a geometry
     """@en ;
-	rdfs:comment """
+    rdfs:comment """
       The WKT serialization of a geometry
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "asWKT"@en ;
-	skos:definition """
+    rdfs:domain :Geometry ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :wktLiteral ;
+    rdfs:subPropertyOf :hasSerialization ;
+    skos:definition """
       The WKT serialization of a geometry
     """@en ;
-	skos:prefLabel "asWKT"@en .
-# 
-# http://www.opengis.net/ont/geosparql#coordinateDimension
+    skos:prefLabel "asWKT"@en ;
+.
 
-:coordinateDimension a owl:DatatypeProperty ;
-	rdfs:domain :Geometry ;
-	rdfs:range xsd:integer ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
+:coordinateDimension
+    a owl:DatatypeProperty ;
+    rdfs:label "coordinateDimension"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
       The number of measurements or axes needed to describe the position of this
       geometry in a coordinate system.
     """@en ;
-	rdfs:comment """
+    rdfs:comment """
       The number of measurements or axes needed to describe the position of this
       geometry in a coordinate system.
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "coordinateDimension"@en ;
-	skos:definition """
+    rdfs:domain :Geometry ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range xsd:integer ;
+    skos:definition """
       The number of measurements or axes needed to describe the position of this
       geometry in a coordinate system.
     """@en ;
-	skos:prefLabel "coordinateDimension"@en .
-# 
-# http://www.opengis.net/ont/geosparql#dimension
+    skos:prefLabel "coordinateDimension"@en ;
+.
 
-:dimension a owl:DatatypeProperty ;
-	rdfs:domain :Geometry ;
-	rdfs:range xsd:integer ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
+:defaultGeometry
+    a owl:ObjectProperty ;
+    rdfs:label "defaultGeometry"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      The default geometry to be used in spatial calculations.
+      It is Usually the most detailed geometry.
+    """@en ;
+    rdfs:comment """
+      The default geometry to be used in spatial calculations.
+      It is Usually the most detailed geometry.
+    """@en ;
+    rdfs:domain :Feature ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :Geometry ;
+    rdfs:subPropertyOf :hasGeometry ;
+    skos:definition """
+      The default geometry to be used in spatial calculations.
+      It is Usually the most detailed geometry.
+    """@en ;
+    skos:prefLabel "defaultGeometry"@en ;
+.
+
+:dimension
+    a owl:DatatypeProperty ;
+    rdfs:label "dimension"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
       The topological dimension of this geometric object, which
       must be less than or equal to the coordinate dimension.
       In non-homogeneous collections, this will return the largest
       topological dimension of the contained objects.
     """@en ;
-	rdfs:comment """
+    rdfs:comment """
       The topological dimension of this geometric object, which
       must be less than or equal to the coordinate dimension.
       In non-homogeneous collections, this will return the largest
       topological dimension of the contained objects.
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "dimension"@en ;
-	skos:definition """
+    rdfs:domain :Geometry ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range xsd:integer ;
+    skos:definition """
       The topological dimension of this geometric object, which
       must be less than or equal to the coordinate dimension.
       In non-homogeneous collections, this will return the largest
       topological dimension of the contained objects.
     """@en ;
-	skos:prefLabel "dimension"@en .
-# 
-# http://www.opengis.net/ont/geosparql#hasSerialization
+    skos:prefLabel "dimension"@en ;
+.
 
-:hasSerialization a owl:DatatypeProperty ;
-	rdfs:domain :Geometry ;
-	rdfs:range rdfs:Literal ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      Connects a geometry object with its text-based serialization.
+:ehContains
+    a owl:ObjectProperty ;
+    rdfs:label "contains"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially contains the
+      object SpatialObject. DE-9IM: T*TFF*FF*
     """@en ;
-	rdfs:comment """
-      Connects a geometry object with its text-based serialization.
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially contains the
+      object SpatialObject. DE-9IM: T*TFF*FF*
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "has serialization"@en ;
-	skos:definition """
-      Connects a geometry object with its text-based serialization.
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially contains the
+      object SpatialObject. DE-9IM: T*TFF*FF*
     """@en ;
-	skos:prefLabel "has serialization"@en .
-# 
-# http://www.opengis.net/ont/geosparql#isEmpty
+    skos:prefLabel "contains"@en ;
+.
 
-:isEmpty a owl:DatatypeProperty ;
-	rdfs:domain :Geometry ;
-	rdfs:range xsd:boolean ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
+:ehCoveredBy
+    a owl:ObjectProperty ;
+    rdfs:label "coveredBy"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject is spatially covered
+      by the object SpatialObject. DE-9IM: TFF*TFT**
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject is spatially covered
+      by the object SpatialObject. DE-9IM: TFF*TFT**
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject is spatially covered
+      by the object SpatialObject. DE-9IM: TFF*TFT**
+    """@en ;
+    skos:prefLabel "coveredBy"@en ;
+.
+
+:ehCovers
+    a owl:ObjectProperty ;
+    rdfs:label "covers"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially covers the
+      object SpatialObject. DE-9IM: T*TFT*FF*
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially covers the
+      object SpatialObject. DE-9IM: T*TFT*FF*
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially covers the
+      object SpatialObject. DE-9IM: T*TFT*FF*
+    """@en ;
+    skos:prefLabel "covers"@en ;
+.
+
+:ehDisjoint
+    a owl:ObjectProperty ;
+    rdfs:label "disjoint"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject is spatially disjoint
+      from the object SpatialObject. DE-9IM: FF*FF****
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject is spatially disjoint
+      from the object SpatialObject. DE-9IM: FF*FF****
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject is spatially disjoint
+      from the object SpatialObject. DE-9IM: FF*FF****
+    """@en ;
+    skos:prefLabel "disjoint"@en ;
+.
+
+:ehEquals
+    a owl:ObjectProperty ;
+    rdfs:label "equals"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially equals the
+      object SpatialObject. DE-9IM: TFFFTFFFT
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially equals the
+      object SpatialObject. DE-9IM: TFFFTFFFT
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially equals the
+      object SpatialObject. DE-9IM: TFFFTFFFT
+    """@en ;
+    skos:prefLabel "equals"@en ;
+.
+
+:ehInside
+    a owl:ObjectProperty ;
+    rdfs:label "inside"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject is spatially inside
+      the object SpatialObject. DE-9IM: TFF*FFT**
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject is spatially inside
+      the object SpatialObject. DE-9IM: TFF*FFT**
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject is spatially inside
+      the object SpatialObject. DE-9IM: TFF*FFT**
+    """@en ;
+    skos:prefLabel "inside"@en ;
+.
+
+:ehMeet
+    a owl:ObjectProperty ;
+    rdfs:label "meet"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially meets the
+      object SpatialObject.
+      DE-9IM: FT******* ^ F**T***** ^ F***T****
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially meets the
+      object SpatialObject.
+      DE-9IM: FT******* ^ F**T***** ^ F***T****
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially meets the
+      object SpatialObject.
+      DE-9IM: FT******* ^ F**T***** ^ F***T****
+    """@en ;
+    skos:prefLabel "meet"@en ;
+.
+
+:ehOverlap
+    a owl:ObjectProperty ;
+    rdfs:label "overlap"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially overlaps the
+      object SpatialObject. DE-9IM: T*T***T**
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially overlaps the
+      object SpatialObject. DE-9IM: T*T***T**
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially overlaps the
+      object SpatialObject. DE-9IM: T*T***T**
+    """@en ;
+    skos:prefLabel "overlap"@en ;
+.
+
+:isEmpty
+    a owl:DatatypeProperty ;
+    rdfs:label "isEmpty"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
       (true) if this geometric object is the empty Geometry. If
       true, then this geometric object represents the empty point
       set for the coordinate space.
     """@en ;
-	rdfs:comment """
+    rdfs:comment """
       (true) if this geometric object is the empty Geometry. If
       true, then this geometric object represents the empty point
       set for the coordinate space.
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "isEmpty"@en ;
-	skos:definition """
+    rdfs:domain :Geometry ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range xsd:boolean ;
+    skos:definition """
       (true) if this geometric object is the empty Geometry. If
       true, then this geometric object represents the empty point
       set for the coordinate space.
     """@en ;
-	skos:prefLabel "isEmpty"@en .
-# 
-# http://www.opengis.net/ont/geosparql#isSimple
+    skos:prefLabel "isEmpty"@en ;
+.
 
-:isSimple a owl:DatatypeProperty ;
-	rdfs:domain :Geometry ;
-	rdfs:range xsd:boolean ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
+:isSimple
+    a owl:DatatypeProperty ;
+    rdfs:label "isSimple"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
       (true) if this geometric object has no anomalous geometric
       points, such as self intersection or self tangency.
     """@en ;
-	rdfs:comment """
+    rdfs:comment """
       (true) if this geometric object has no anomalous geometric
       points, such as self intersection or self tangency.
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "isSimple"@en ;
-	skos:definition """
+    rdfs:domain :Geometry ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range xsd:boolean ;
+    skos:definition """
       (true) if this geometric object has no anomalous geometric
       points, such as self intersection or self tangency.
     """@en ;
-	skos:prefLabel "isSimple"@en .
-# 
-# http://www.opengis.net/ont/geosparql#spatialDimension
+    skos:prefLabel "isSimple"@en ;
+.
 
-:spatialDimension a owl:DatatypeProperty ;
-	rdfs:domain :Geometry ;
-	rdfs:range xsd:integer ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
-      The number of measurements or axes needed to describe the spatial position of
-      this geometry in a coordinate system.
+:rcc8dc
+    a owl:ObjectProperty ;
+    rdfs:label "disconnected"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject is spatially disjoint
+      from the object SpatialObject. DE-9IM: FFTFFTTTT
     """@en ;
-	rdfs:comment """
-      The number of measurements or axes needed to describe the spatial position of
-      this geometry in a coordinate system.
+    rdfs:comment """
+      Exists if the subject SpatialObject is spatially disjoint
+      from the object SpatialObject. DE-9IM: FFTFFTTTT
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "spatialDimension"@en ;
-	skos:definition """
-      The number of measurements or axes needed to describe the spatial position of
-      this geometry in a coordinate system.
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject is spatially disjoint
+      from the object SpatialObject. DE-9IM: FFTFFTTTT
     """@en ;
-	skos:prefLabel "spatialDimension"@en .
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Classes
-# #
-# #################################################################
-# 
-# 
-# http://www.opengis.net/ont/geosparql#Feature
+    skos:prefLabel "disconnected"@en ;
+.
 
-:Feature a owl:Class ;
-	rdfs:subClassOf :SpatialObject ;
-	owl:disjointWith :Geometry ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
+:rcc8ec
+    a owl:ObjectProperty ;
+    rdfs:label "externally connected"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially meets the
+      object SpatialObject. DE-9IM: FFTFTTTTT
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially meets the
+      object SpatialObject. DE-9IM: FFTFTTTTT
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially meets the
+      object SpatialObject. DE-9IM: FFTFTTTTT
+    """@en ;
+    skos:prefLabel "externally connected"@en ;
+.
+
+:rcc8eq
+    a owl:ObjectProperty ;
+    rdfs:label "equals"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially equals the
+      object SpatialObject. DE-9IM: TFFFTFFFT
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially equals the
+      object SpatialObject. DE-9IM: TFFFTFFFT
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially equals the
+      object SpatialObject. DE-9IM: TFFFTFFFT
+    """@en ;
+    skos:prefLabel "equals"@en ;
+.
+
+:rcc8ntpp
+    a owl:ObjectProperty ;
+    rdfs:label "non-tangential proper part"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject is spatially inside
+      the object SpatialObject. DE-9IM: TFFTFFTTT
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject is spatially inside
+      the object SpatialObject. DE-9IM: TFFTFFTTT
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject is spatially inside
+      the object SpatialObject. DE-9IM: TFFTFFTTT
+    """@en ;
+    skos:prefLabel "non-tangential proper part"@en ;
+.
+
+:rcc8ntppi
+    a owl:ObjectProperty ;
+    rdfs:label "non-tangential proper part inverse"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially contains the
+      object SpatialObject. DE-9IM: TTTFFTFFT
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially contains the
+      object SpatialObject. DE-9IM: TTTFFTFFT
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially contains the
+      object SpatialObject. DE-9IM: TTTFFTFFT
+    """@en ;
+    skos:prefLabel "non-tangential proper part inverse"@en ;
+.
+
+:rcc8po
+    a owl:ObjectProperty ;
+    rdfs:label "partially overlapping"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially overlaps the
+      object SpatialObject. DE-9IM: TTTTTTTTT
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially overlaps the
+      object SpatialObject. DE-9IM: TTTTTTTTT
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially overlaps the
+      object SpatialObject. DE-9IM: TTTTTTTTT
+    """@en ;
+    skos:prefLabel "partially overlapping"@en ;
+.
+
+:rcc8tpp
+    a owl:ObjectProperty ;
+    rdfs:label "tangential proper part"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject is spatially covered
+      by the object SpatialObject. DE-9IM: TFFTTFTTT
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject is spatially covered
+      by the object SpatialObject. DE-9IM: TFFTTFTTT
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject is spatially covered
+      by the object SpatialObject. DE-9IM: TFFTTFTTT
+    """@en ;
+    skos:prefLabel "tangential proper part"@en ;
+.
+
+:rcc8tppi
+    a owl:ObjectProperty ;
+    rdfs:label "tangential proper part inverse"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially covers the
+      object SpatialObject. DE-9IM: TTTFTTFFT
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially covers the
+      object SpatialObject. DE-9IM: TTTFTTFFT
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially covers the
+      object SpatialObject. DE-9IM: TTTFTTFFT
+    """@en ;
+    skos:prefLabel "tangential proper part inverse"@en ;
+.
+
+:sfContains
+    a owl:ObjectProperty ;
+    rdfs:label "contains"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially contains the
+      object SpatialObject. DE-9IM: T*****FF*
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially contains the
+      object SpatialObject. DE-9IM: T*****FF*
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially contains the
+      object SpatialObject. DE-9IM: T*****FF*
+    """@en ;
+    skos:prefLabel "contains"@en ;
+.
+
+:sfCrosses
+    a owl:ObjectProperty ;
+    rdfs:label "crosses"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially crosses the
+      object SpatialObject. DE-9IM: T*T******
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially crosses the
+      object SpatialObject. DE-9IM: T*T******
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially crosses the
+      object SpatialObject. DE-9IM: T*T******
+    """@en ;
+    skos:prefLabel "crosses"@en ;
+.
+
+:sfDisjoint
+    a owl:ObjectProperty ;
+    rdfs:label "disjoint"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject is spatially disjoint
+      from the object SpatialObject. DE-9IM: FF*FF****
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject is spatially disjoint
+      from the object SpatialObject. DE-9IM: FF*FF****
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject is spatially disjoint
+      from the object SpatialObject. DE-9IM: FF*FF****
+    """@en ;
+    skos:prefLabel "disjoint"@en ;
+.
+
+:sfEquals
+    a owl:ObjectProperty ;
+    rdfs:label "equals"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially equals the
+      object SpatialObject. DE-9IM: TFFFTFFFT
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially equals the
+      object SpatialObject. DE-9IM: TFFFTFFFT
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially equals the
+      object SpatialObject. DE-9IM: TFFFTFFFT
+    """@en ;
+    skos:prefLabel "equals"@en ;
+.
+
+:sfIntersects
+    a owl:ObjectProperty ;
+    rdfs:label "intersects"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject is not spatially disjoint
+      from the object SpatialObject.
+      DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject is not spatially disjoint
+      from the object SpatialObject.
+      DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject is not spatially disjoint
+      from the object SpatialObject.
+      DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T****
+    """@en ;
+    skos:prefLabel "intersects"@en ;
+.
+
+:sfOverlaps
+    a owl:ObjectProperty ;
+    rdfs:label "overlaps"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially overlaps the
+      object SpatialObject. DE-9IM: T*T***T**
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially overlaps the
+      object SpatialObject. DE-9IM: T*T***T**
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially overlaps the
+      object SpatialObject. DE-9IM: T*T***T**
+    """@en ;
+    skos:prefLabel "overlaps"@en ;
+.
+
+:sfTouches
+    a owl:ObjectProperty ;
+    rdfs:label "touches"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject spatially touches the
+      object SpatialObject.
+      DE-9IM: FT******* ^ F**T***** ^ F***T****
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject spatially touches the
+      object SpatialObject.
+      DE-9IM: FT******* ^ F**T***** ^ F***T****
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject spatially touches the
+      object SpatialObject.
+      DE-9IM: FT******* ^ F**T***** ^ F***T****
+    """@en ;
+    skos:prefLabel "touches"@en ;
+.
+
+:sfWithin
+    a owl:ObjectProperty ;
+    rdfs:label "within"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Exists if the subject SpatialObject is spatially within the
+      object SpatialObject. DE-9IM: T*F**F***
+    """@en ;
+    rdfs:comment """
+      Exists if the subject SpatialObject is spatially within the
+      object SpatialObject. DE-9IM: T*F**F***
+    """@en ;
+    rdfs:domain :SpatialObject ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :SpatialObject ;
+    skos:definition """
+      Exists if the subject SpatialObject is spatially within the
+      object SpatialObject. DE-9IM: T*F**F***
+    """@en ;
+    skos:prefLabel "within"@en ;
+.
+
+:spatialDimension
+    a owl:DatatypeProperty ;
+    rdfs:label "spatialDimension"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      The number of measurements or axes needed to describe the spatial position of
+      this geometry in a coordinate system.
+    """@en ;
+    rdfs:comment """
+      The number of measurements or axes needed to describe the spatial position of
+      this geometry in a coordinate system.
+    """@en ;
+    rdfs:domain :Geometry ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range xsd:integer ;
+    skos:definition """
+      The number of measurements or axes needed to describe the spatial position of
+      this geometry in a coordinate system.
+    """@en ;
+    skos:prefLabel "spatialDimension"@en ;
+.
+
+xsd:date
+    a rdfs:Datatype ;
+.
+
+skos:definition
+    a owl:AnnotationProperty ;
+.
+
+skos:note
+    a owl:AnnotationProperty ;
+.
+
+skos:prefLabel
+    a owl:AnnotationProperty ;
+.
+
+:gmlLiteral
+    a rdfs:Datatype ;
+    rdfs:label "GML Literal"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      A GML serialization of a geometry object.
+    """@en ;
+    rdfs:comment """
+      A GML serialization of a geometry object.
+    """@en ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    skos:definition """
+      A GML serialization of a geometry object.
+    """@en ;
+    skos:prefLabel "GML Literal"@en ;
+.
+
+:hasGeometry
+    a owl:ObjectProperty ;
+    rdfs:label "hasGeometry"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      A spatial representation for a given feature.
+    """@en ;
+    rdfs:comment """
+      A spatial representation for a given feature.
+    """@en ;
+    rdfs:domain :Feature ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range :Geometry ;
+    skos:definition """
+      A spatial representation for a given feature.
+    """@en ;
+    skos:prefLabel "hasGeometry"@en ;
+.
+
+:wktLiteral
+    a rdfs:Datatype ;
+    rdfs:label "Well-known Text Literal"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      A Well-known Text serialization of a geometry object.
+    """@en ;
+    rdfs:comment """
+      A Well-known Text serialization of a geometry object.
+    """@en ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    skos:definition """
+      A Well-known Text serialization of a geometry object.
+    """@en ;
+    skos:prefLabel "Well-known Text Literal"@en ;
+.
+
+:Feature
+    a owl:Class ;
+    rdfs:label "Feature"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
       This class represents the top-level feature type. This class is
       equivalent to GFI_Feature defined in ISO 19156:2011, and it is
       superclass of all feature types.
     """@en ;
-	rdfs:comment """
+    rdfs:comment """
       This class represents the top-level feature type. This class is
       equivalent to GFI_Feature defined in ISO 19156:2011, and it is
       superclass of all feature types.
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "Feature"@en ;
-	skos:definition """
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:subClassOf :SpatialObject ;
+    owl:disjointWith :Geometry ;
+    skos:definition """
       This class represents the top-level feature type. This class is
       equivalent to GFI_Feature defined in ISO 19156:2011, and it is
       superclass of all feature types.
     """@en ;
-	skos:prefLabel "Feature"@en .
-# 
-# http://www.opengis.net/ont/geosparql#Geometry
+    skos:prefLabel "Feature"@en ;
+.
 
-:Geometry a owl:Class ;
-	rdfs:subClassOf :SpatialObject ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
+:hasSerialization
+    a owl:DatatypeProperty ;
+    rdfs:label "has serialization"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
+      Connects a geometry object with its text-based serialization.
+    """@en ;
+    rdfs:comment """
+      Connects a geometry object with its text-based serialization.
+    """@en ;
+    rdfs:domain :Geometry ;
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:range rdfs:Literal ;
+    skos:definition """
+      Connects a geometry object with its text-based serialization.
+    """@en ;
+    skos:prefLabel "has serialization"@en ;
+.
+
+:Geometry
+    a owl:Class ;
+    rdfs:label "Geometry"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
       The class represents the top-level geometry type. This class is
       equivalent to the UML class GM_Object defined in ISO 19107, and
       it is superclass of all geometry types.
     """@en ;
-	rdfs:comment """
+    rdfs:comment """
       The class represents the top-level geometry type. This class is
       equivalent to the UML class GM_Object defined in ISO 19107, and
       it is superclass of all geometry types.
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "Geometry"@en ;
-	skos:definition """
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    rdfs:subClassOf :SpatialObject ;
+    skos:definition """
       The class represents the top-level geometry type. This class is
       equivalent to the UML class GM_Object defined in ISO 19107, and
       it is superclass of all geometry types.
     """@en ;
-	skos:prefLabel "Geometry"@en .
-# 
-# http://www.opengis.net/ont/geosparql#SpatialObject
+    skos:prefLabel "Geometry"@en ;
+.
 
-:SpatialObject a owl:Class ;
-	dc:contributor "Matthew Perry" ;
-	dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
-	dc:date "2011-06-16"^^xsd:date ;
-	dc:description """
+dc:
+    dcterms:modified "2012-06-14"^^xsd:date ;
+    dcterms:publisher <http://purl.org/dc/aboutdcmi#DCMI> ;
+    dcterms:title "Dublin Core Metadata Element Set, Version 1.1"@en ;
+.
+
+<http://www.opengis.net/ont/geosparql>
+    a owl:Ontology ;
+    dc:creator "Open Geospatial Consortium" ;
+    dc:date "2012-04-30"^^xsd:date ;
+    dc:description "An RDF/OWL vocabulary for representing spatial information" ;
+    dc:source
+        <http://www.opengis.net/doc/IS/geosparql/1.0> ,
+        "OGC GeoSPARQL – A Geographic Query Language for RDF Data OGC 11-052r5" ;
+    dc:title "GeoSPARQL Ontology" ;
+    rdfs:seeAlso
+        <http://www.opengis.net/def/function/ogc-geosparql/1.0> ,
+        <http://www.opengis.net/def/rule/ogc-geosparql/1.0> ,
+        <http://www.opengis.net/doc/IS/geosparql/1.0> ;
+    owl:versionIRI <http://www.opengis.net/ont/geosparql/1.0> ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
+.
+
+:SpatialObject
+    a owl:Class ;
+    rdfs:label "SpatialObject"@en ;
+    dc:contributor "Matthew Perry" ;
+    dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+    dc:date "2011-06-16"^^xsd:date ;
+    dc:description """
       The class spatial-object represents everything that can have
       a spatial representation. It is superclass of feature and geometry.
     """@en ;
-	rdfs:comment """
+    rdfs:comment """
       The class spatial-object represents everything that can have
       a spatial representation. It is superclass of feature and geometry.
     """@en ;
-	rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> , <http://www.opengis.net/spec/geosparql/1.0> ;
-	rdfs:label "SpatialObject"@en ;
-	skos:definition """
+    rdfs:isDefinedBy
+        <http://www.opengis.net/ont/geosparql> ,
+        <http://www.opengis.net/spec/geosparql/1.0> ;
+    skos:definition """
       The class spatial-object represents everything that can have
       a spatial representation. It is superclass of feature and geometry.
     """@en ;
-	skos:prefLabel "SpatialObject"@en .
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Annotations
-# #
-# #################################################################
-# 
-# 
-
-<http://purl.org/dc/elements/1.1/> <http://purl.org/dc/terms/publisher> <http://purl.org/dc/aboutdcmi#DCMI> ;
-	<http://purl.org/dc/terms/title> "Dublin Core Metadata Element Set, Version 1.1"@en ;
-	<http://purl.org/dc/terms/modified> "2012-06-14"^^xsd:date .
-# 
-
-dc:coverage <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#coverage-006> ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
-	rdfs:comment "The spatial or temporal topic of the resource, the spatial applicability of the resource, or the jurisdiction under which the resource is relevant."@en ;
-	<http://purl.org/dc/terms/description> "Spatial topic and spatial applicability may be a named place or a location specified by its geographic coordinates. Temporal topic may be a named period, date, or date range. A jurisdiction may be a named administrative entity or a geographic place to which the resource applies. Recommended best practice is to use a controlled vocabulary such as the Thesaurus of Geographic Names [TGN]. Where appropriate, named places or time periods can be used in preference to numeric identifiers such as sets of coordinates or date ranges."@en ;
-	rdfs:label "Coverage"@en ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date .
-# 
-
-dc:format skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	rdfs:label "Format"@en ;
-	rdfs:comment "The file format, physical medium, or dimensions of the resource."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	<http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#format-007> ;
-	<http://purl.org/dc/terms/description> "Examples of dimensions include size and duration. Recommended best practice is to use a controlled vocabulary such as the list of Internet Media Types [MIME]."@en .
-# 
-
-dc:identifier <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#identifier-006> ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	<http://purl.org/dc/terms/description> "Recommended best practice is to identify the resource by means of a string conforming to a formal identification system. "@en ;
-	rdfs:comment "An unambiguous reference to the resource within a given context."@en ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	rdfs:label "Identifier"@en ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en .
-# 
-
-dc:language <http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
-	rdfs:label "Language"@en ;
-	<http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#language-007> ;
-	<http://purl.org/dc/terms/description> "Recommended best practice is to use a controlled vocabulary such as RFC 4646 [RFC4646]."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	rdfs:seeAlso <http://www.ietf.org/rfc/rfc4646.txt> ;
-	rdfs:comment "A language of the resource."@en .
-# 
-
-dc:publisher <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#publisher-006> ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	rdfs:label "Publisher"@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	<http://purl.org/dc/terms/description> "Examples of a Publisher include a person, an organization, or a service. Typically, the name of a Publisher should be used to indicate the entity."@en ;
-	rdfs:comment "An entity responsible for making the resource available."@en .
-# 
-
-dc:relation <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#relation-006> ;
-	rdfs:label "Relation"@en ;
-	<http://purl.org/dc/terms/description> "Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system. "@en ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
-	rdfs:comment "A related resource."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> .
-# 
-
-dc:rights <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#rights-006> ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/description> "Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights."@en ;
-	rdfs:label "Rights"@en ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	rdfs:comment "Information about rights held in and over the resource."@en .
-# 
-
-dc:subject <http://purl.org/dc/terms/description> "Typically, the subject will be represented using keywords, key phrases, or classification codes. Recommended best practice is to use a controlled vocabulary."@en ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	rdfs:label "Subject"@en ;
-	rdfs:comment "The topic of the resource."@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	<http://purl.org/dc/terms/modified> "2012-06-14"^^xsd:date ;
-	<http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#subject-007> .
-# 
-
-dc:title rdfs:comment "A name given to the resource."@en ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en ;
-	rdfs:label "Title"@en ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#title-006> ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> .
-# 
-
-dc:type <http://purl.org/dc/terms/hasVersion> <http://dublincore.org/usage/terms/history/#type-006> ;
-	rdfs:comment "The nature or genre of the resource."@en ;
-	rdfs:label "Type"@en ;
-	rdfs:isDefinedBy <http://purl.org/dc/elements/1.1/> ;
-	<http://purl.org/dc/terms/description> "Recommended best practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical medium, or dimensions of the resource, use the Format element."@en ;
-	<http://purl.org/dc/terms/issued> "1999-07-02"^^xsd:date ;
-	<http://purl.org/dc/terms/modified> "2008-01-14"^^xsd:date ;
-	skos:note "A second property with the same name as this property has been declared in the dcterms: namespace (http://purl.org/dc/terms/).  See the Introduction to the document \"DCMI Metadata Terms\" (http://dublincore.org/documents/dcmi-terms/) for an explanation."@en .
-# 
-# Generated by the OWL API (version 4.5.6.2018-09-06T00:27:41Z) https://github.com/owlcs/owlapi
+    skos:prefLabel "SpatialObject"@en ;
+.

--- a/1.0/geo.ttl
+++ b/1.0/geo.ttl
@@ -9,12 +9,15 @@
 
 <http://www.opengis.net/ont/geosparql> a owl:Ontology ;
     dc:title "GeoSPARQL Ontology" ;
-	dc:creator "Open Geospatial Consortium"^^xsd:string ;
+	dc:creator "Open Geospatial Consortium" ;
 	dc:date "2012-04-30"^^xsd:date ;
-	dc:description "An RDF/OWL vocabulary for representing spatial information"^^xsd:string ;
-	dc:source <http://www.opengis.net/doc/IS/geosparql/1.0> , "OGC GeoSPARQL – A Geographic Query Language for RDF Data OGC 11-052r5"^^xsd:string ;
+	dc:description "An RDF/OWL vocabulary for representing spatial information" ;
+	dc:source <http://www.opengis.net/doc/IS/geosparql/1.0> , "OGC GeoSPARQL – A Geographic Query Language for RDF Data OGC 11-052r5" ;
 	rdfs:seeAlso <http://www.opengis.net/def/function/ogc-geosparql/1.0> , <http://www.opengis.net/def/rule/ogc-geosparql/1.0> , <http://www.opengis.net/doc/IS/geosparql/1.0> ;
-	owl:versionInfo "OGC GeoSPARQL 1.0"^^xsd:string .
+	owl:versionInfo "OGC GeoSPARQL 1.0" ;
+	owl:versionIRI <http://www.opengis.net/ont/geosparql/1.0> ;
+.
+
 # 
 # 
 # #################################################################

--- a/1.0/profile.ttl
+++ b/1.0/profile.ttl
@@ -4,76 +4,75 @@ PREFIX prof: <http://www.w3.org/ns/dx/prof/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX role: <http://www.w3.org/ns/dx/prof/role/>
 PREFIX sdo: <https://schema.org/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-
 <http://www.opengis.net/def/geosparql>
     a prof:Profile ;
-    owl:versionInfo "OGC GeoSPARQL 1.0" ;
-    owl:versionIRI <http://www.opengis.net/def/geosparql/1.0> ;   
     dcterms:created "2020-11-20"^^xsd:date ;
-    dcterms:modified "2020-12-22"^^xsd:date ;
+    dcterms:description "This is a 'profile declaration' for the GeoSPARQL 1.0 specification (standard) as originally published in 2012. It describes the multiple parts of the specification and how the standard relates to other standards. It is formulated according to the Profiles Vocabulary."@en ;
     dcterms:issued "2021"^^xsd:gYear ;
+    dcterms:modified "2020-12-22"^^xsd:date ;
     dcterms:publisher <https://ror.org/00fsdxs93> ;
     dcterms:title "GeoSPARQL 1.0 Profile" ;
-    dcterms:description """This is a 'profile declaration' for the GeoSPARQL 1.0 specification (standard) as originally published in 2012. It describes the multiple parts of the specification and how the standard relates to other standards. It is formulated according to the Profiles Vocabulary."""@en ;
-    skos:scopeNote """Profile declarations are used to allow data to identify specifications in a way that allows data to make conformance claims to them - a broader conformance claim than that made to individual 'conformance classes' that are commonly found in recent OGC specifications. Profile declarations are also used to describe and relate the often multiple parts of specifications: ontologies, specification 'documents', vocabularies, validators and so on. This declaration describes where those parts are, what form (format) they take, what information models they implement and what roles they play."""@en ;    
-    prof:hasResource 
+    owl:versionIRI <http://www.opengis.net/def/geosparql/1.0> ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
+    skos:scopeNote "Profile declarations are used to allow data to identify specifications in a way that allows data to make conformance claims to them - a broader conformance claim than that made to individual 'conformance classes' that are commonly found in recent OGC specifications. Profile declarations are also used to describe and relate the often multiple parts of specifications: ontologies, specification 'documents', vocabularies, validators and so on. This declaration describes where those parts are, what form (format) they take, what information models they implement and what roles they play."@en ;
+    prof:hasResource
+        <http://www.opengis.net/def/geosparql/funcsrules> ,
         <http://www.opengis.net/doc/IS/geosparql/1.0> ,
         <http://www.opengis.net/ont/geosparql> ,
-        <http://www.opengis.net/def/geosparql/funcsrules> ,
         <http://www.opengis.net/ont/sf> ;
 .
 
-<https://ror.org/00fsdxs93>
-    a owl:NamedIndividual ;
-    a sdo:Organization ;
-    sdo:name "Open Geospatial Consortium" ;
-    sdo:url <https://www.ogc.org> ;
+<http://www.opengis.net/ont/gml>
+    dcterms:conformsTo <http://www.w3.org/TR/owl2-rdf-based-semantics/> ;
+    dcterms:description "An OWL ontology (vocabulary) of the GML geometry types"@en ;
+    dcterms:format "text/xml" ;
+    dcterms:title "GML Geometry Types Vocabulary"@en ;
+    prof:hasArtifact "https://schemas.opengis.net/gml/3.2.1/gml_32_geometries.rdf"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.
+
+<http://www.opengis.net/def/geosparql/funcsrules>
+    dcterms:conformsTo <https://www.w3.org/TR/skos-reference/> ;
+    dcterms:description "all GeoSPARQL functions and rules presented as a SKOS vocabulary"@en ;
+    dcterms:format "text/turtle" ;
+    dcterms:title "GeoSPARQL Functions & Rules vocabulary"@en ;
+    prof:hasArtifact <http://defs-dev.opengis.net/static/definitions/conceptschemes/functions_geosparql.ttl> ;
+    prof:hasRole role:vocabulary ;
 .
 
 <http://www.opengis.net/doc/IS/geosparql/1.0>
-    dcterms:title "GeoSPARQL Specification Document as a PDF"@en ;
     dcterms:format "application/pdf" ;
+    dcterms:title "GeoSPARQL Specification Document as a PDF"@en ;
     prof:hasArtifact <https://portal.ogc.org/files/?artifact_id=47664> ;
     prof:hasRole role:specification ;
 .
 
 <http://www.opengis.net/ont/geosparql>
-    dcterms:title "GeoSPARQL Ontology"@en ;
-    dcterms:description "The GeoSPARQL 1.1 ontology in RDF (turtle)"@en ;
     dcterms:conformsTo <http://www.w3.org/TR/owl2-rdf-based-semantics/> ;
+    dcterms:description "The GeoSPARQL 1.1 ontology in RDF (turtle)"@en ;
     dcterms:format "application/rdf+xml" ;
+    dcterms:title "GeoSPARQL Ontology"@en ;
     prof:hasArtifact <http://schemas.opengis.net/geosparql/1.0/geosparql_vocab_all.rdf> ;
     prof:hasRole role:scheme ;
 .
 
-<http://www.opengis.net/def/geosparql/funcsrules>
-    dcterms:title "GeoSPARQL Functions & Rules vocabulary"@en ;
-    dcterms:description "all GeoSPARQL functions and rules presented as a SKOS vocabulary"@en ;
-    dcterms:conformsTo <https://www.w3.org/TR/skos-reference/> ;
-    dcterms:format "text/turtle" ;
-    prof:hasArtifact <http://defs-dev.opengis.net/static/definitions/conceptschemes/functions_geosparql.ttl> ;
-    prof:hasRole role:vocabulary ;
-.
-
 <http://www.opengis.net/ont/sf>
-    dcterms:title "Simple Features Vocabulary"@en ;
-    dcterms:description "An OWL ontology (vocabulary) of the Simple Features geometry types"@en ;
     dcterms:conformsTo <http://www.w3.org/TR/owl2-rdf-based-semantics/> ;
+    dcterms:description "An OWL ontology (vocabulary) of the Simple Features geometry types"@en ;
     dcterms:format "text/xml" ;
+    dcterms:title "Simple Features Vocabulary"@en ;
+    rdfs:comment "A Turtle format artifact for this Resource is present in the GeoSPARQL 1.0 profile repository. It includes ontology annotations (title, date etc.) not present in the online artifact referenced here."@en ;
     prof:hasArtifact <http://schemas.opengis.net/sf/1.0/simple_features_geometries.rdf> ;
     prof:hasRole role:vocabulary ;
-    rdfs:comment "A Turtle format artifact for this Resource is present in the GeoSPARQL 1.0 profile repository. It includes ontology annotations (title, date etc.) not present in the online artifact referenced here."@en ;
 .
 
-<http://www.opengis.net/ont/gml>
-    dcterms:title "GML Geometry Types Vocabulary"@en ;
-    dcterms:description "An OWL ontology (vocabulary) of the GML geometry types"@en ;
-    dcterms:conformsTo <http://www.w3.org/TR/owl2-rdf-based-semantics/> ;
-    dcterms:format "text/xml" ;
-    prof:hasArtifact "https://schemas.opengis.net/gml/3.2.1/gml_32_geometries.rdf"^^xsd:anyURI ;
-    prof:hasRole role:vocabulary ;
+<https://ror.org/00fsdxs93>
+    a
+        owl:NamedIndividual ,
+        sdo:Organization ;
+    sdo:name "Open Geospatial Consortium" ;
+    sdo:url <https://www.ogc.org> ;
 .

--- a/1.0/profile.ttl
+++ b/1.0/profile.ttl
@@ -11,6 +11,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <http://www.opengis.net/def/geosparql>
     a prof:Profile ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
     owl:versionIRI <http://www.opengis.net/def/geosparql/1.0> ;   
     dcterms:created "2020-11-20"^^xsd:date ;
     dcterms:modified "2020-12-22"^^xsd:date ;

--- a/1.0/servicedescription_allfunctions.ttl
+++ b/1.0/servicedescription_allfunctions.ttl
@@ -1,57 +1,59 @@
-@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
-@prefix geo: <http://www.opengis.net/ont/geosparql#> .
-@prefix ent: <http://www.w3.org/ns/entailment/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix prof: <http://www.w3.org/ns/owl-profile/> .
-@prefix geof: <http://www.opengis.net/def/function/geosparql/> .
-@prefix void: <http://rdfs.org/ns/void#> .
+PREFIX ent: <http://www.w3.org/ns/entailment/>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-<http://www.opengis.net/def/geosparql/servicedescallfunctions> 
-    a sd:Service, skos:ConceptScheme ;
-    skos:prefLabel "GeoSPARQL 1.0 SPARQL Service Description: All Functions" ;
-    owl:versionInfo "OGC GeoSPARQL 1.0" ;
+<http://www.opengis.net/def/geosparql/servicedescallfunctions>
+    a
+        skos:ConceptScheme ,
+        sd:Service ;
     owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescallfunctions/1.0> ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
+    skos:prefLabel "GeoSPARQL 1.0 SPARQL Service Description: All Functions" ;
+    sd:defaultEntailmentRegime ent:RDFS ;
+    sd:extensionFunction
+        geof:asGML ,
+        geof:asWKT ,
+        geof:boundary ,
+        geof:buffer ,
+        geof:centroid ,
+        geof:convexHull ,
+        geof:difference ,
+        geof:dimension ,
+        geof:distance ,
+        geof:ehContains ,
+        geof:ehCoveredBy ,
+        geof:ehCovers ,
+        geof:ehDisjoint ,
+        geof:ehEquals ,
+        geof:ehInside ,
+        geof:ehMeet ,
+        geof:ehOverlap ,
+        geof:envelope ,
+        geof:getSRID ,
+        geof:intersection ,
+        geof:rcc8dc ,
+        geof:rcc8ec ,
+        geof:rcc8eq ,
+        geof:rcc8ntpp ,
+        geof:rcc8ntppi ,
+        geof:rcc8po ,
+        geof:rcc8tpp ,
+        geof:rcc8tppi ,
+        geof:relate ,
+        geof:sfContains ,
+        geof:sfCrosses ,
+        geof:sfDisjoint ,
+        geof:sfEquals ,
+        geof:sfIntersects ,
+        geof:sfOverlaps ,
+        geof:sfTouches ,
+        geof:sfWithin ,
+        geof:symDifference ,
+        geof:union ;
+    sd:resultFormat
+        <http://www.w3.org/ns/formats/RDF_XML> ,
+        <http://www.w3.org/ns/formats/Turtle> ;
     sd:supportedLanguage sd:SPARQL11Query ;
-    sd:extensionFunction geof:asGML;
-    sd:extensionFunction geof:asWKT;
-    sd:extensionFunction geof:boundary;
-    sd:extensionFunction geof:buffer;
-    sd:extensionFunction geof:centroid;
-    sd:extensionFunction geof:convexHull;
-    sd:extensionFunction geof:difference;
-    sd:extensionFunction geof:dimension;
-    sd:extensionFunction geof:distance;
-    sd:extensionFunction geof:ehContains;
-    sd:extensionFunction geof:ehCoveredBy;
-    sd:extensionFunction geof:ehCovers;
-    sd:extensionFunction geof:ehDisjoint;
-    sd:extensionFunction geof:ehEquals;
-    sd:extensionFunction geof:ehInside;
-    sd:extensionFunction geof:ehMeet;
-    sd:extensionFunction geof:ehOverlap;
-    sd:extensionFunction geof:envelope;
-    sd:extensionFunction geof:getSRID;
-    sd:extensionFunction geof:intersection;
-    sd:extensionFunction geof:rcc8dc;
-    sd:extensionFunction geof:rcc8ec;
-    sd:extensionFunction geof:rcc8eq;
-    sd:extensionFunction geof:rcc8ntpp;
-    sd:extensionFunction geof:rcc8ntppi;
-    sd:extensionFunction geof:rcc8po;
-    sd:extensionFunction geof:rcc8tpp;
-    sd:extensionFunction geof:rcc8tppi;
-    sd:extensionFunction geof:relate;
-    sd:extensionFunction geof:sfContains;
-    sd:extensionFunction geof:sfCrosses;
-    sd:extensionFunction geof:sfDisjoint;
-    sd:extensionFunction geof:sfEquals;
-    sd:extensionFunction geof:sfIntersects;
-    sd:extensionFunction geof:sfOverlaps;
-    sd:extensionFunction geof:sfTouches;
-    sd:extensionFunction geof:sfWithin;
-    sd:extensionFunction geof:symDifference;
-    sd:extensionFunction geof:union;
-    sd:resultFormat <http://www.w3.org/ns/formats/RDF_XML>, <http://www.w3.org/ns/formats/Turtle> ;
-    sd:defaultEntailmentRegime ent:RDFS
 .

--- a/1.0/servicedescription_allfunctions.ttl
+++ b/1.0/servicedescription_allfunctions.ttl
@@ -2,12 +2,16 @@
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix ent: <http://www.w3.org/ns/entailment/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix prof: <http://www.w3.org/ns/owl-profile/> .
 @prefix geof: <http://www.opengis.net/def/function/geosparql/> .
 @prefix void: <http://rdfs.org/ns/void#> .
 
-<http://www.opengis.net/def/geosparql/servicedescallfunctions> a sd:Service, skos:ConceptScheme ;
+<http://www.opengis.net/def/geosparql/servicedescallfunctions> 
+    a sd:Service, skos:ConceptScheme ;
     skos:prefLabel "GeoSPARQL 1.0 SPARQL Service Description: All Functions" ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescallfunctions/1.0> ;
     sd:supportedLanguage sd:SPARQL11Query ;
     sd:extensionFunction geof:asGML;
     sd:extensionFunction geof:asWKT;

--- a/1.0/servicedescription_conformanceclasses.ttl
+++ b/1.0/servicedescription_conformanceclasses.ttl
@@ -1,50 +1,42 @@
-@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
-@prefix geo: <http://www.opengis.net/ont/geosparql#> .
-@prefix ent: <http://www.w3.org/ns/entailment/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix prof: <http://www.w3.org/ns/owl-profile/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix conf10core: <http://www.opengis.net/spec/geosparql/1.0/conf/core/> .
-@prefix conf11core: <http://www.opengis.net/spec/geosparql/1.1/conf/core/> .
-@prefix conf10gx: <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-extension/> .
-@prefix conf11gx: <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension/> .
-@prefix conf10gtx: <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-topology-extension/> .
-@prefix conf11gtx: <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-topology-extension/> .
-@prefix conf10qre: <http://www.opengis.net/spec/geosparql/1.0/conf/query-rewrite-extension/> .
-@prefix conf11qre: <http://www.opengis.net/spec/geosparql/1.1/conf/query-rewrite-extension/> .
-@prefix conf10ree: <http://www.opengis.net/spec/geosparql/1.0/conf/rdfs-entailment-extension/> .
-@prefix conf11ree: <http://www.opengis.net/spec/geosparql/1.1/conf/rdfs-entailment-extension/> .
-@prefix conf10tve: <http://www.opengis.net/spec/geosparql/1.0/conf/topology-vocab-extension/> .
-@prefix conf11tve: <http://www.opengis.net/spec/geosparql/1.1/conf/topology-vocab-extension/> .
-@prefix void: <http://rdfs.org/ns/void#> .
+PREFIX conf10core: <http://www.opengis.net/spec/geosparql/1.0/conf/core/>
+PREFIX conf10gtx: <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-topology-extension/>
+PREFIX conf10gx: <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-extension/>
+PREFIX conf10qre: <http://www.opengis.net/spec/geosparql/1.0/conf/query-rewrite-extension/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-<http://www.opengis.net/def/geosparql/servicedescconformanceclasses> 
-    a sd:Service, skos:ConceptScheme ;
-    skos:prefLabel "GeoSPARQL 1.0 SPARQL Service Description: All Conformance Classes" ;
+<http://www.opengis.net/def/geosparql/servicedescconformanceclasses>
+    a
+        skos:ConceptScheme ,
+        sd:Service ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescconformanceclasses/1.0> ;
     owl:versionInfo "OGC GeoSPARQL 1.0" ;
-    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescconformanceclasses/1.0> ;   
+    skos:prefLabel "GeoSPARQL 1.0 SPARQL Service Description: All Conformance Classes" ;
+    sd:feature
+        conf10core:feature-class ,
+        conf10core:sparql-protocol ,
+        conf10core:spatial-object-class ,
+        conf10gx:feature-properties ,
+        conf10gx:geometry-as-gml-literal ,
+        conf10gx:geometry-as-wkt-literal ,
+        conf10gx:geometry-class ,
+        conf10gx:geometry-properties ,
+        conf10gx:gml-literal ,
+        conf10gx:gml-literal-empty ,
+        conf10gx:gml-profile ,
+        conf10gx:query-functions ,
+        conf10gx:srid-function ,
+        conf10gx:wkt-axis-order ,
+        conf10gx:wkt-literal ,
+        conf10gx:wkt-literal-default-srs ,
+        conf10gx:wkt-literal-empty ,
+        conf10gtx:eh-query-functions ,
+        conf10gtx:rcc8-query-functions ,
+        conf10gtx:relate-query-function ,
+        conf10gtx:sf-query-functions ,
+        conf10qre:eh-query-rewrite ,
+        conf10qre:rcc8-query-rewrite ,
+        conf10qre:sf-query-rewrite ;
     sd:supportedLanguage sd:SPARQL11Query ;
-    sd:feature conf10core:sparql-protocol ;
-    sd:feature conf10core:feature-class ;
-    sd:feature conf10core:spatial-object-class ;
-    sd:feature conf10gx:geometry-class ;
-    sd:feature conf10gx:geometry-properties ;
-    sd:feature conf10gx:feature-properties ;
-    sd:feature conf10gx:geometry-as-gml-literal ;
-    sd:feature conf10gx:geometry-as-wkt-literal ;
-    sd:feature conf10gx:gml-literal ;
-    sd:feature conf10gx:gml-literal-empty ;
-    sd:feature conf10gx:gml-profile ;
-    sd:feature conf10gx:query-functions ;
-    sd:feature conf10gx:srid-function ;
-    sd:feature conf10gx:wkt-axis-order ;
-    sd:feature conf10gx:wkt-literal ;
-    sd:feature conf10gx:wkt-literal-default-srs ;
-    sd:feature conf10gx:wkt-literal-empty ;
-    sd:feature conf10gtx:eh-query-functions ;
-    sd:feature conf10gtx:rcc8-query-functions ;
-    sd:feature conf10gtx:relate-query-function ;
-    sd:feature conf10gtx:sf-query-functions ;
-    sd:feature conf10qre:eh-query-rewrite ;
-    sd:feature conf10qre:rcc8-query-rewrite ;
-    sd:feature conf10qre:sf-query-rewrite .
+.

--- a/1.0/servicedescription_conformanceclasses.ttl
+++ b/1.0/servicedescription_conformanceclasses.ttl
@@ -1,6 +1,7 @@
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix ent: <http://www.w3.org/ns/entailment/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix prof: <http://www.w3.org/ns/owl-profile/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix conf10core: <http://www.opengis.net/spec/geosparql/1.0/conf/core/> .
@@ -17,8 +18,11 @@
 @prefix conf11tve: <http://www.opengis.net/spec/geosparql/1.1/conf/topology-vocab-extension/> .
 @prefix void: <http://rdfs.org/ns/void#> .
 
-<http://www.opengis.net/def/geosparql/servicedescconformanceclasses> a sd:Service, skos:ConceptScheme ;
+<http://www.opengis.net/def/geosparql/servicedescconformanceclasses> 
+    a sd:Service, skos:ConceptScheme ;
     skos:prefLabel "GeoSPARQL 1.0 SPARQL Service Description: All Conformance Classes" ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescconformanceclasses/1.0> ;   
     sd:supportedLanguage sd:SPARQL11Query ;
     sd:feature conf10core:sparql-protocol ;
     sd:feature conf10core:feature-class ;

--- a/1.0/servicedescription_extensions.ttl
+++ b/1.0/servicedescription_extensions.ttl
@@ -1,19 +1,23 @@
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix ent: <http://www.w3.org/ns/entailment/> .
 @prefix prof: <http://www.w3.org/ns/owl-profile/> .
 @prefix void: <http://rdfs.org/ns/void#> .
 
-<http://www.opengis.net/def/geosparql/servicedescextensions> a sd:Service, skos:ConceptScheme ;
+<http://www.opengis.net/def/geosparql/servicedescextensions> 
+	a sd:Service, skos:ConceptScheme ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescextensions/1.0> ;   	
     sd:supportedLanguage sd:SPARQL11Query ;
     skos:prefLabel "GeoSPARQL 1.0 SPARQL Service Description: All Extensions" ;
-	  sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-topology-extension/> ;
-	  sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/query-rewrite-extension/> ;
-	  sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/rdfs-entailment-extension/> ;
-	  sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/topology-vocab-extension/> ;
-	  sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-extension/> ;
-	  sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/core/> ;
+	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-topology-extension/> ;
+	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/query-rewrite-extension/> ;
+	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/rdfs-entailment-extension/> ;
+	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/topology-vocab-extension/> ;
+	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-extension/> ;
+	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/core/> ;
     sd:resultFormat <http://www.w3.org/ns/formats/RDF_XML>, <http://www.w3.org/ns/formats/Turtle> ;
     sd:defaultEntailmentRegime ent:RDFS
 .

--- a/1.0/servicedescription_extensions.ttl
+++ b/1.0/servicedescription_extensions.ttl
@@ -1,23 +1,25 @@
-@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
-@prefix geo: <http://www.opengis.net/ont/geosparql#> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix ent: <http://www.w3.org/ns/entailment/> .
-@prefix prof: <http://www.w3.org/ns/owl-profile/> .
-@prefix void: <http://rdfs.org/ns/void#> .
+PREFIX ent: <http://www.w3.org/ns/entailment/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-<http://www.opengis.net/def/geosparql/servicedescextensions> 
-	a sd:Service, skos:ConceptScheme ;
+<http://www.opengis.net/def/geosparql/servicedescextensions>
+    a
+        skos:ConceptScheme ,
+        sd:Service ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescextensions/1.0> ;
     owl:versionInfo "OGC GeoSPARQL 1.0" ;
-    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescextensions/1.0> ;   	
-    sd:supportedLanguage sd:SPARQL11Query ;
     skos:prefLabel "GeoSPARQL 1.0 SPARQL Service Description: All Extensions" ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-topology-extension/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/query-rewrite-extension/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/rdfs-entailment-extension/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/topology-vocab-extension/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-extension/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.0/conf/core/> ;
-    sd:resultFormat <http://www.w3.org/ns/formats/RDF_XML>, <http://www.w3.org/ns/formats/Turtle> ;
-    sd:defaultEntailmentRegime ent:RDFS
+    sd:defaultEntailmentRegime ent:RDFS ;
+    sd:feature
+        <http://www.opengis.net/spec/geosparql/1.0/conf/core/> ,
+        <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-extension/> ,
+        <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-topology-extension/> ,
+        <http://www.opengis.net/spec/geosparql/1.0/conf/query-rewrite-extension/> ,
+        <http://www.opengis.net/spec/geosparql/1.0/conf/rdfs-entailment-extension/> ,
+        <http://www.opengis.net/spec/geosparql/1.0/conf/topology-vocab-extension/> ;
+    sd:resultFormat
+        <http://www.w3.org/ns/formats/RDF_XML> ,
+        <http://www.w3.org/ns/formats/Turtle> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
 .

--- a/1.0/sf_geometries.ttl
+++ b/1.0/sf_geometries.ttl
@@ -1,21 +1,13 @@
-@prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix geo: <http://www.opengis.net/ont/geosparql#> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix sf: <http://www.opengis.net/ont/sf#> .
-@prefix xsd:<http://www.w3.org/2001/XMLSchema#> .
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sf: <http://www.opengis.net/ont/sf#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<http://www.opengis.net/ont/sf> a owl:Ontology ;
-    owl:imports <http://www.opengis.net/ont/geosparql> ;
-    dc:title "Simple Features Vocabulary" ;
-	dc:creator "Open Geospatial Consortium" ;
-	dc:date "2012-09-11"^^xsd:date ;
-	dc:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types" ;
-	owl:versionInfo "OGC GeoSPARQL 1.0" ;
-    owl:versionIRI <http://www.opengis.net/ont/sf/1.0> ;
-.
-
-sf:Curve a rdfs:Class,
+sf:Curve
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Curve"@en ;
     rdfs:comment """A Curve is a 1-dimensional geometric object usually stored as a sequence of Points, with the subtype of Curve specifying the form of the interpolation between Points. This specification defines only one subclass of Curve, LineString, which uses linear interpolation between Points.
@@ -35,9 +27,12 @@ The boundary of a non-closed Curve consists of its two end Points.
 
 A Curve is defined as topologically closed, that is, it contains its endpoints f(a) and f(b)."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Geometry .
+    rdfs:subClassOf sf:Geometry ;
+.
 
-sf:Geometry a rdfs:Class,
+sf:Geometry
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Geometry"@en ;
     rdfs:comment """Geometry is the root class of the hierarchy.
@@ -48,9 +43,12 @@ The interpretation of the coordinates is subject to the coordinate reference sys
 
 All Geometry classes described in this specification are defined so that instances of Geometry are topologically closed, i.e. all represented geometries include their boundary as point sets. This does not affect their representation, and open version of the same classes may be used in other circumstances, such as topological representations."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf geo:Geometry .
+    rdfs:subClassOf geo:Geometry ;
+.
 
-sf:GeometryCollection a rdfs:Class,
+sf:GeometryCollection
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Geometry Collection"@en ;
     rdfs:comment """A GeometryCollection is a geometric object that is a collection of some number of geometric objects.
@@ -58,30 +56,42 @@ sf:GeometryCollection a rdfs:Class,
 All the elements in a GeometryCollection shall be in the same Spatial Reference System. This is also the Spatial Reference System for the GeometryCollection.
 GeometryCollection places no other constraints on its elements. Subclasses of GeometryCollection may restrict membership based on dimension and may also place other constraints on the degree of spatial overlap between elements."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Geometry .
+    rdfs:subClassOf sf:Geometry ;
+.
 
-sf:Line a rdfs:Class,
+sf:Line
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Line"@en ;
-    rdfs:comment """A Line is a LineString with exactly 2 Points."""@en ;
+    rdfs:comment "A Line is a LineString with exactly 2 Points."@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:LineString .
+    rdfs:subClassOf sf:LineString ;
+.
 
-sf:LineString a rdfs:Class,
+sf:LineString
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Line String"@en ;
-    rdfs:comment """A LineString is a Curve with linear interpolation between Points. Each consecutive pair of Points defines a Line segment."""@en ;
+    rdfs:comment "A LineString is a Curve with linear interpolation between Points. Each consecutive pair of Points defines a Line segment."@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Curve .
+    rdfs:subClassOf sf:Curve ;
+.
 
-sf:LinearRing a rdfs:Class,
+sf:LinearRing
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Linear Ring"@en ;
-    rdfs:comment """A LinearRing is a LineString that is both closed and simple."""@en ;
+    rdfs:comment "A LinearRing is a LineString that is both closed and simple."@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:LineString .
+    rdfs:subClassOf sf:LineString ;
+.
 
-sf:MultiCurve a rdfs:Class,
+sf:MultiCurve
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Multi Curve"@en ;
     rdfs:comment """A MultiCurve is a 1-dimensional GeometryCollection whose elements are Curves.
@@ -96,16 +106,22 @@ A MultiCurve is closed if all of its elements are closed. The boundary of a clos
 
 A MultiCurve is defined as topologically closed."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:GeometryCollection .
+    rdfs:subClassOf sf:GeometryCollection ;
+.
 
-sf:MultiLineString a rdfs:Class,
+sf:MultiLineString
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Multi Line String"@en ;
-    rdfs:comment """A MultiLineString is a MultiCurve whose elements are LineStrings."""@en ;
+    rdfs:comment "A MultiLineString is a MultiCurve whose elements are LineStrings."@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:MultiCurve .
+    rdfs:subClassOf sf:MultiCurve ;
+.
 
-sf:MultiPoint a rdfs:Class,
+sf:MultiPoint
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Multi Point"@en ;
     rdfs:comment """A MultiPoint is a 0-dimensional GeometryCollection. The elements of a MultiPoint are restricted to Points. ThePoints are not connected or ordered in any semantically important way.
@@ -116,9 +132,12 @@ Every MultiPoint is spatially equal to a simple Multipoint.
 
 The boundary of a MultiPoint is the empty set."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:GeometryCollection .
+    rdfs:subClassOf sf:GeometryCollection ;
+.
 
-sf:MultiPolygon a rdfs:Class,
+sf:MultiPolygon
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Multi Polygon"@en ;
     rdfs:comment """A MultiPolygon is a MultiSurface whose elements are Polygons.
@@ -133,27 +152,36 @@ e) The interior of a MultiPolygon with more than 1 Polygon is not connected; the
 
 The boundary of a MultiPolygon is a set of closed Curves (LineStrings) corresponding to the boundaries of its element Polygons. Each Curve in the boundary of the MultiPolygon is in the boundary of exactly 1 element Polygon, and every Curve in the boundary of an element Polygon is in the boundary of the MultiPolygon."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:MultiSurface .
+    rdfs:subClassOf sf:MultiSurface ;
+.
 
-sf:MultiSurface a rdfs:Class,
+sf:MultiSurface
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Multi Surface"@en ;
     rdfs:comment """A MultiSurface is a 2-dimensional GeometryCollection whose elements are Surfaces, all using coordinates from the same coordinate reference system. The geometric interiors of any two Surfaces in a MultiSurface may not intersect in the full coordinate system. The boundaries of any two coplanar elements in a MultiSurface may intersect, at most, at a finite number of Points. If they were to meet along a curve, they could be merged into a single surface.
 
 A MultiSurface may be used to represent heterogeneous surfaces collections of polygons and polyhedral surfaces. It defines a set of methods for its subclasses. The subclass of MultiSurface is MultiPolygon corresponding to a collection of Polygons only. Other collections shall use MultiSurface."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:GeometryCollection .
+    rdfs:subClassOf sf:GeometryCollection ;
+.
 
-sf:Point a rdfs:Class,
+sf:Point
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Point"@en ;
     rdfs:comment """A Point is a 0-dimensional geometric object and represents a single location in coordinate space. 
 A Point has an x-coordinate value, a y-coordinate value. If called for by the associated Spatial Reference System, it may also have coordinate values for z and m.
 The boundary of a Point is the empty set."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Geometry .
+    rdfs:subClassOf sf:Geometry ;
+.
 
-sf:Polygon a rdfs:Class,
+sf:Polygon
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Polygon"@en ;
     rdfs:comment """A Polygon is a planar Surface defined by 1 exterior boundary and 0 or more interior boundaries. Each interior boundary defines a hole in the Polygon.
@@ -167,9 +195,12 @@ d) A Polygon may not have cut lines, spikes or punctures.
 e) The interior of every Polygon is a connected point set;
 f) The exterior of a Polygon with 1 or more holes is not connected. Each hole defines a connected component of the exterior."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Surface .
+    rdfs:subClassOf sf:Surface ;
+.
 
-sf:PolyhedralSurface a rdfs:Class,
+sf:PolyhedralSurface
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Polyhedral Surface"@en ;
     rdfs:comment """A PolyhedralSurface is a contiguous collection of polygons, which share common boundary segments. For each pair of polygons that touch, the common boundary shall be expressible as a finite collection of LineStrings. Each such LineString shall be part of the boundary of at most 2 Polygon patches. 
@@ -178,9 +209,12 @@ For any two polygons that share a common boundary, the top of the polygon shall 
 
 If each such LineString is the boundary of exactly 2 Polygon patches, then the PolyhedralSurface is a simple, closed polyhedron and is topologically isomorphic to the surface of a sphere. By the Jordan Surface Theorem (Jordans Theorem for 2-spheres), such polyhedrons enclose a solid topologically isomorphic to the interior of a sphere; the ball. In this case, the top of the surface will either point inward or outward of the enclosed finite solid. If outward, the surface is the exterior boundary of the enclosed surface. If inward, the surface is the interior of the infinite complement of the enclosed solid. A Ball with some number of voids (holes) inside can thus be presented as one exterior boundary shell, and some number in interior boundary shells."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Surface .
+    rdfs:subClassOf sf:Surface ;
+.
 
-sf:Surface a rdfs:Class,
+sf:Surface
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Surface"@en ;
     rdfs:comment """A Surface is a 2-dimensional geometric object.
@@ -192,18 +226,37 @@ The boundary of a simple Surface is the set of closed Curves corresponding to it
 
 A Polygon is a simple Surface that is planar. A PolyhedralSurface is a simple surface, consisting of some number of Polygon patches or facets. If a PolyhedralSurface is closed, then it bounds a solid. A MultiSurface containing a set of closed PolyhedralSurfaces can be used to represent a Solid object with holes."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Geometry .
+    rdfs:subClassOf sf:Geometry ;
+.
 
-sf:TIN a rdfs:Class,
+sf:TIN
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Triangulated Irregular Network"@en ;
-    rdfs:comment """A TIN (triangulated irregular network) is a PolyhedralSurface consisting only of Triangle patches."""@en ;
+    rdfs:comment "A TIN (triangulated irregular network) is a PolyhedralSurface consisting only of Triangle patches."@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:PolyhedralSurface .
+    rdfs:subClassOf sf:PolyhedralSurface ;
+.
 
-sf:Triangle a rdfs:Class,
+sf:Triangle
+    a
+        rdfs:Class ,
         owl:Class ;
     rdfs:label "Triangle"@en ;
-    rdfs:comment """A Triangle is a polygon with 3 distinct, non-collinear vertices and no interior boundary."""@en ;
+    rdfs:comment "A Triangle is a polygon with 3 distinct, non-collinear vertices and no interior boundary."@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Polygon .
+    rdfs:subClassOf sf:Polygon ;
+.
+
+<http://www.opengis.net/ont/sf>
+    a owl:Ontology ;
+    dc:creator "Open Geospatial Consortium" ;
+    dc:date "2012-09-11"^^xsd:date ;
+    dc:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types" ;
+    dc:title "Simple Features Vocabulary" ;
+    owl:imports <http://www.opengis.net/ont/geosparql> ;
+    owl:versionIRI <http://www.opengis.net/ont/sf/1.0> ;
+    owl:versionInfo "OGC GeoSPARQL 1.0" ;
+.
+

--- a/1.0/sf_geometries.ttl
+++ b/1.0/sf_geometries.ttl
@@ -8,10 +8,12 @@
 <http://www.opengis.net/ont/sf> a owl:Ontology ;
     owl:imports <http://www.opengis.net/ont/geosparql> ;
     dc:title "Simple Features Vocabulary" ;
-	dc:creator "Open Geospatial Consortium"^^xsd:string ;
+	dc:creator "Open Geospatial Consortium" ;
 	dc:date "2012-09-11"^^xsd:date ;
-	dc:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types"^^xsd:string ;
-	owl:versionInfo "OGC GeoSPARQL 1.0.1"^^xsd:string .
+	dc:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types" ;
+	owl:versionInfo "OGC GeoSPARQL 1.0" ;
+    owl:versionIRI <http://www.opengis.net/ont/sf/1.0> ;
+.
 
 sf:Curve a rdfs:Class,
         owl:Class ;

--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -1,365 +1,487 @@
-BASE <http://www.opengis.net/def/geosparql/funcsrules>
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX funcs: <http://www.opengis.net/def/function/geosparql/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX policy: <http://www.opengis.net/def/metamodel/ogc-na/>
-PREFIX sd: <http://www.w3.org/ns/sparql-service-description#> 
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX rules: <http://www.opengis.net/def/rule/geosparql/>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sdo: <https://schema.org/>
-PREFIX spec11: <http://www.opengis.net/spec/geosparql/1.1/specification.html#> # TODO: use PID IRI
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX spec11: <http://www.opengis.net/spec/geosparql/1.1/specification.html#>
 PREFIX status: <http://www.opengis.net/def/status/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-
-<http://www.opengis.net/def/geosparql/funcsrules> 
-    a owl:Ontology , skos:ConceptScheme ;
-    dcterms:modified "2021-06-16"^^xsd:date ;
+funcs:
+    a skos:Collection ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    owl:imports <http://www.opengis.net/def/ogc-na> ;
-    owl:versionInfo "OGC GeosPARQL 1.1" ;
-    owl:versionIRI <http://www.opengis.net/def/geosparql/funcsrules/1.1> ;
-    skos:definition "A vocabulary (taxonomy) of the functions and rules defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:definition "All the GeoSPARQL Functions defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:member
+        funcs:area ,
+        funcs:asDGGS ,
+        funcs:asGML ,
+        funcs:asGeoJSON ,
+        funcs:asKML ,
+        funcs:asWKT ,
+        funcs:boundary ,
+        funcs:boundingCircle ,
+        funcs:buffer ,
+        funcs:concaveHull ,
+        funcs:convexHull ,
+        funcs:difference ,
+        funcs:dimension ,
+        funcs:distance ,
+        funcs:ehContains ,
+        funcs:ehCoveredBy ,
+        funcs:ehCovers ,
+        funcs:ehDisjoint ,
+        funcs:ehEquals ,
+        funcs:ehInside ,
+        funcs:ehMeet ,
+        funcs:ehOverlap ,
+        funcs:envelope ,
+        funcs:getSRID ,
+        funcs:intersection ,
+        funcs:isEmpty ,
+        funcs:isSimple ,
+        funcs:maxx ,
+        funcs:maxy ,
+        funcs:maxz ,
+        funcs:metricBuffer ,
+        funcs:metricDistance ,
+        funcs:minx ,
+        funcs:miny ,
+        funcs:minz ,
+        funcs:rcc8dc ,
+        funcs:rcc8ec ,
+        funcs:rcc8eq ,
+        funcs:rcc8ntpp ,
+        funcs:rcc8ntppi ,
+        funcs:rcc8po ,
+        funcs:rcc8tpp ,
+        funcs:rcc8tppi ,
+        funcs:relate ,
+        funcs:sfContains ,
+        funcs:sfCrosses ,
+        funcs:sfDisjoint ,
+        funcs:sfEquals ,
+        funcs:sfIntersects ,
+        funcs:sfOverlaps ,
+        funcs:sfTouches ,
+        funcs:sfWithin ,
+        funcs:symDifference ,
+        funcs:union ;
+    skos:prefLabel "GeoSPARQL Functions"@en ;
+.
+
+funcs:aggboundingBox
+    a sd:Aggregate ;
+    dcterms:date "2021-02-25"^^xsd:date ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A spatial aggregate function that calculates the minimum bounding box of set of geometries."@en ;
+    skos:prefLabel "bounding box"@en ;
+.
+
+funcs:aggboundingCircle
+    a sd:Aggregate ;
+    dcterms:date "2021-02-25"^^xsd:date ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A spatial aggregate function that calculates the minimum bounding circle of set of geometries."@en ;
+    skos:prefLabel "bounding circle"@en ;
+.
+
+funcs:centroid
+    a sd:Function ;
+    dcterms:date "2021-02-25"^^xsd:date ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A spatial aggregate function that calculates a centroid of a set of geometries."@en ;
+    skos:prefLabel "centroid"@en ;
+.
+
+funcs:common
+    a skos:Collection ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "All the GeoSPARQL Common Query Functions defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:member funcs:relate ;
+    skos:prefLabel "GeoSPARQL Common Query Functions"@en ;
+.
+
+funcs:eh
+    a skos:Collection ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "All the GeoSPARQL Egenhofer Topological Functions defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:member
+        funcs:ehContains ,
+        funcs:ehCoveredBy ,
+        funcs:ehCovers ,
+        funcs:ehDisjoint ,
+        funcs:ehEquals ,
+        funcs:ehInside ,
+        funcs:ehMeet ,
+        funcs:ehOverlap ;
+    skos:prefLabel "GeoSPARQL Egenhofer Topological Functions" ;
+.
+
+funcs:nonTopo
+    a skos:Collection ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "All the GeoSPARQL Non-topological Query Functions defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:member
+        funcs:area ,
+        funcs:boundary ,
+        funcs:boundingCircle ,
+        funcs:buffer ,
+        funcs:convexHull ,
+        funcs:difference ,
+        funcs:dimension ,
+        funcs:distance ,
+        funcs:envelope ,
+        funcs:geometryN ,
+        funcs:getSRID ,
+        funcs:intersection ,
+        funcs:isEmpty ,
+        funcs:isSimple ,
+        funcs:length ,
+        funcs:maxx ,
+        funcs:maxy ,
+        funcs:maxz ,
+        funcs:metricBuffer ,
+        funcs:minx ,
+        funcs:miny ,
+        funcs:minz ,
+        funcs:numGeometries ,
+        funcs:symDifference ,
+        funcs:union ;
+    skos:prefLabel "GeoSPARQL Non-topological Query Functions"@en ;
+.
+
+funcs:rcc
+    a skos:Collection ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "All the GeoSPARQL RCC8 Topological Functions defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:member
+        funcs:rcc8dc ,
+        funcs:rcc8ec ,
+        funcs:rcc8eq ,
+        funcs:rcc8ntpp ,
+        funcs:rcc8ntppi ,
+        funcs:rcc8po ,
+        funcs:rcc8tpp ,
+        funcs:rcc8tppi ;
+    skos:prefLabel "GeoSPARQL RCC8 Topological Functions"@en ;
+.
+
+funcs:sa
+    a skos:Collection ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:member
+        funcs:aggBoundingBox ,
+        funcs:aggBoundingCircle ,
+        funcs:aggCentroid ,
+        funcs:aggConcaveHull ,
+        funcs:aggUnion ;
+    skos:prefLabel "GeoSPARQL Spatial Aggregate Functions"@en ;
+.
+
+funcs:sf
+    a skos:Collection ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "All the GeoSPARQL Simple Features Topological Functions defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:member
+        funcs:sfContains ,
+        funcs:sfCrosses ,
+        funcs:sfDisjoint ,
+        funcs:sfEquals ,
+        funcs:sfIntersects ,
+        funcs:sfOverlaps ,
+        funcs:sfTouches ,
+        funcs:sfWithin ;
+    skos:prefLabel "GeoSPARQL Simple Features Functions"@en ;
+.
+
+<http://www.opengis.net/def/geosparql/funcsrules>
+    a
+        owl:Ontology ,
+        skos:ConceptScheme ;
     dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
     dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
-	dcterms:publisher [
-		a sdo:Organization ;
-		sdo:name "Open Geospatial Consortium" ;
-		sdo:url "https://www.ogc.org"^^xsd:anyURI ;
-	] ;    
-	dcterms:rights "(c) 2022 Open Geospatial Consortium" ;    
+    dcterms:modified "2021-06-16"^^xsd:date ;
+    dcterms:publisher [
+            a sdo:Organization ;
+            sdo:name "Open Geospatial Consortium" ;
+            sdo:url "https://www.ogc.org"^^xsd:anyURI
+        ] ;
+    dcterms:rights "(c) 2022 Open Geospatial Consortium" ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    owl:imports <http://www.opengis.net/def/ogc-na> ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/funcsrules/1.1> ;
+    owl:versionInfo "OGC GeosPARQL 1.1" ;
+    skos:definition "A vocabulary (taxonomy) of the functions and rules defined within the GeoSPARQL 1.1 specification"@en ;
     skos:hasTopConcept
-        funcs:area,
-		funcs:asDGGS,
-		funcs:asKML,
-		funcs:asGeoJSON,
-		funcs:asGML,
-		funcs:asWKT,
-        funcs:boundary,
-	funcs:boundingCircle,
-        funcs:buffer,
-        funcs:convexHull,
-        funcs:difference,
-        funcs:dimension,
-        funcs:distance,
-        funcs:ehContains,
-        funcs:ehCoveredBy,
-        funcs:ehCovers,
-        funcs:ehDisjoint,
-        funcs:ehEquals,
-        funcs:ehInside,
-        funcs:ehMeet,
-        funcs:ehOverlap,
-        funcs:envelope,
-        funcs:getSRID,
-        funcs:geometryN,
-        funcs:intersection,
-        funcs:isEmpty,
-        funcs:isSimple,
-        funcs:minx,
-        funcs:miny,
-        funcs:minz,
-        funcs:maxx,
-        funcs:maxy,
-        funcs:maxz,
-        funcs:numGeometries,
-        funcs:transform,
-        funcs:rcc8dc,
-        funcs:rcc8ec,
-        funcs:rcc8eq,
-        funcs:rcc8ntpp,
-        funcs:rcc8ntppi,
-        funcs:rcc8po,
-        funcs:rcc8tpp,
-        funcs:rcc8tppi,
-        funcs:relate,
-        funcs:sfContains,
-        funcs:sfCrosses,
-        funcs:sfDisjoint,
-        funcs:sfEquals,
-        funcs:sfIntersects,
-        funcs:sfOverlaps,
-        funcs:sfTouches,
-        funcs:sfWithin,
-        funcs:symDifference,
-        funcs:union,
-        rules:ehContains,
-        rules:ehCoveredBy,
-        rules:ehCovers,
-        rules:ehDisjoint,
-        rules:ehEquals,
-        rules:ehInside,
-        rules:ehMeet,
-        rules:ehOverlap,
-        rules:rcc8dc,
-        rules:rcc8ec,
-        rules:rcc8eq,
-        rules:rcc8ntpp,
-        rules:rcc8ntppi,
-        rules:rcc8po,
-        rules:rcc8tpp,
-        rules:rcc8tppi,
-        rules:sfContains,
-        rules:sfCrosses,
-        rules:sfDisjoint,
-        rules:sfEquals,
-        rules:sfIntersects,
-        rules:sfOverlaps,
-        rules:sfTouches,
+        funcs:area ,
+        funcs:asDGGS ,
+        funcs:asGML ,
+        funcs:asGeoJSON ,
+        funcs:asKML ,
+        funcs:asWKT ,
+        funcs:boundary ,
+        funcs:boundingCircle ,
+        funcs:buffer ,
+        funcs:convexHull ,
+        funcs:difference ,
+        funcs:dimension ,
+        funcs:distance ,
+        funcs:ehContains ,
+        funcs:ehCoveredBy ,
+        funcs:ehCovers ,
+        funcs:ehDisjoint ,
+        funcs:ehEquals ,
+        funcs:ehInside ,
+        funcs:ehMeet ,
+        funcs:ehOverlap ,
+        funcs:envelope ,
+        funcs:geometryN ,
+        funcs:getSRID ,
+        funcs:intersection ,
+        funcs:isEmpty ,
+        funcs:isSimple ,
+        funcs:maxx ,
+        funcs:maxy ,
+        funcs:maxz ,
+        funcs:minx ,
+        funcs:miny ,
+        funcs:minz ,
+        funcs:numGeometries ,
+        funcs:rcc8dc ,
+        funcs:rcc8ec ,
+        funcs:rcc8eq ,
+        funcs:rcc8ntpp ,
+        funcs:rcc8ntppi ,
+        funcs:rcc8po ,
+        funcs:rcc8tpp ,
+        funcs:rcc8tppi ,
+        funcs:relate ,
+        funcs:sfContains ,
+        funcs:sfCrosses ,
+        funcs:sfDisjoint ,
+        funcs:sfEquals ,
+        funcs:sfIntersects ,
+        funcs:sfOverlaps ,
+        funcs:sfTouches ,
+        funcs:sfWithin ,
+        funcs:symDifference ,
+        funcs:transform ,
+        funcs:union ,
+        rules:ehContains ,
+        rules:ehCoveredBy ,
+        rules:ehCovers ,
+        rules:ehDisjoint ,
+        rules:ehEquals ,
+        rules:ehInside ,
+        rules:ehMeet ,
+        rules:ehOverlap ,
+        rules:rcc8dc ,
+        rules:rcc8ec ,
+        rules:rcc8eq ,
+        rules:rcc8ntpp ,
+        rules:rcc8ntppi ,
+        rules:rcc8po ,
+        rules:rcc8tpp ,
+        rules:rcc8tppi ,
+        rules:sfContains ,
+        rules:sfCrosses ,
+        rules:sfDisjoint ,
+        rules:sfEquals ,
+        rules:sfIntersects ,
+        rules:sfOverlaps ,
+        rules:sfTouches ,
         rules:sfWithin ;
-    skos:prefLabel "GeoSPARQL Functions and Rules Register"@en .
+    skos:prefLabel "GeoSPARQL Functions and Rules Register"@en ;
+.
 
-funcs: a skos:Collection ;
+rules:
+    a skos:Collection ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL Functions defined within the GeoSPARQL 1.1 specification"""@en ;
-    skos:member 
-        funcs:area,
-		funcs:asDGGS,
-		funcs:asKML,
-		funcs:asGeoJSON,
-		funcs:asGML,
-		funcs:asWKT,
-        funcs:boundary,
-        funcs:boundingCircle,
-        funcs:metricBuffer,
-        funcs:buffer,
-        funcs:concaveHull,
-        funcs:convexHull,
-        funcs:difference,
-        funcs:dimension,
-        funcs:metricDistance,
-        funcs:distance,
-        funcs:ehContains,
-        funcs:ehCoveredBy,
-        funcs:ehCovers,
-        funcs:ehDisjoint,
-        funcs:ehEquals,
-        funcs:ehInside,
-        funcs:ehMeet,
-        funcs:ehOverlap,
-        funcs:envelope,
-        funcs:getSRID,
-        funcs:isEmpty,
-        funcs:isSimple,
-        funcs:minx,
-        funcs:miny,
-        funcs:minz,
-        funcs:maxx,
-        funcs:maxy,
-        funcs:maxz,
-        funcs:intersection,
-        funcs:rcc8dc,
-        funcs:rcc8ec,
-        funcs:rcc8eq,
-        funcs:rcc8ntpp,
-        funcs:rcc8ntppi,
-        funcs:rcc8po,
-        funcs:rcc8tpp,
-        funcs:rcc8tppi,
-        funcs:relate,
-        funcs:sfContains,
-        funcs:sfCrosses,
-        funcs:sfDisjoint,
-        funcs:sfEquals,
-        funcs:sfIntersects,
-        funcs:sfOverlaps,
-        funcs:sfTouches,
-        funcs:sfWithin,
-        funcs:symDifference,
-        funcs:union ;
-    skos:prefLabel "GeoSPARQL Functions"@en .
-
-funcs:eh a skos:Collection ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL Egenhofer Topological Functions defined within the GeoSPARQL 1.1 specification"""@en ;
-    skos:member 
-        funcs:ehContains,
-        funcs:ehCoveredBy,
-        funcs:ehCovers,
-        funcs:ehDisjoint,
-        funcs:ehEquals,
-        funcs:ehInside,
-        funcs:ehMeet,
-        funcs:ehOverlap ;
-    skos:prefLabel "GeoSPARQL Egenhofer Topological Functions" .
-
-funcs:rcc a skos:Collection ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL RCC8 Topological Functions defined within the GeoSPARQL 1.1 specification"""@en ;
-    skos:member 
-        funcs:rcc8dc,
-        funcs:rcc8ec,
-        funcs:rcc8eq,
-        funcs:rcc8ntpp,
-        funcs:rcc8ntppi,
-        funcs:rcc8po,
-        funcs:rcc8tpp,
-        funcs:rcc8tppi ;
-    skos:prefLabel "GeoSPARQL RCC8 Topological Functions"@en .
-
-funcs:sf a skos:Collection ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL Simple Features Topological Functions defined within the GeoSPARQL 1.1 specification"""@en ;
-    skos:member 
-        funcs:sfContains,
-        funcs:sfCrosses,
-        funcs:sfDisjoint,
-        funcs:sfEquals,
-        funcs:sfIntersects,
-        funcs:sfOverlaps,
-        funcs:sfTouches,
-        funcs:sfWithin ;
-    skos:prefLabel "GeoSPARQL Simple Features Functions"@en .
-
-funcs:nonTopo a skos:Collection ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL Non-topological Query Functions defined within the GeoSPARQL 1.1 specification"""@en ;
+    skos:definition "All the GeoSPARQL Rules defined within the GeoSPARQL 1.1 specification"@en ;
     skos:member
-        funcs:area,
-        funcs:boundary,
-	funcs:boundingCircle,
-        funcs:buffer,
-	funcs:metricBuffer,
-        funcs:convexHull,
-        funcs:difference,
-        funcs:dimension,
-        funcs:distance,
-        funcs:envelope,
-        funcs:geometryN,
-        funcs:getSRID,
-        funcs:isEmpty,
-        funcs:isSimple,
-        funcs:length,
-        funcs:minx,
-        funcs:miny,
-        funcs:minz,
-        funcs:maxx,
-        funcs:maxy,
-        funcs:maxz,
-        funcs:numGeometries,
-        funcs:intersection,
-        funcs:symDifference,
-        funcs:union ;
-    skos:prefLabel "GeoSPARQL Non-topological Query Functions"@en .
-
-funcs:common a skos:Collection ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL Common Query Functions defined within the GeoSPARQL 1.1 specification"""@en ;
-    skos:member 
-        funcs:relate ;
-    skos:prefLabel "GeoSPARQL Common Query Functions"@en .    
-
-funcs:sa a skos:Collection ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:member
-        funcs:aggBoundingCircle,
-	funcs:aggBoundingBox,
-        funcs:aggCentroid,
-        funcs:aggConcaveHull,
-        funcs:aggUnion;
-    skos:prefLabel "GeoSPARQL Spatial Aggregate Functions"@en .
-
-rules: a skos:Collection ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL Rules defined within the GeoSPARQL 1.1 specification"""@en ;
-    skos:member rules:ehContains,
-        rules:ehCoveredBy,
-        rules:ehCovers,
-        rules:ehDisjoint,
-        rules:ehEquals,
-        rules:ehInside,
-        rules:ehMeet,
-        rules:ehOverlap,
-        rules:rcc8dc,
-        rules:rcc8ec,
-        rules:rcc8eq,
-        rules:rcc8ntpp,
-        rules:rcc8ntppi,
-        rules:rcc8po,
-        rules:rcc8tpp,
-        rules:rcc8tppi,
-        rules:sfContains,
-        rules:sfCrosses,
-        rules:sfDisjoint,
-        rules:sfEquals,
-        rules:sfIntersects,
-        rules:sfOverlaps,
-        rules:sfTouches,
+        rules:ehContains ,
+        rules:ehCoveredBy ,
+        rules:ehCovers ,
+        rules:ehDisjoint ,
+        rules:ehEquals ,
+        rules:ehInside ,
+        rules:ehMeet ,
+        rules:ehOverlap ,
+        rules:rcc8dc ,
+        rules:rcc8ec ,
+        rules:rcc8eq ,
+        rules:rcc8ntpp ,
+        rules:rcc8ntppi ,
+        rules:rcc8po ,
+        rules:rcc8tpp ,
+        rules:rcc8tppi ,
+        rules:sfContains ,
+        rules:sfCrosses ,
+        rules:sfDisjoint ,
+        rules:sfEquals ,
+        rules:sfIntersects ,
+        rules:sfOverlaps ,
+        rules:sfTouches ,
         rules:sfWithin ;
-    skos:prefLabel "GeoSPARQL Rules"@en .
+    skos:prefLabel "GeoSPARQL Rules"@en ;
+.
 
-rules:eh a skos:Collection ;
+rules:eh
+    a skos:Collection ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL Egenhofer Rules defined within the GeoSPARQL 1.1 specification"""@en ;
-    skos:member 
-        rules:ehContains,
-        rules:ehCoveredBy,
-        rules:ehCovers,
-        rules:ehDisjoint,
-        rules:ehEquals,
-        rules:ehInside,
-        rules:ehMeet,
+    skos:definition "All the GeoSPARQL Egenhofer Rules defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:member
+        rules:ehContains ,
+        rules:ehCoveredBy ,
+        rules:ehCovers ,
+        rules:ehDisjoint ,
+        rules:ehEquals ,
+        rules:ehInside ,
+        rules:ehMeet ,
         rules:ehOverlap ;
-    skos:prefLabel "GeoSPARQL Egenhofer Topological Rules"@en .
+    skos:prefLabel "GeoSPARQL Egenhofer Topological Rules"@en ;
+.
 
-rules:rcc a skos:Collection ;
+rules:rcc
+    a skos:Collection ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL RCC8 Rules defined within the GeoSPARQL 1.1 specification"""@en ;
-    skos:member 
-        rules:rcc8dc,
-        rules:rcc8ec,
-        rules:rcc8eq,
-        rules:rcc8ntpp,
-        rules:rcc8ntppi,
-        rules:rcc8po,
-        rules:rcc8tpp,
+    skos:definition "All the GeoSPARQL RCC8 Rules defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:member
+        rules:rcc8dc ,
+        rules:rcc8ec ,
+        rules:rcc8eq ,
+        rules:rcc8ntpp ,
+        rules:rcc8ntppi ,
+        rules:rcc8po ,
+        rules:rcc8tpp ,
         rules:rcc8tppi ;
-    skos:prefLabel "GeoSPARQL RCC8 Topological Rules"@en .
+    skos:prefLabel "GeoSPARQL RCC8 Topological Rules"@en ;
+.
 
-rules:sf a skos:Collection ;
+rules:sf
+    a skos:Collection ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """All the GeoSPARQL Simple Features Topological Rules defined within the GeoSPARQL 1.1 specification"""@en ;
-    skos:member 
-        rules:sfContains,
-        rules:sfCrosses,
-        rules:sfDisjoint,
-        rules:sfEquals,
-        rules:sfIntersects,
-        rules:sfOverlaps,
-        rules:sfTouches,
+    skos:definition "All the GeoSPARQL Simple Features Topological Rules defined within the GeoSPARQL 1.1 specification"@en ;
+    skos:member
+        rules:sfContains ,
+        rules:sfCrosses ,
+        rules:sfDisjoint ,
+        rules:sfEquals ,
+        rules:sfIntersects ,
+        rules:sfOverlaps ,
+        rules:sfTouches ,
         rules:sfWithin ;
-    skos:prefLabel "GeoSPARQL Simple Features Rules"@en .
+    skos:prefLabel "GeoSPARQL Simple Features Rules"@en ;
+.
 
-funcs:area a sd:Function ;
+funcs:aggConcaveHull
+    a sd:Aggregate ;
+    dcterms:date "2021-02-25"^^xsd:date ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A spatial aggregate function that calculates the concave hull of a set of geometries."@en ;
+    skos:prefLabel "concave hull"@en ;
+.
+
+funcs:aggUnion
+    a sd:Aggregate ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A spatial aggregate function that calculates the union of a set of geometries."@en ;
+    skos:prefLabel "aggregate union"@en ;
+.
+
+funcs:concaveHull
+    a sd:Function ;
+    dcterms:date "2021-02-25"^^xsd:date ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that calculates the concave hull of a set of geometries."@en ;
+    skos:prefLabel "concave hull"@en ;
+.
+
+funcs:length
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "Returns the area of a geometry in squaremeters."@en ;
-    skos:prefLabel "area"@en .
+    skos:definition "Returns the length of a geometry in meters."@en ;
+    skos:prefLabel "length"@en ;
+.
 
-funcs:asDGGS a sd:Function ;
+funcs:metricDistance
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the distance in meters between the two closest points of the input geometries."@en ;
+    skos:prefLabel "metric distance"@en ;
+.
+
+funcs:transform
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that converts a given geometry to a spatial reference system defined by an IRI. The function raises an error if a transformation is not mathematically possible."@en ;
+    skos:prefLabel "transform"@en ;
+.
+
+funcs:asDGGS
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-dggs-function> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "Converts a given geometry to an equivalent DGGS representation, formulated according to the specific DGGS literal indicated using the specificDggsDatatype parameter."@en ;
-    skos:prefLabel "asDGGS"@en .
-	
-funcs:asGeoJSON a sd:Function ;
+    skos:prefLabel "asDGGS"@en ;
+.
+
+funcs:asGML
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-gml-function> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "Converts a given geometry to an equivalent GML representation defined by a gmlProfile version string preserving the coordinate reference system."@en ;
+    skos:prefLabel "asGML"@en ;
+.
+
+funcs:asGeoJSON
+    a sd:Function ;
     dcterms:contributor "Timo Homburg" ;
     dcterms:creator "OGC GeoSPARQL 2.0 Standard Working Group" ;
     dcterms:date "2021-05-20"^^xsd:date ;
@@ -368,744 +490,819 @@ funcs:asGeoJSON a sd:Function ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-geojson-function> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "Converts a given geometry to an equivalent GeoJSON representation. Coordinates are converted to the CRS84 coordinate system, the only valid coordinate system to be used in a GeoJSON literal."@en ;
-    skos:prefLabel "asGeoJSON"@en .
-		
-funcs:asGML a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-gml-function> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "Converts a given geometry to an equivalent GML representation defined by a gmlProfile version string preserving the coordinate reference system."@en ;
-    skos:prefLabel "asGML"@en .
-	
-funcs:asKML a sd:Function ;
+    skos:prefLabel "asGeoJSON"@en ;
+.
+
+funcs:asKML
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-kml-function> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "Converts a given geometry to an equivalent KML representation. Coordinates are converted to the CRS84 coordinate system, the only valid coordinate system to be used in a KML literal."@en ;
-    skos:prefLabel "asKML"@en .
-	
-funcs:asWKT a sd:Function ;
+    skos:prefLabel "asKML"@en ;
+.
+
+funcs:asWKT
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/geometry-as-wkt-function> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "Converts a given geometry to an equivalent WKT representation preserving the coordinate reference system and geometry type, if possible."@en ;
-    skos:prefLabel "asWKT"@en .
+    skos:prefLabel "asWKT"@en ;
+.
 
-funcs:boundary a sd:Function ;
+funcs:geometryN
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the boundary of the input geometry."@en ;
-    skos:prefLabel "boundary"@en .
+    skos:definition "A query function that returns the the nth geometry if the given geometry literal contains a GeometryCollection."@en ;
+    skos:prefLabel "geometryN"@en ;
+.
 
-funcs:boundingCircle a sd:Function ;
-    dcterms:date "2021-02-25"^^xsd:date ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that calculates the minimum bounding circle of set of geometries."@en ;
-    skos:prefLabel "bounding circle"@en .
-
-funcs:aggboundingBox a sd:Aggregate ;
-    dcterms:date "2021-02-25"^^xsd:date ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A spatial aggregate function that calculates the minimum bounding box of set of geometries."@en ;
-    skos:prefLabel "bounding box"@en .
-
-funcs:aggboundingCircle a sd:Aggregate ;
-    dcterms:date "2021-02-25"^^xsd:date ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A spatial aggregate function that calculates the minimum bounding circle of set of geometries."@en ;
-    skos:prefLabel "bounding circle"@en .
-
-funcs:metricBuffer a sd:Function ;
+funcs:metricBuffer
+    a sd:Function ;
     dcterms:date "2022-04-20"^^xsd:date ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query function that returns a buffer around the input geometry, using a distance in meters."@en ;
-    skos:prefLabel "metric buffer"@en .
+    skos:prefLabel "metric buffer"@en ;
+.
 
-funcs:buffer a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns a buffer around the input geometry."@en ;
-    skos:prefLabel "buffer"@en .
-
-funcs:centroid a sd:Function ;
-    dcterms:date "2021-02-25"^^xsd:date ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A spatial aggregate function that calculates a centroid of a set of geometries."@en ;
-    skos:prefLabel "centroid"@en .
-
-funcs:concaveHull a sd:Function ;
-    dcterms:date "2021-02-25"^^xsd:date ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that calculates the concave hull of a set of geometries."@en ;
-    skos:prefLabel "concave hull"@en .
-
-funcs:aggConcaveHull a sd:Aggregate ;
-    dcterms:date "2021-02-25"^^xsd:date ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A spatial aggregate function that calculates the concave hull of a set of geometries."@en ;
-    skos:prefLabel "concave hull"@en .
-
-funcs:convexHull a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the convex hull of the input geometry."@en ;
-    skos:prefLabel "convex hull"@en .
-
-funcs:difference a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns a geometry consisting of all points that are part of the first geometry but not the second geometry."@en ;
-    skos:prefLabel "difference"@en .
-
-funcs:metricDistance a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the distance in meters between the two closest points of the input geometries."@en ;
-    skos:prefLabel "metric distance"@en .
-
-funcs:distance a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the distance between the two closest points of the input geometries."@en ;
-    skos:prefLabel "distance"@en ;
-    skos:example spec11:B.2.2.4 .
-
-funcs:ehContains a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions>  ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument. 
-      
-DE-9IM: T*TFF*FF*"""@en ;
-    skos:prefLabel "contains"@en .
-
-funcs:ehCoveredBy a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument is spatially covered by the second geometry argument.
-
-DE-9IM: TFF*TFT**"""@en ;
-    skos:prefLabel "covered by"@en .
-
-funcs:ehCovers a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions>  ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument spatially covers the second geometry argument.
-
-DE-9IM: T*TFT*FF*"""@en ;
-    skos:prefLabel "covers"@en .
-
-funcs:ehDisjoint a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions>  ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries are disjoint. 
-
-DE-9IM: FF*FF****"""@en ;
-    skos:prefLabel "disjoint"@en .
-
-funcs:ehEquals a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions>  ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries are equal. 
-
-DE-9IM: TFFFTFFFT"""@en ;
-    skos:prefLabel "equals"@en .
-
-funcs:ehInside a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument is spatially inside the second geometry argument.
-
-DE-9IM: TFF*FFT**"""@en ;
-    skos:prefLabel "inside"@en .
-
-funcs:ehMeet a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions>  ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries meet.
-
-DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
-    skos:prefLabel "meet"@en .
-
-funcs:ehOverlap a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions>  ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries overlap.
-
-DE-9IM: T*T***T**"""@en ;
-    skos:prefLabel "overlap"@en .
-
-funcs:envelope a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions>  ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the minimum bounding rectangle of the input geometry."@en ;
-    skos:prefLabel "envelope"@en .
-
-funcs:geometryN a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the the nth geometry if the given geometry literal contains a GeometryCollection."@en ;
-    skos:prefLabel "geometryN"@en .
-
-funcs:getSRID a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/srid-function> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the spatial reference system URI of the input geometry."@en ;
-    skos:prefLabel "getSRID"@en .
-
-funcs:isEmpty a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns true if the input geometry is empty."@en ;
-    skos:prefLabel "isEmpty"@en .
-
-funcs:isSimple a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns true if the input geometry is a simple geometry."@en ;
-    skos:prefLabel "isSimple"@en .
-
-funcs:dimension a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "Returns the dimension of a geometry."@en ;
-    skos:prefLabel "area"@en .
-
-funcs:length a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "Returns the length of a geometry in meters."@en ;
-    skos:prefLabel "length"@en .
-
-
-funcs:minx a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the minimum x coordinate of the input geometry."@en ;
-    skos:scopeNote "X indicates the first dimension as indicated by the spatial reference system"@en ;
-    skos:prefLabel "minX"@en .
-
-funcs:maxx a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the maximum x coordinate of the input geometry."@en ;
-    skos:scopeNote "X indicates the first dimension as indicated by the spatial reference system"@en ;
-    skos:prefLabel "maxX"@en .
-
-funcs:miny a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the minimum y coordinate of the input geometry."@en ;
-    skos:scopeNote "Y indicates the second dimension as indicated by the spatial reference system"@en ;
-    skos:prefLabel "minY"@en .
-
-funcs:maxy a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the maximum y coordinate of the input geometry."@en ;
-    skos:scopeNote "Y indicates the second dimension as indicated by the spatial reference system"@en ;
-    skos:prefLabel "maxY"@en .
-
-funcs:minz a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the minimum z coordinate of the input geometry."@en ;
-    skos:scopeNote "Z indicates the third dimension as indicated by the spatial reference system"@en ;
-    skos:prefLabel "minZ"@en .
-
-funcs:maxz a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that returns the maximum z coordinate of the input geometry."@en ;
-    skos:scopeNote "Z indicates the third dimension as indicated by the spatial reference system"@en ;
-    skos:prefLabel "maxZ"@en .
-
-funcs:numGeometries a skos:Concept, sd:Function ;
+funcs:numGeometries
+    a
+        skos:Concept ,
+        sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query function that returns the number of geometries if the given geometry literal contains a GeometryCollection."@en ;
-    skos:prefLabel "numGeometries"@en .
+    skos:prefLabel "numGeometries"@en ;
+.
 
-funcs:intersection a sd:Function ;
+funcs:area
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "Returns the area of a geometry in squaremeters."@en ;
+    skos:prefLabel "area"@en ;
+.
+
+funcs:boundary
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the boundary of the input geometry."@en ;
+    skos:prefLabel "boundary"@en ;
+.
+
+funcs:boundingCircle
+    a sd:Function ;
+    dcterms:date "2021-02-25"^^xsd:date ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that calculates the minimum bounding circle of set of geometries."@en ;
+    skos:prefLabel "bounding circle"@en ;
+.
+
+funcs:buffer
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns a buffer around the input geometry."@en ;
+    skos:prefLabel "buffer"@en ;
+.
+
+funcs:convexHull
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the convex hull of the input geometry."@en ;
+    skos:prefLabel "convex hull"@en ;
+.
+
+funcs:difference
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns a geometry consisting of all points that are part of the first geometry but not the second geometry."@en ;
+    skos:prefLabel "difference"@en ;
+.
+
+funcs:dimension
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "Returns the dimension of a geometry."@en ;
+    skos:prefLabel "area"@en ;
+.
+
+funcs:distance
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the distance between the two closest points of the input geometries."@en ;
+    skos:example spec11:B.2.2.4 ;
+    skos:prefLabel "distance"@en ;
+.
+
+funcs:ehContains
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument. \r
+      \r
+DE-9IM: T*TFF*FF*"""@en ;
+    skos:prefLabel "contains"@en ;
+.
+
+funcs:ehCoveredBy
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition """A query function that returns true if the first geometry argument is spatially covered by the second geometry argument.\r
+\r
+DE-9IM: TFF*TFT**"""@en ;
+    skos:prefLabel "covered by"@en ;
+.
+
+funcs:ehCovers
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition """A query function that returns true if the first geometry argument spatially covers the second geometry argument.\r
+\r
+DE-9IM: T*TFT*FF*"""@en ;
+    skos:prefLabel "covers"@en ;
+.
+
+funcs:ehDisjoint
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition """A query function that returns true if the input geometries are disjoint. \r
+\r
+DE-9IM: FF*FF****"""@en ;
+    skos:prefLabel "disjoint"@en ;
+.
+
+funcs:ehEquals
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition """A query function that returns true if the input geometries are equal. \r
+\r
+DE-9IM: TFFFTFFFT"""@en ;
+    skos:prefLabel "equals"@en ;
+.
+
+funcs:ehInside
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition """A query function that returns true if the first geometry argument is spatially inside the second geometry argument.\r
+\r
+DE-9IM: TFF*FFT**"""@en ;
+    skos:prefLabel "inside"@en ;
+.
+
+funcs:ehMeet
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition """A query function that returns true if the input geometries meet.\r
+\r
+DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
+    skos:prefLabel "meet"@en ;
+.
+
+funcs:ehOverlap
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/eh-query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition """A query function that returns true if the input geometries overlap.\r
+\r
+DE-9IM: T*T***T**"""@en ;
+    skos:prefLabel "overlap"@en ;
+.
+
+funcs:envelope
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the minimum bounding rectangle of the input geometry."@en ;
+    skos:prefLabel "envelope"@en ;
+.
+
+funcs:getSRID
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/srid-function> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the spatial reference system URI of the input geometry."@en ;
+    skos:prefLabel "getSRID"@en ;
+.
+
+funcs:intersection
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query function that returns a geometry consisting of all points that are part of both input geometries."@en ;
-    skos:prefLabel "intersection"@en .
+    skos:prefLabel "intersection"@en ;
+.
 
-funcs:rcc8dc a sd:Function ;
+funcs:isEmpty
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns true if the input geometry is empty."@en ;
+    skos:prefLabel "isEmpty"@en ;
+.
+
+funcs:isSimple
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns true if the input geometry is a simple geometry."@en ;
+    skos:prefLabel "isSimple"@en ;
+.
+
+funcs:maxx
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the maximum x coordinate of the input geometry."@en ;
+    skos:prefLabel "maxX"@en ;
+    skos:scopeNote "X indicates the first dimension as indicated by the spatial reference system"@en ;
+.
+
+funcs:maxy
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the maximum y coordinate of the input geometry."@en ;
+    skos:prefLabel "maxY"@en ;
+    skos:scopeNote "Y indicates the second dimension as indicated by the spatial reference system"@en ;
+.
+
+funcs:maxz
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the maximum z coordinate of the input geometry."@en ;
+    skos:prefLabel "maxZ"@en ;
+    skos:scopeNote "Z indicates the third dimension as indicated by the spatial reference system"@en ;
+.
+
+funcs:minx
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the minimum x coordinate of the input geometry."@en ;
+    skos:prefLabel "minX"@en ;
+    skos:scopeNote "X indicates the first dimension as indicated by the spatial reference system"@en ;
+.
+
+funcs:miny
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the minimum y coordinate of the input geometry."@en ;
+    skos:prefLabel "minY"@en ;
+    skos:scopeNote "Y indicates the second dimension as indicated by the spatial reference system"@en ;
+.
+
+funcs:minz
+    a sd:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that returns the minimum z coordinate of the input geometry."@en ;
+    skos:prefLabel "minZ"@en ;
+    skos:scopeNote "Z indicates the third dimension as indicated by the spatial reference system"@en ;
+.
+
+funcs:rcc8dc
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/rcc8-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries are disjoint. 
-
+    skos:definition """A query function that returns true if the input geometries are disjoint. \r
+\r
 DE-9IM: FFTFFTTTT"""@en ;
-    skos:prefLabel "disconnected"@en .
+    skos:prefLabel "disconnected"@en ;
+.
 
-funcs:rcc8ec a sd:Function ;
+funcs:rcc8ec
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/rcc8-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries meet. 
-
+    skos:definition """A query function that returns true if the input geometries meet. \r
+\r
 DE-9IM: FFTFTTTTT"""@en ;
-    skos:prefLabel "externally connected"@en .
+    skos:prefLabel "externally connected"@en ;
+.
 
-funcs:rcc8eq a sd:Function ;
+funcs:rcc8eq
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/rcc8-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries are equal. 
-      
+    skos:definition """A query function that returns true if the input geometries are equal. \r
+      \r
 DE-9IM: TFFFTFFFT"""@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-funcs:rcc8ntpp a sd:Function ;
+funcs:rcc8ntpp
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/rcc8-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument is spatially inside the second geometry argument.
-
+    skos:definition """A query function that returns true if the first geometry argument is spatially inside the second geometry argument.\r
+\r
 DE-9IM: TFFTFFTTT"""@en ;
-    skos:prefLabel "non-tangential proper part"@en .
+    skos:prefLabel "non-tangential proper part"@en ;
+.
 
-funcs:rcc8ntppi a sd:Function ;
+funcs:rcc8ntppi
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/rcc8-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument.
-
+    skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument.\r
+\r
 DE-9IM: TTTFFTFFT"""@en ;
-    skos:prefLabel "non-tangential proper part inverse"@en .
+    skos:prefLabel "non-tangential proper part inverse"@en ;
+.
 
-funcs:rcc8po a sd:Function ;
+funcs:rcc8po
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/rcc8-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries overlap.
-
+    skos:definition """A query function that returns true if the input geometries overlap.\r
+\r
 DE-9IM: TTTTTTTTT"""@en ;
-    skos:prefLabel "partially overlapping"@en .
+    skos:prefLabel "partially overlapping"@en ;
+.
 
-funcs:rcc8tpp a sd:Function ;
+funcs:rcc8tpp
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/rcc8-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument is spatially covered by the second geometry argument.
-
+    skos:definition """A query function that returns true if the first geometry argument is spatially covered by the second geometry argument.\r
+\r
 DE-9IM: TFFTTFTTT"""@en ;
-    skos:prefLabel "tangential proper part"@en .
+    skos:prefLabel "tangential proper part"@en ;
+.
 
-funcs:rcc8tppi a sd:Function ;
+funcs:rcc8tppi
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/rcc8-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument spatially covers the second geometry argument.
-
+    skos:definition """A query function that returns true if the first geometry argument spatially covers the second geometry argument.\r
+\r
 DE-9IM: TTTFTTFFT"""@en ;
-    skos:prefLabel "tangential proper part inverse"@en .
+    skos:prefLabel "tangential proper part inverse"@en ;
+.
 
-funcs:relate a sd:Function ;
+funcs:relate
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/relate-query-function> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query function that returns true if the spatial relationship between the two input geometries corresponds to one with acceptable values for the specified DE-9IM pattern matrix."@en ;
-    skos:prefLabel "relate"@en .
+    skos:prefLabel "relate"@en ;
+.
 
-funcs:sfContains a sd:Function ;
+funcs:sfContains
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/sf-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument.
-
+    skos:definition """A query function that returns true if the first geometry argument spatially contains the second geometry argument.\r
+\r
 DE-9IM: T*****FF*"""@en ;
+    skos:example spec11:B.2.2.1 ;
     skos:prefLabel "contains"@en ;
-    skos:example spec11:B.2.2.1 .
+.
 
-funcs:sfCrosses a sd:Function ;
+funcs:sfCrosses
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/sf-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument spatially crosses the second geometry argument.
-
+    skos:definition """A query function that returns true if the first geometry argument spatially crosses the second geometry argument.\r
+\r
 DE-9IM: T*T***T**"""@en ;
-    skos:prefLabel "crosses"@en .
+    skos:prefLabel "crosses"@en ;
+.
 
-funcs:sfDisjoint a sd:Function ;
+funcs:sfDisjoint
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/sf-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries are disjoint. 
-      
+    skos:definition """A query function that returns true if the input geometries are disjoint. \r
+      \r
 DE-9IM: FF*FF****"""@en ;
-    skos:prefLabel "disjoint"@en .
+    skos:prefLabel "disjoint"@en ;
+.
 
-funcs:sfEquals a sd:Function ;
+funcs:sfEquals
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/sf-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries are equal. 
-
+    skos:definition """A query function that returns true if the input geometries are equal. \r
+\r
 DE-9IM: TFFFTFFFT"""@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-funcs:sfIntersects a sd:Function ;
+funcs:sfIntersects
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/sf-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries intersect.
-
+    skos:definition """A query function that returns true if the input geometries intersect.\r
+\r
 DE-9IM: T******** ^ *T******* ^ ***T***** ^ ****T**** """@en ;
-    skos:prefLabel "intersects"@en .
+    skos:prefLabel "intersects"@en ;
+.
 
-funcs:sfOverlaps a sd:Function ;
+funcs:sfOverlaps
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/sf-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument spatially overlaps the second geometry argument.
-
+    skos:definition """A query function that returns true if the first geometry argument spatially overlaps the second geometry argument.\r
+\r
 DE-9IM: T*T***T** """@en ;
-    skos:prefLabel "overlaps"@en .
+    skos:prefLabel "overlaps"@en ;
+.
 
-funcs:sfTouches a sd:Function ;
+funcs:sfTouches
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/sf-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the input geometries touch.
-
+    skos:definition """A query function that returns true if the input geometries touch.\r
+\r
 DE-9IM: FT******* ^ F**T***** ^ F***T****"""@en ;
+    skos:example spec11:B.2.2.3 ;
     skos:prefLabel "touches"@en ;
-    skos:example spec11:B.2.2.3 .
+.
 
-funcs:sfWithin a sd:Function ;
+funcs:sfWithin
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-topology-extension/sf-query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition """A query function that returns true if the first geometry argument is spatially within the second geometry argument. 
-
+    skos:definition """A query function that returns true if the first geometry argument is spatially within the second geometry argument. \r
+\r
 DE-9IM: T*F**F***"""@en ;
+    skos:example spec11:B.2.2.2 ;
     skos:prefLabel "within"@en ;
-    skos:example spec11:B.2.2.2 .
+.
 
-funcs:symDifference a sd:Function ;
+funcs:symDifference
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query function that returns a geometry consisting of all points that are part of only one input geometry."@en ;
-    skos:prefLabel "symmetric difference"@en .
+    skos:prefLabel "symmetric difference"@en ;
+.
 
-funcs:transform a sd:Function ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A query function that converts a given geometry to a spatial reference system defined by an IRI. The function raises an error if a transformation is not mathematically possible."@en ;
-    skos:prefLabel "transform"@en .
-
-funcs:union a sd:Function ;
+funcs:union
+    a sd:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query function that returns a geometry consisting of all points that are part of at least one input geometry."@en ;
+    skos:example spec11:B.2.2.3 ;
     skos:prefLabel "union"@en ;
-    skos:example spec11:B.2.2.3 .
+.
 
-funcs:aggUnion a sd:Aggregate ;
-    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
-    policy:status status:valid ;
-    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/sa-functions> ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A spatial aggregate function that calculates the union of a set of geometries."@en ;
-    skos:prefLabel "aggregate union"@en .
-
-rules:ehContains a skos:Concept ;
+rules:ehContains
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/eh-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object contains another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "contains"@en .
+    skos:prefLabel "contains"@en ;
+.
 
-rules:ehCoveredBy a skos:Concept ;
+rules:ehCoveredBy
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/eh-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is covered by another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "covered by"@en .
+    skos:prefLabel "covered by"@en ;
+.
 
-rules:ehCovers a skos:Concept ;
+rules:ehCovers
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/eh-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object covers another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "covers"@en .
+    skos:prefLabel "covers"@en ;
+.
 
-rules:ehDisjoint a skos:Concept ;
+rules:ehDisjoint
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/eh-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are disjoint based on their associated primary geometry objects."@en ;
-    skos:prefLabel "disjoint"@en .
+    skos:prefLabel "disjoint"@en ;
+.
 
-rules:ehEquals a skos:Concept ;
+rules:ehEquals
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/eh-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are equal based on their associated primary geometry objects."@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-rules:ehInside a skos:Concept ;
+rules:ehInside
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/eh-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is inside another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "inside"@en .
+    skos:prefLabel "inside"@en ;
+.
 
-rules:ehMeet a skos:Concept ;
+rules:ehMeet
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/eh-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects meet based on their associated primary geometry objects."@en ;
-    skos:prefLabel "meet"@en .
+    skos:prefLabel "meet"@en ;
+.
 
-rules:ehOverlap a skos:Concept ;
+rules:ehOverlap
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/eh-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects overlap based on their associated primary geometry objects."@en ;
-    skos:prefLabel "overlap"@en .
+    skos:prefLabel "overlap"@en ;
+.
 
-rules:rcc8dc a skos:Concept ;
+rules:rcc8dc
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/rcc8-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are disjoint based on their associated primary geometry objects."@en ;
-    skos:prefLabel "disconnected"@en .
+    skos:prefLabel "disconnected"@en ;
+.
 
-rules:rcc8ec a skos:Concept ;
+rules:rcc8ec
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/rcc8-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are externally connected based on their associated primary geometry objects."@en ;
-    skos:prefLabel "externally connected"@en .
+    skos:prefLabel "externally connected"@en ;
+.
 
-rules:rcc8eq a skos:Concept ;
+rules:rcc8eq
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/rcc8-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine two spatial objects are equal based on their associated primary geometry objects."@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-rules:rcc8ntpp a skos:Concept ;
+rules:rcc8ntpp
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/rcc8-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/spec/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is a non-tangential proper part of another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "non-tangential proper part"@en .
+    skos:prefLabel "non-tangential proper part"@en ;
+.
 
-rules:rcc8ntppi a skos:Concept ;
+rules:rcc8ntppi
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/rcc8-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is a non-tangential proper part inverse of another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "non-tangential proper part inverse"@en .
+    skos:prefLabel "non-tangential proper part inverse"@en ;
+.
 
-rules:rcc8po a skos:Concept ;
+rules:rcc8po
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/rcc8-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects partially overlap based on their associated primary geometry objects."@en ;
-    skos:prefLabel "partially overlapping"@en .
+    skos:prefLabel "partially overlapping"@en ;
+.
 
-rules:rcc8tpp a skos:Concept ;
+rules:rcc8tpp
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/rcc8-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is a tangential proper part of another spatial object based on their associated geometry objects."@en ;
-    skos:prefLabel "tangential proper part"@en .
+    skos:prefLabel "tangential proper part"@en ;
+.
 
-rules:rcc8tppi a skos:Concept ;
+rules:rcc8tppi
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/rcc8-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is a tangential proper part inverse of another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "tangential proper part inverse"@en .
+    skos:prefLabel "tangential proper part inverse"@en ;
+.
 
-rules:sfContains a skos:Concept ;
+rules:sfContains
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/sf-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object contains another spatial object based on their associated primary geometry objects."@en ;
-    skos:prefLabel "contains"@en .
+    skos:prefLabel "contains"@en ;
+.
 
-rules:sfCrosses a skos:Concept ;
+rules:sfCrosses
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/sf-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects cross based their associated primary geometry objects."@en ;
-    skos:prefLabel "crosses"@en .
+    skos:prefLabel "crosses"@en ;
+.
 
-rules:sfDisjoint a skos:Concept;
+rules:sfDisjoint
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/sf-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are disjoint based on their associated primary geometry objects."@en ;
-    skos:prefLabel "disjoint"@en .
+    skos:prefLabel "disjoint"@en ;
+.
 
-rules:sfEquals a skos:Concept ;
+rules:sfEquals
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/sf-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects are equal based on their associated primary geometry objects."@en ;
-    skos:prefLabel "equals"@en .
+    skos:prefLabel "equals"@en ;
+.
 
-rules:sfIntersects a skos:Concept ;
+rules:sfIntersects
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/sf-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects intersect based on their associated primary geometry objects."@en ;
-    skos:prefLabel "intersects"@en .
+    skos:prefLabel "intersects"@en ;
+.
 
-rules:sfOverlaps a skos:Concept ;
+rules:sfOverlaps
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/sf-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects overlap based on their associated primary geometry objects."@en ;
+    skos:example spec11:B.2.2.5 ;
     skos:prefLabel "overlaps"@en ;
-    skos:example spec11:B.2.2.5 .
+.
 
-rules:sfTouches a skos:Concept;
+rules:sfTouches
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/sf-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if two spatial objects touch based on their associated primary geometry objects."@en ;
-    skos:prefLabel "touches"@en .
+    skos:prefLabel "touches"@en ;
+.
 
-rules:sfWithin a skos:Concept ;
+rules:sfWithin
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/query-rewrite-extension/sf-query-rewrite> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A query rewrite rule used to determine if one spatial object is within another spatial object based on their associated geometry objects."@en ;
-    skos:prefLabel "within"@en .
+    skos:prefLabel "within"@en ;
+.

--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -19,7 +19,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:modified "2021-06-16"^^xsd:date ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     owl:imports <http://www.opengis.net/def/ogc-na> ;
-    owl:versionIRI <http://defs-dev.opengis.net/static/definitions/conceptschemes/functions_geosparql.ttl> ;
+    owl:versionInfo "OGC GeosPARQL 1.1" ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/funcsrules/1.1> ;
     skos:definition "A vocabulary (taxonomy) of the functions and rules defined within the GeoSPARQL 1.1 specification"@en ;
     dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
     dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;

--- a/1.1/geo.ttl
+++ b/1.1/geo.ttl
@@ -86,6 +86,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	dcterms:source <http://www.opengis.net/doc/IS/geosparql/1.1> , "OGC GeoSPARQL - A Geographic Query Language for RDF Data OGC 11-052r5"@en ;
 	rdfs:seeAlso <http://www.opengis.net/doc/IS/geosparql/1.1> ;
 	owl:versionInfo "OGC GeoSPARQL 1.1" ;
+	owl:versionIRI <http://www.opengis.net/ont/geosparql/1.1> ;
 .
 
 

--- a/1.1/profile.ttl
+++ b/1.1/profile.ttl
@@ -1,188 +1,181 @@
-BASE <http://www.opengis.net/def/geosparql>
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX role: <http://www.w3.org/ns/dx/prof/role/>
 PREFIX sdo: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-
 <http://www.opengis.net/def/geosparql>
     a prof:Profile ;
-    owl:versionInfo "OGC GeosPARQL 1.1" ;
-    owl:versionIRI <http://www.opengis.net/def/geosparql/1.1> ;
     dcterms:created "2020-10-11"^^xsd:date ;
     dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
+    dcterms:description "This is a 'profile declaration' for the GeoSPARQL 1.1 specification (standard). It describes the multiple parts of the specification and how the standard relates to other standards. It is formulated according to the Profiles Vocabulary."@en ;
+    dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
     dcterms:modified "2021-06-16"^^xsd:date ;
-	dcterms:publisher [
-	    a sdo:Organization ;
-	    sdo:name "Open Geospatial Consortium" ;
-	    sdo:url "https://www.ogc.org"^^xsd:anyURI ;
-	] ;
+    dcterms:publisher [
+            a sdo:Organization ;
+            sdo:name "Open Geospatial Consortium" ;
+            sdo:url "https://www.ogc.org"^^xsd:anyURI
+        ] ;
+    dcterms:rights "(c) 2021 Open Geospatial Consortium" ;
     dcterms:title "GeoSPARQL 1.1 Profile" ;
-    dcterms:description """This is a 'profile declaration' for the GeoSPARQL 1.1 specification (standard). It describes the multiple parts of the specification and how the standard relates to other standards. It is formulated according to the Profiles Vocabulary."""@en ;
-	dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
-	dcterms:rights "(c) 2021 Open Geospatial Consortium" ;    
-    skos:scopeNote """Profile declarations are used to allow data to identify specifications in a way that allows data to make conformance claims to them - a broader conformance claim than that made to individual 'conformance classes' that are commonly found in recent OGC specifications. Profile declarations are also used to describe and relate the often multiple parts of specifications: ontologies, specification 'documents', vocabularies, validators and so on. This declaration describes where those parts are, what form (format) they take, what information models they implement and what roles they play."""@en ;
-    prof:hasResource 
+    owl:versionIRI <http://www.opengis.net/def/geosparql/1.1> ;
+    owl:versionInfo "OGC GeosPARQL 1.1" ;
+    skos:scopeNote "Profile declarations are used to allow data to identify specifications in a way that allows data to make conformance claims to them - a broader conformance claim than that made to individual 'conformance classes' that are commonly found in recent OGC specifications. Profile declarations are also used to describe and relate the often multiple parts of specifications: ontologies, specification 'documents', vocabularies, validators and so on. This declaration describes where those parts are, what form (format) they take, what information models they implement and what roles they play."@en ;
+    prof:hasResource
+        <http://www.opengis.net/def/geosparql/extended-examples> ,
+        <http://www.opengis.net/def/geosparql/funcsrules> ,
+        <http://www.opengis.net/def/geosparql/geo-jsonldcontext> ,
+        <http://www.opengis.net/def/geosparql/repository> ,
+        <http://www.opengis.net/def/geosparql/reqs> ,
+        <http://www.opengis.net/def/geosparql/safuncs> ,
+        <http://www.opengis.net/def/geosparql/sf-jsonldcontext> ,
+        <http://www.opengis.net/def/geosparql/validator> ,
         <http://www.opengis.net/doc/IS/geosparql/1.1> ,
         <http://www.opengis.net/doc/IS/geosparql/1.1.pdf> ,
+        <http://www.opengis.net/doc/IS/geosparql/release-notes-1.1> ,
         <http://www.opengis.net/ont/geosparql> ,
         <http://www.opengis.net/ont/geosparql.json> ,
-        <http://www.opengis.net/def/geosparql/validator> ,
-        <http://www.opengis.net/def/geosparql/repository> ,
-        <http://www.opengis.net/def/geosparql/funcsrules> ,
-        <http://www.opengis.net/def/geosparql/safuncs> ,
-        <http://www.opengis.net/ont/sf> ,
-        <http://www.opengis.net/def/geosparql/reqs> ,
-        <http://www.opengis.net/def/geosparql/geo-jsonldcontext> ,
-        <http://www.opengis.net/def/geosparql/sf-jsonldcontext> ,
-        <http://www.opengis.net/def/geosparql/extended-examples> ,
-        <http://www.opengis.net/doc/IS/geosparql/release-notes-1.1> ;
+        <http://www.opengis.net/ont/sf> ;
+.
+
+<http://www.opengis.net/ont/gml>
+    a prof:ResourceDescriptor ;
+    dcterms:conformsTo <http://www.w3.org/TR/owl2-rdf-based-semantics/> ;
+    dcterms:description "An OWL ontology (vocabulary) of the GML geometry types"@en ;
+    dcterms:format "text/xml" ;
+    dcterms:title "GML Geometry Types Vocabulary"@en ;
+    prof:hasArtifact "https://schemas.opengis.net/gml/3.2.1/gml_32_geometries.rdf"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
 .
 
 <https://ror.org/00fsdxs93>
-    a owl:NamedIndividual ;
-    a sdo:Organization ;
+    a
+        owl:NamedIndividual ,
+        sdo:Organization ;
     sdo:name "Open Geospatial Consortium" ;
     sdo:url <https://www.ogc.org> ;
 .
 
+<http://www.opengis.net/def/geosparql/extended-examples>
+    a prof:ResourceDescriptor ;
+    dcterms:description "Examples that are too long to sensibly fit within the Specification's Annex B. They are presented as individual files within a version control repository directory."@en ;
+    dcterms:title "Extended Examples"@en ;
+    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/tree/master/1.1/examples"^^xsd:anyURI ;
+    prof:hasRole role:example ;
+.
+
+<http://www.opengis.net/def/geosparql/funcsrules>
+    a prof:ResourceDescriptor ;
+    dcterms:conformsTo <https://www.w3.org/TR/skos-reference/> ;
+    dcterms:description "all GeoSPARQL functions and rules presented as a SKOS vocabulary"@en ;
+    dcterms:format "text/turtle" ;
+    dcterms:title "GeoSPARQL Functions & Rules vocabulary"@en ;
+    prof:hasArtifact "http://defs-dev.opengis.net/static/definitions/conceptschemes/functions_geosparql.ttl"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.
+
+<http://www.opengis.net/def/geosparql/geo-jsonldcontext>
+    a prof:ResourceDescriptor ;
+    dcterms:description "This is a JSON-LD context which can be used to incorporate the GeoSPARQL vocabulary in a JSON-LD file"@en ;
+    dcterms:format "text/json" ;
+    dcterms:title "JSON-LD context for the GeoSPARQL ontology"@en ;
+    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/blob/master/1.1/contexts/geo-context.json"^^xsd:anyURI ;
+    prof:hasRole role:specification ;
+.
+
+<http://www.opengis.net/def/geosparql/repository>
+    a prof:ResourceDescriptor ;
+    dcterms:description "Code repository storing all Profile artifacts"@en ;
+    dcterms:title "Profile code repository"@en ;
+    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql"^^xsd:anyURI ;
+    prof:hasRole role:repository ;
+.
+
+<http://www.opengis.net/def/geosparql/reqs>
+    a prof:ResourceDescriptor ;
+    dcterms:conformsTo <https://www.w3.org/TR/skos-reference/> ;
+    dcterms:description "A vocabulary of the requirements and conformance classes in the GeoSPARQL 1.1 specification"@en ;
+    dcterms:format "text/turtle" ;
+    dcterms:title "GeoSPARQL 1.1 Requirement and Conformance Class Vocabulary"@en ;
+    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/blob/master/1.1/reqs.ttl"^^xsd:anyURI ;
+    prof:hasRole role:specification ;
+.
+
+<http://www.opengis.net/def/geosparql/safuncs>
+    a prof:ResourceDescriptor ;
+    dcterms:conformsTo <https://www.w3.org/TR/skos-reference/> ;
+    dcterms:description "all GeoSPARQL Spatial Aggregate functions presented as a SKOS vocabulary"@en ;
+    dcterms:format "text/turtle" ;
+    dcterms:title "GeoSPARQL Spatial Aggregate Functions"@en ;
+    prof:hasArtifact "http://defs-dev.opengis.net/static/definitions/conceptschemes/sa_functions.ttl"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.
+
+<http://www.opengis.net/def/geosparql/sf-jsonldcontext>
+    a prof:ResourceDescriptor ;
+    dcterms:description "This is a JSON-LD context which can be used to incorporate the Simple Features vocabulary in a JSON-LD file"@en ;
+    dcterms:format "text/json" ;
+    dcterms:title "JSON-LD context for the Simple Features vocabulary"@en ;
+    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/blob/master/1.1/contexts/sf-context.json"^^xsd:anyURI ;
+    prof:hasRole role:specification ;
+.
+
+<http://www.opengis.net/def/geosparql/validator>
+    a prof:ResourceDescriptor ;
+    dcterms:conformsTo <https://www.w3.org/TR/shacl/> ;
+    dcterms:description "A [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/) file that specifies rules for RDF data that can be used to test the conformance of data to the GeoSPARQL standard."@en ;
+    dcterms:format "text/turtle" ;
+    dcterms:title "GeoSPARQL RDF Shapes Validator"@en ;
+    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/master/1.1/validator.ttl"^^xsd:anyURI ;
+    prof:hasRole role:validation ;
+.
+
 <http://www.opengis.net/doc/IS/geosparql/1.1>
     a prof:ResourceDescriptor ;
-    dcterms:title "GeoSPARQL Specification online"@en ;
     dcterms:format "text/html" ;
-    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/master/1.1/spec/_11-052r4.html"^^xsd:anyURI ;
-    prof:hasRole role:specification
+    dcterms:title
+        "GeoSPARQL 1.1 Release Notes"@en ,
+        "GeoSPARQL Specification online"@en ;
+    prof:hasArtifact
+        "https://github.com/opengeospatial/ogc-geosparql/master/1.1/spec/_11-052r4.html"^^xsd:anyURI ,
+        "https://opengeospatial.github.io/ogc-geosparql/geosparql11/releasenotes.html"^^xsd:anyURI ;
+    prof:hasRole role:specification ;
 .
 
 <http://www.opengis.net/doc/IS/geosparql/1.1.pdf>
     a prof:ResourceDescriptor ;
-    dcterms:title "GeoSPARQL Specification Document as a PDF"@en ;
     dcterms:format "application/pdf" ;
+    dcterms:title "GeoSPARQL Specification Document as a PDF"@en ;
     prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/master/1.1/spec/_11-052r4.pdf"^^xsd:anyURI ;
     prof:hasRole role:specification ;
 .
 
 <http://www.opengis.net/ont/geosparql>
     a prof:ResourceDescriptor ;
-    dcterms:title "GeoSPARQL Ontology"@en ;
     dcterms:description "The GeoSPARQL 1.1 ontology in RDF (turtle)"@en ;
     dcterms:format "text/turtle" ;
+    dcterms:title "GeoSPARQL Ontology"@en ;
     prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/master/1.1/geo.ttl"^^xsd:anyURI ;
     prof:hasRole role:schema ;
 .
 
 <http://www.opengis.net/ont/geosparql.json>
     a prof:ResourceDescriptor ;
-    dcterms:title "GeoSPARQL Ontology"@en ;
     dcterms:description "The GeoSPARQL 1.1 ontology in RDF (JSON-LD)"@en ;
     dcterms:format "application/ld+json" ;
+    dcterms:title "GeoSPARQL Ontology"@en ;
     prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/master/1.1/geo.json"^^xsd:anyURI ;
     prof:hasRole role:schema ;
 .
 
-<http://www.opengis.net/def/geosparql/validator>
-    a prof:ResourceDescriptor ;
-    dcterms:title "GeoSPARQL RDF Shapes Validator"@en ;
-    dcterms:description "A [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/) file that specifies rules for RDF data that can be used to test the conformance of data to the GeoSPARQL standard."@en ;
-    dcterms:format "text/turtle" ;
-    dcterms:conformsTo <https://www.w3.org/TR/shacl/> ;
-    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/master/1.1/validator.ttl"^^xsd:anyURI ;
-    prof:hasRole role:validation ;
-.
-
-<http://www.opengis.net/def/geosparql/repository>
-    a prof:ResourceDescriptor ;
-    dcterms:title "Profile code repository"@en ;
-    dcterms:description "Code repository storing all Profile artifacts"@en ;
-    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql"^^xsd:anyURI ;
-    prof:hasRole role:repository ;
-.
-
-<http://www.opengis.net/def/geosparql/funcsrules>
-    a prof:ResourceDescriptor ;
-    dcterms:title "GeoSPARQL Functions & Rules vocabulary"@en ;
-    dcterms:description "all GeoSPARQL functions and rules presented as a SKOS vocabulary"@en ;
-    dcterms:conformsTo <https://www.w3.org/TR/skos-reference/> ;
-    dcterms:format "text/turtle" ;
-    prof:hasArtifact "http://defs-dev.opengis.net/static/definitions/conceptschemes/functions_geosparql.ttl"^^xsd:anyURI ;
-    prof:hasRole role:vocabulary ;
-.
-
-<http://www.opengis.net/def/geosparql/safuncs>
-    a prof:ResourceDescriptor ;
-    dcterms:title "GeoSPARQL Spatial Aggregate Functions"@en ;
-    dcterms:description "all GeoSPARQL Spatial Aggregate functions presented as a SKOS vocabulary"@en ;
-    dcterms:conformsTo <https://www.w3.org/TR/skos-reference/> ;
-    dcterms:format "text/turtle" ;
-    prof:hasArtifact "http://defs-dev.opengis.net/static/definitions/conceptschemes/sa_functions.ttl"^^xsd:anyURI ;
-    prof:hasRole role:vocabulary ;
-.
-
 <http://www.opengis.net/ont/sf>
     a prof:ResourceDescriptor ;
-    dcterms:title "Simple Features Vocabulary"@en ;
-    dcterms:description "An OWL ontology (vocabulary) of the Simple Features geometry types"@en ;
     dcterms:conformsTo <http://www.w3.org/TR/owl2-rdf-based-semantics/> ;
+    dcterms:description "An OWL ontology (vocabulary) of the Simple Features geometry types"@en ;
     dcterms:format "text/turtle" ;
+    dcterms:title "Simple Features Vocabulary"@en ;
     prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/blob/master/1.1/sf_geometries.ttl"^^xsd:anyURI ;
     prof:hasRole role:vocabulary ;
-.
-
-<http://www.opengis.net/ont/gml>
-    a prof:ResourceDescriptor ;
-    dcterms:title "GML Geometry Types Vocabulary"@en ;
-    dcterms:description "An OWL ontology (vocabulary) of the GML geometry types"@en ;
-    dcterms:conformsTo <http://www.w3.org/TR/owl2-rdf-based-semantics/> ;
-    dcterms:format "text/xml" ;
-    prof:hasArtifact "https://schemas.opengis.net/gml/3.2.1/gml_32_geometries.rdf"^^xsd:anyURI ;
-    prof:hasRole role:vocabulary ;
-.
-
-<http://www.opengis.net/def/geosparql/reqs>
-    a prof:ResourceDescriptor ;
-    dcterms:title "GeoSPARQL 1.1 Requirement and Conformance Class Vocabulary"@en ;
-    dcterms:description "A vocabulary of the requirements and conformance classes in the GeoSPARQL 1.1 specification"@en ;
-    dcterms:conformsTo <https://www.w3.org/TR/skos-reference/> ;
-    dcterms:format "text/turtle" ;
-    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/blob/master/1.1/reqs.ttl"^^xsd:anyURI ;
-    prof:hasRole role:specification ;  # this may not be appropriate: we may need a new Role, see https://github.com/w3c/dx-prof/issues/41
-.
-
-<http://www.opengis.net/def/geosparql/geo-jsonldcontext>
-    a prof:ResourceDescriptor ;
-    dcterms:title "JSON-LD context for the GeoSPARQL ontology"@en ;
-    dcterms:description "This is a JSON-LD context which can be used to incorporate the GeoSPARQL vocabulary in a JSON-LD file"@en ;
-    dcterms:format "text/json" ;
-    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/blob/master/1.1/contexts/geo-context.json"^^xsd:anyURI ;
-    prof:hasRole role:specification ;
-.
-
-<http://www.opengis.net/def/geosparql/sf-jsonldcontext>
-    a prof:ResourceDescriptor ;
-    dcterms:title "JSON-LD context for the Simple Features vocabulary"@en ;
-    dcterms:description "This is a JSON-LD context which can be used to incorporate the Simple Features vocabulary in a JSON-LD file"@en ;
-    dcterms:format "text/json" ;
-    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/blob/master/1.1/contexts/sf-context.json"^^xsd:anyURI ;
-    prof:hasRole role:specification ;
-.
-
-<http://www.opengis.net/def/geosparql/extended-examples>
-    a prof:ResourceDescriptor ;
-    dcterms:title "Extended Examples"@en ;
-    dcterms:description "Examples that are too long to sensibly fit within the Specification's Annex B. They are presented as individual files within a version control repository directory."@en ;
-    prof:hasArtifact "https://github.com/opengeospatial/ogc-geosparql/tree/master/1.1/examples"^^xsd:anyURI ;
-    prof:hasRole role:example ;
-.
-
-<http://www.opengis.net/doc/IS/geosparql/1.1>
-    a prof:ResourceDescriptor ;
-    dcterms:title "GeoSPARQL 1.1 Release Notes"@en ;
-    dcterms:format "text/html" ;
-    prof:hasArtifact "https://opengeospatial.github.io/ogc-geosparql/geosparql11/releasenotes.html"^^xsd:anyURI ;
-    prof:hasRole role:specification
 .

--- a/1.1/profile.ttl
+++ b/1.1/profile.ttl
@@ -12,6 +12,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <http://www.opengis.net/def/geosparql>
     a prof:Profile ;
+    owl:versionInfo "OGC GeosPARQL 1.1" ;
     owl:versionIRI <http://www.opengis.net/def/geosparql/1.1> ;
     dcterms:created "2020-10-11"^^xsd:date ;
     dcterms:creator "OGC GeoSPARQL Standards Working Group" ;

--- a/1.1/reqs.ttl
+++ b/1.1/reqs.ttl
@@ -10,11 +10,9 @@ PREFIX conf11qre: <http://www.opengis.net/spec/geosparql/1.1/conf/query-rewrite-
 PREFIX confs10: <http://www.opengis.net/spec/geosparql/1.0/conf/>
 PREFIX confs11: <http://www.opengis.net/spec/geosparql/1.1/conf/>
 PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov1: <http://www.w3.org/ns/prov-o/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX sdo: <https://schema.org/>
-PREFIX sd: <http://www.w3.org/ns/sparql-service-description#> 
 PREFIX reqs10: <http://www.opengis.net/spec/geosparql/1.0/req/>
 PREFIX reqs10core: <http://www.opengis.net/spec/geosparql/1.0/req/core/>
 PREFIX reqs10gtx: <http://www.opengis.net/spec/geosparql/1.0/req/geometry-topology-extension/>
@@ -24,237 +22,29 @@ PREFIX reqs10ree: <http://www.opengis.net/spec/geosparql/1.0/req/rdfs-entailment
 PREFIX reqs10tve: <http://www.opengis.net/spec/geosparql/1.0/req/topology-extension/>
 PREFIX reqs11core: <http://www.opengis.net/spec/geosparql/1.1/req/core/>
 PREFIX reqs11gx: <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/>
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
+PREFIX sdo: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX spec: <http://www.opengis.net/def/spec-element/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-
-<http://www.opengis.net/def/geosparql/reqs> rdf:type skos:ConceptScheme ;
-                                             dcterms:created "2021-06-28"^^xsd:date ;
-                                             dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
-                                             dcterms:modified "2022-06-16"^^xsd:date ;
-                                             rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-                                             skos:definition "A vocabulary of the requirements and conformance classes in the GeoSPARQL 1.1 specification"@en ;
-                                             dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
-                                             dcterms:publisher [
-                                                a sdo:Organization ;
-                                                sdo:name "Open Geospatial Consortium" ;
-                                                sdo:url "https://www.ogc.org"^^xsd:anyURI ;
-                                             ] ;                                             
-	                                         dcterms:rights "(c) 2022 Open Geospatial Consortium" ;
-                                             skos:prefLabel "GeoSPARQL 1.1 Requirements and Conformance Class Register"@en ;
-                                             owl:versionInfo "OGC GeoSPARQL 1.1" ;
-                                             owl:versionIRI <http://www.opengis.net/def/geosparql/reqs/1.1> .
-
-
-confs10:core
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    skos:member
-        conf10core:sparql-protocol ,
-        conf10core:spatial-object-class ,
-        conf10core:feature-class ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Core"@en ;
-.
-
-confs11:core
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires confs10:core ;        
-    skos:member          
-        conf11core:feature-collection-class ,
-        conf11core:sparql-protocol ,
-        conf11core:spatial-object-class ,
-        conf11core:spatial-object-collection-class ,
-        conf11core:spatial-object-properties ;
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Core"@en ;
-.
-
-confs10:topology-extension
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires confs10:core ;
-    skos:member
-        conf10gtx:eh-query-functions ,
-        conf10gtx:rcc8-query-functions ,
-        conf10gtx:relate-query-function ,
-        conf10gtx:sf-query-functions ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Topology Extension"@en ;
-.
-
-confs11:topology-extension
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires 
-        confs11:core ,
-        confs10:topology-extension ;          
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Topology Extension"@en ;
-.
-
-confs10:geometry-extension
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires confs10:core ;
-    skos:member
-        conf10gx:feature-properties ,
-        conf10gx:geometry-as-gml-literal ,
-        conf10gx:geometry-as-wkt-literal ,
-        conf10gx:geometry-properties ,
-        conf10gx:gml-literal ,
-        conf10gx:gml-literal-empty ,
-        conf10gx:gml-profile ,
-        conf10gx:query-functions ,
-        conf10gx:srid-function ,
-        conf10gx:wkt-axis-order ,
-        conf10gx:wkt-literal ,
-        conf10gx:wkt-literal-default-srs ,
-        conf10gx:wkt-literal-empty ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Geometry Extension"@en ;
-.
-
-confs11:geometry-extension
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires 
-        confs11:core ,
-        confs10:geometry-extension ;
-    skos:member
-        conf11gx:geojson-literal ,
-        conf11gx:geojson-literal-empty ,
-        conf11gx:geojson-literal-srs ,
-        conf11gx:geometry-as-geojson-literal ,
-        conf11gx:geometry-as-kml-literal ,
-        conf11gx:geometry-properties ,
-        conf11gx:kml-literal ,
-        conf11gx:kml-literal-empty ,
-        conf11gx:kml-literal-srs ,
-        conf11gx:query-functions ,
-        conf11gx:query-functions-non-sf ,
-        conf11gx:sa-functions ;
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Geometry Extension"@en ;
-.
-
-confs11:geometry-extension-dggs
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires confs11:core ;
-    skos:member
-        conf10gx:geometry-class ,
-        conf10gx:query-functions ,
-        conf10gx:srid-function ,        
-        conf11gx:dggs-literal ,
-        conf11gx:dggs-literal-empty ,
-        conf11gx:dggs-literal-srs ,
-        conf11gx:feature-properties ,
-        conf11gx:query-functions ,
-        conf11gx:query-functions-non-sf ,
-        conf11gx:sa-functions ;
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Geometry Extension - DGGS"@en ;
-.
-
-confs10:geometry-topology-extension
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires
-        confs10:geometry-extension ,
-        confs10:topology-extension ;
-    skos:member
-        conf10gtx:eh-query-functions ,
-        conf10gtx:rcc8-query-functions ,
-        conf10gtx:relate-query-function ,
-        conf10gtx:sf-query-functions ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Geometry Topology Extension"@en ;
-.
-
-confs11:geometry-topology-extension
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires
-        confs11:geometry-extension ,
-        confs11:topology-extension ,
-        confs10:geometry-topology-extension ;       
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Geometry Topology Extension"@en ;
-.
-
-confs10:query-rewrite-extension
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires confs10:geometry-topology-extension ;
-    skos:member
-        conf10qre:eh-query-rewrite ,
-        conf10qre:rcc8-query-rewrite ,
-        conf10qre:sf-query-rewrite ;
-    skos:notation "" ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Query Rewrite Extension"@en ;
-.
-
-conf11qre:query-rewrite-extension
-    a 
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires 
-        confs11:geometry-topology-extension ,
-        confs10:query-rewrite-extension ;
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Query Rewrite Extension"@en ;
-.
-
-confs10:rdfs-entailment-extension
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;
-    dcterms:requires confs10:geometry-topology-extension ;
-    skos:member
-        conf10ree:bgp-rdfs-ent ,
-        conf10ree:gml-geometry-types ,
-        conf10ree:wkt-geometry-types ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: RDFS Entailment Extension"@en ;
-.
-
-confs11:rdfs-entailment-extension
-    a
-        spec:ConformanceClass ,
-        skos:Collection, sd:Feature ;      
-    dcterms:requires 
-        confs11:geometry-topology-extension ,
-        confs10:rdfs-entailment-extension ;
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: RDFS Entailment Extension"@en ;
-.
-
-conf10ree:bgp-rdfs-ent
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs10ree:bgp-rdfs-ent ;
-    skos:definition "Verify that a set of SPARQL queries involving entailed RDF triples returns the correct result for a test dataset using the specified serialization, version and relation_family"@en ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: BGP RDFS Entailment"@en ;
-.
-
-conf10ree:gml-geometry-types
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs10ree:gml-geometry-types ;
-    skos:definition "Verify that a set of SPARQL queries involving GML Geometry types returns the correct result for a test dataset using the specified version of GML"@en ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: GML Geometry Types"@en ;
-.
-
-conf10ree:wkt-geometry-types
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs10ree:wkt-geometry-types ;
-    skos:definition "Verify that a set of SPARQL queries involving WKT Geometry types returns the correct result for a test dataset using the specified version of Simple Features"@en ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: WKT Geometry Types"@en ;
+<http://www.opengis.net/def/geosparql/reqs>
+    a skos:ConceptScheme ;
+    dcterms:created "2021-06-28"^^xsd:date ;
+    dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
+    dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
+    dcterms:modified "2022-06-16"^^xsd:date ;
+    dcterms:publisher [
+            a sdo:Organization ;
+            sdo:name "Open Geospatial Consortium" ;
+            sdo:url "https://www.ogc.org"^^xsd:anyURI
+        ] ;
+    dcterms:rights "(c) 2022 Open Geospatial Consortium" ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/reqs/1.1> ;
+    owl:versionInfo "OGC GeoSPARQL 1.1" ;
+    skos:definition "A vocabulary of the requirements and conformance classes in the GeoSPARQL 1.1 specification"@en ;
+    skos:prefLabel "GeoSPARQL 1.1 Requirements and Conformance Class Register"@en ;
 .
 
 conf10tve:eh-spatial-relations
@@ -359,6 +149,26 @@ conf11core:geometry-collection-class
     skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Geometry Collection Class"@en ;
 .
 
+confs11:geometry-extension-dggs
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires confs11:core ;
+    skos:member
+        conf10gx:geometry-class ,
+        conf10gx:query-functions ,
+        conf10gx:srid-function ,
+        conf11gx:dggs-literal ,
+        conf11gx:dggs-literal-empty ,
+        conf11gx:dggs-literal-srs ,
+        conf11gx:feature-properties ,
+        conf11gx:query-functions ,
+        conf11gx:query-functions-non-sf ,
+        conf11gx:sa-functions ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Geometry Extension - DGGS"@en ;
+.
+
 conf11gx:geometry-as-dggs-function
     a spec:ConformanceTest ;
     spec:testPurpose "check conformance with this requirement"@en ;
@@ -366,6 +176,15 @@ conf11gx:geometry-as-dggs-function
     rdfs:seeAlso reqs11gx:geometry-as-dggs-function ;
     skos:definition "Verify that a set of SPARQL queries involving the geof:asDGGS function returns the correct result for a test dataset when using the specified serialization and version"@en ;
     skos:prefLabel "GeoSPARQL 1.1 Conformance Test: asDGGS Function"@en ;
+.
+
+conf11gx:geometry-as-dggs-literal
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement" ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs11gx:geometry-as-dggs-literal ;
+    skos:definition "Verify that queries involving the geo:asDGGS property return the correct result for a test dataset"@en ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Geometry asDGGS Literal"@en ;
 .
 
 conf11gx:geometry-as-geojson-function
@@ -420,6 +239,28 @@ conf11gx:query-functions-non-sf-dggs
     rdfs:seeAlso reqs11gx:query-functions-non-sf-dggs ;
     skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:area, geof:geometryN, geof:length, geof:maxX, geof:maxY, geof:maxZ, geof:minX, geof:minY, geof:minZ, geof:numGeometries and geof:projectTo for DGGS geometry literals"@en ;
     skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Query Functions, non Simple Features, DGGS"@en ;
+.
+
+conf11qre:query-rewrite-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires
+        confs10:query-rewrite-extension ,
+        confs11:geometry-topology-extension ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Query Rewrite Extension"@en ;
+.
+
+confs11:rdfs-entailment-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires
+        confs10:rdfs-entailment-extension ,
+        confs11:geometry-topology-extension ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: RDFS Entailment Extension"@en ;
 .
 
 conf10core:feature-class
@@ -512,24 +353,6 @@ conf10gx:gml-profile
     skos:prefLabel "GeoSPARQL 1.0 Conformance Test: GML Profile"@en ;
 .
 
-conf10gx:query-functions
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs10gx:query-functions ;
-    skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:distance, geof:buffer, geof:convexHull, geof:intersection, geof:union, geof:difference,geof:symDifference, geof:envelope and geof:boundary"@en ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Query Functions"@en ;
-.
-
-conf10gx:srid-function
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs10gx:srid-function ;
-    skos:definition "Verify that a SPARQL query involving the geof:getSRID function returns the correct result for a test dataset when using the specified serialization and version"@en ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SRID Function"@en ;
-.
-
 conf10gx:wkt-axis-order
     a spec:ConformanceTest ;
     spec:testPurpose "check conformance with this requirement"@en ;
@@ -566,6 +389,87 @@ conf10gx:wkt-literal-empty
     skos:prefLabel "GeoSPARQL 1.0 Conformance Test: WKT Literal Empty"@en ;
 .
 
+confs10:query-rewrite-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires confs10:geometry-topology-extension ;
+    skos:member
+        conf10qre:eh-query-rewrite ,
+        conf10qre:rcc8-query-rewrite ,
+        conf10qre:sf-query-rewrite ;
+    skos:notation "" ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Query Rewrite Extension"@en ;
+.
+
+conf10qre:eh-query-rewrite
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs10qre:eh-query-rewrite ;
+    skos:definition "Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: geor:ehEquals, geor:ehDisjoint, geor:ehMeet, geor:ehOverlap, geor:ehCovers, geor:ehCoveredBy, geor:ehInside, geor:ehContains"@en ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: EH Query Rewrite"@en ;
+.
+
+conf10qre:rcc8-query-rewrite
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs10qre:rcc8-query-rewrite ;
+    skos:definition "Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: geor:rcc8eq, geor:rcc8dc, geor:rcc8ec, geor:rcc8po, geor:rcc8tppi, geor:rcc8tpp, geor:rcc8ntpp, geor:rcc8ntppi"@en ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: RCC8 Query Rewrite"@en ;
+.
+
+conf10qre:sf-query-rewrite
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs10qre:sf-query-rewrite ;
+    skos:definition "Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: geor:sfEquals, geor:sfDisjoint, geor:sfIntersects, geor:sfTouches, geor:sfCrosses, geor:sfWithin, geor:sfContains and geor:sfOverlaps"@en ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SF Query Rewrite"@en ;
+.
+
+confs10:rdfs-entailment-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires confs10:geometry-topology-extension ;
+    skos:member
+        conf10ree:bgp-rdfs-ent ,
+        conf10ree:gml-geometry-types ,
+        conf10ree:wkt-geometry-types ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: RDFS Entailment Extension"@en ;
+.
+
+conf10ree:bgp-rdfs-ent
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs10ree:bgp-rdfs-ent ;
+    skos:definition "Verify that a set of SPARQL queries involving entailed RDF triples returns the correct result for a test dataset using the specified serialization, version and relation_family"@en ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: BGP RDFS Entailment"@en ;
+.
+
+conf10ree:gml-geometry-types
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs10ree:gml-geometry-types ;
+    skos:definition "Verify that a set of SPARQL queries involving GML Geometry types returns the correct result for a test dataset using the specified version of GML"@en ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: GML Geometry Types"@en ;
+.
+
+conf10ree:wkt-geometry-types
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs10ree:wkt-geometry-types ;
+    skos:definition "Verify that a set of SPARQL queries involving WKT Geometry types returns the correct result for a test dataset using the specified version of Simple Features"@en ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: WKT Geometry Types"@en ;
+.
+
 conf11core:feature-collection-class
     a spec:ConformanceTest ;
     spec:testPurpose "check conformance with this requirement"@en ;
@@ -599,6 +503,30 @@ conf11core:spatial-object-properties
     rdfs:seeAlso reqs11core:spatial-object-properties ;
     skos:definition "Verify that queries involving these properties return the correct result for a test dataset"@en ;
     skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Spatial Object Properties"@en ;
+.
+
+confs11:geometry-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires
+        confs10:geometry-extension ,
+        confs11:core ;
+    skos:member
+        conf11gx:geojson-literal ,
+        conf11gx:geojson-literal-empty ,
+        conf11gx:geojson-literal-srs ,
+        conf11gx:geometry-as-geojson-literal ,
+        conf11gx:geometry-as-kml-literal ,
+        conf11gx:geometry-properties ,
+        conf11gx:kml-literal ,
+        conf11gx:kml-literal-empty ,
+        conf11gx:kml-literal-srs ,
+        conf11gx:query-functions ,
+        conf11gx:query-functions-non-sf ,
+        conf11gx:sa-functions ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Geometry Extension"@en ;
 .
 
 conf11gx:dggs-literal
@@ -655,15 +583,6 @@ conf11gx:geojson-literal-srs
     skos:prefLabel "GeoSPARQL 1.1 Conformance Test: GeoJSON Literal Default SRS"@en ;
 .
 
-conf11gx:geometry-as-dggs-literal
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement" ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs11gx:geometry-as-dggs-literal ;
-    skos:definition "Verify that queries involving the geo:asDGGS property return the correct result for a test dataset"@en ;
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Geometry asDGGS Literal"@en ;
-.
-
 conf11gx:geometry-as-geojson-literal
     a spec:ConformanceTest ;
     spec:testPurpose "check conformance with this requirement"@en ;
@@ -718,31 +637,15 @@ conf11gx:kml-literal-srs
     skos:prefLabel "GeoSPARQL 1.1 Conformance Test: KML Literal Default SRS"@en ;
 .
 
-conf11gx:query-functions
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs11gx:query-functions ;
-    skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:boundary geof:buffer, geof:convexHull, geof:coordinateDimension, geof:difference, geof:dimension, geof:distance, geof:envelope, geof:geometryType, geof:getSRID, geof:intersection, geof:is3D, geof:isEmpty, geof:isMeasured, geof:isSimple, geof:spatialDimension, geof:symDifference, geof:transform and geof:union  for non-DGGS geometry literals"@en ;
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Query Functions"@en ;
-.
-
-conf11gx:query-functions-non-sf
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs11gx:query-functions-non-sf ;
-    skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:area, geof:geometryN, geof:length, geof:maxX, geof:maxY, geof:maxZ, geof:minX, geof:minY, geof:minZ, geof:numGeometries and geof:projectTo for non-DGGS geometry literals" ;
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Query Functions, non Simple Features"@en ;
-.
-
-conf11gx:sa-functions
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement" ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs11gx:sa-functions ;
-    skos:definition "Verify that queries involving these functions return the correct result for a test dataset"@en ;
-    skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Spatial Aggregate Functions"@en ;
+confs11:topology-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires
+        confs10:topology-extension ,
+        confs11:core ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Topology Extension"@en ;
 .
 
 reqs11core:feature-collection-class
@@ -808,6 +711,47 @@ conf10core:sparql-protocol
     skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SPARQL Protocol"@en ;
 .
 
+confs10:geometry-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires confs10:core ;
+    skos:member
+        conf10gx:feature-properties ,
+        conf10gx:geometry-as-gml-literal ,
+        conf10gx:geometry-as-wkt-literal ,
+        conf10gx:geometry-properties ,
+        conf10gx:gml-literal ,
+        conf10gx:gml-literal-empty ,
+        conf10gx:gml-profile ,
+        conf10gx:query-functions ,
+        conf10gx:srid-function ,
+        conf10gx:wkt-axis-order ,
+        conf10gx:wkt-literal ,
+        conf10gx:wkt-literal-default-srs ,
+        conf10gx:wkt-literal-empty ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Geometry Extension"@en ;
+.
+
+conf10gx:query-functions
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs10gx:query-functions ;
+    skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:distance, geof:buffer, geof:convexHull, geof:intersection, geof:union, geof:difference,geof:symDifference, geof:envelope and geof:boundary"@en ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: Query Functions"@en ;
+.
+
+conf10gx:srid-function
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs10gx:srid-function ;
+    skos:definition "Verify that a SPARQL query involving the geof:getSRID function returns the correct result for a test dataset when using the specified serialization and version"@en ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SRID Function"@en ;
+.
+
 conf10gtx:eh-query-functions
     a spec:ConformanceTest ;
     spec:testPurpose "check conformance with this requirement"@en ;
@@ -844,31 +788,18 @@ conf10gtx:sf-query-functions
     skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SF Query Functions"@en ;
 .
 
-conf10qre:eh-query-rewrite
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs10qre:eh-query-rewrite ;
-    skos:definition "Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: geor:ehEquals, geor:ehDisjoint, geor:ehMeet, geor:ehOverlap, geor:ehCovers, geor:ehCoveredBy, geor:ehInside, geor:ehContains"@en ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: EH Query Rewrite"@en ;
-.
-
-conf10qre:rcc8-query-rewrite
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs10qre:rcc8-query-rewrite ;
-    skos:definition "Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: geor:rcc8eq, geor:rcc8dc, geor:rcc8ec, geor:rcc8po, geor:rcc8tppi, geor:rcc8tpp, geor:rcc8ntpp, geor:rcc8ntppi"@en ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: RCC8 Query Rewrite"@en ;
-.
-
-conf10qre:sf-query-rewrite
-    a spec:ConformanceTest ;
-    spec:testPurpose "check conformance with this requirement"@en ;
-    spec:testType spec:Capabilities ;
-    rdfs:seeAlso reqs10qre:sf-query-rewrite ;
-    skos:definition "Verify that queries involving the following query transformation rules return the correct result for a test dataset when using the specified serialization and version: geor:sfEquals, geor:sfDisjoint, geor:sfIntersects, geor:sfTouches, geor:sfCrosses, geor:sfWithin, geor:sfContains and geor:sfOverlaps"@en ;
-    skos:prefLabel "GeoSPARQL 1.0 Conformance Test: SF Query Rewrite"@en ;
+confs10:topology-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires confs10:core ;
+    skos:member
+        conf10gtx:eh-query-functions ,
+        conf10gtx:rcc8-query-functions ,
+        conf10gtx:relate-query-function ,
+        conf10gtx:sf-query-functions ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Topology Extension"@en ;
 .
 
 reqs10core:feature-class
@@ -1022,6 +953,45 @@ reqs10tve:sf-spatial-relations
     skos:prefLabel "GeoSPARQL 1.0 Requirement: SF Spatial Relations"@en ;
 .
 
+conf11gx:query-functions
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs11gx:query-functions ;
+    skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:boundary geof:buffer, geof:convexHull, geof:coordinateDimension, geof:difference, geof:dimension, geof:distance, geof:envelope, geof:geometryType, geof:getSRID, geof:intersection, geof:is3D, geof:isEmpty, geof:isMeasured, geof:isSimple, geof:spatialDimension, geof:symDifference, geof:transform and geof:union  for non-DGGS geometry literals"@en ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Query Functions"@en ;
+.
+
+conf11gx:query-functions-non-sf
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement"@en ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs11gx:query-functions-non-sf ;
+    skos:definition "Verify that a set of SPARQL queries involving each of the following functions returns the correct result for a test dataset when using the specified serialization and version: geof:area, geof:geometryN, geof:length, geof:maxX, geof:maxY, geof:maxZ, geof:minX, geof:minY, geof:minZ, geof:numGeometries and geof:projectTo for non-DGGS geometry literals" ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Query Functions, non Simple Features"@en ;
+.
+
+conf11gx:sa-functions
+    a spec:ConformanceTest ;
+    spec:testPurpose "check conformance with this requirement" ;
+    spec:testType spec:Capabilities ;
+    rdfs:seeAlso reqs11gx:sa-functions ;
+    skos:definition "Verify that queries involving these functions return the correct result for a test dataset"@en ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Test: Spatial Aggregate Functions"@en ;
+.
+
+confs11:geometry-topology-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires
+        confs10:geometry-topology-extension ,
+        confs11:geometry-extension ,
+        confs11:topology-extension ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Geometry Topology Extension"@en ;
+.
+
 reqs11core:sparql-protocol
     a spec:Requirement ;
     skos:definition "Implementations shall support the SPARQL Query Language for RDF [SPARQL], the SPARQL Protocol [SPARQLPROT] and the SPARQL Query Results XML [SPARQLRESX] and JSON [SPARQLRESJ] Formats"@en ;
@@ -1137,6 +1107,34 @@ reqs11gx:query-functions-non-sf-dggs
     prov1:wasDerivedFrom reqs10gx:query-functions ;
 .
 
+confs10:core
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    skos:member
+        conf10core:feature-class ,
+        conf10core:sparql-protocol ,
+        conf10core:spatial-object-class ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Core"@en ;
+.
+
+confs10:geometry-topology-extension
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires
+        confs10:geometry-extension ,
+        confs10:topology-extension ;
+    skos:member
+        conf10gtx:eh-query-functions ,
+        conf10gtx:rcc8-query-functions ,
+        conf10gtx:relate-query-function ,
+        conf10gtx:sf-query-functions ;
+    skos:prefLabel "GeoSPARQL 1.0 Conformance Class: Geometry Topology Extension"@en ;
+.
+
 reqs10core:sparql-protocol
     a spec:Requirement ;
     skos:definition "Implementations shall support the SPARQL Query Language for RDF, the SPARQL Protocol for RDF and the SPARQL Query Results XML Format"@en ;
@@ -1161,9 +1159,23 @@ reqs10gx:gml-literal
     skos:prefLabel "GeoSPARQL 1.0 Requirement: GML Literal"@en ;
 .
 
+confs11:core
+    a
+        spec:ConformanceClass ,
+        skos:Collection ,
+        sd:Feature ;
+    dcterms:requires confs10:core ;
+    skos:member
+        conf11core:feature-collection-class ,
+        conf11core:sparql-protocol ,
+        conf11core:spatial-object-class ,
+        conf11core:spatial-object-collection-class ,
+        conf11core:spatial-object-properties ;
+    skos:prefLabel "GeoSPARQL 1.1 Conformance Class: Core"@en ;
+.
+
 reqs10gx:query-functions
     a spec:Requirement ;
     skos:definition "Implementations shall support geof:distance, geof:buffer, geof:convexHull, geof:intersection, geof:union, geof:difference, geof:symDifference, geof:envelope and geof:boundary as SPARQL extension functions, consistent with the definitions of the corresponding functions (distance, buffer, convexHull, intersection, difference, symDifference, envelope and boundary respectively) in Simple Features [ISO 19125-1]"@en ;
     skos:prefLabel "GeoSPARQL 1.0 Requirement: Query Functions"@en ;
 .
-

--- a/1.1/reqs.ttl
+++ b/1.1/reqs.ttl
@@ -41,8 +41,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                                                 sdo:name "Open Geospatial Consortium" ;
                                                 sdo:url "https://www.ogc.org"^^xsd:anyURI ;
                                              ] ;                                             
-	                                     dcterms:rights "(c) 2022 Open Geospatial Consortium" ;
-                                             skos:prefLabel "GeoSPARQL 1.1 Requirements and Conformance Class Register"@en .
+	                                         dcterms:rights "(c) 2022 Open Geospatial Consortium" ;
+                                             skos:prefLabel "GeoSPARQL 1.1 Requirements and Conformance Class Register"@en ;
+                                             owl:versionInfo "OGC GeoSPARQL 1.1" ;
+                                             owl:versionIRI <http://www.opengis.net/def/geosparql/reqs/1.1> .
 
 
 confs10:core

--- a/1.1/sa_functions.ttl
+++ b/1.1/sa_functions.ttl
@@ -1,78 +1,86 @@
-BASE <http://www.opengis.net/def/geosparql/safuncs>
-
-PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX status: <http://www.opengis.net/def/status/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX sdo: <https://schema.org/>
-PREFIX policy: <http://www.opengis.net/def/metamodel/ogc-na/>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX policy: <http://www.opengis.net/def/metamodel/ogc-na/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sdo: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX status: <http://www.opengis.net/def/status/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<http://www.opengis.net/def/geosparql/safuncs> 
-    a owl:Ontology , skos:ConceptScheme ;
+<http://www.opengis.net/def/geosparql/safuncs>
+    a
+        owl:Ontology ,
+        skos:ConceptScheme ;
     dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
-    dcterms:modified "2022-06-16"^^xsd:date ;
-    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "A vocabulary (taxonomy) of the spatial aggregate functions defined within the GeoSPARQL 1.1 specification"@en ;
     dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
-	dcterms:publisher [
-		a sdo:Organization ;
-		sdo:name "Open Geospatial Consortium" ;
-		sdo:url "https://www.ogc.org"^^xsd:anyURI ;
-	] ;    
-	dcterms:rights "(c) 2021 Open Geospatial Consortium" ;
+    dcterms:modified "2022-06-16"^^xsd:date ;
+    dcterms:publisher [
+            a sdo:Organization ;
+            sdo:name "Open Geospatial Consortium" ;
+            sdo:url "https://www.ogc.org"^^xsd:anyURI
+        ] ;
+    dcterms:rights "(c) 2021 Open Geospatial Consortium" ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/safuncs/1.1> ;
+    owl:versionInfo "OGC GeoSPARQL 1.1" ;
+    skos:definition "A vocabulary (taxonomy) of the spatial aggregate functions defined within the GeoSPARQL 1.1 specification"@en ;
     skos:hasTopConcept
-        geof:aggBoundingBox,
-        geof:aggBoundingCircle,
-        geof:aggCentroid,
-        geof:aggConcaveHull,
-        geof:aggConvexHull,
+        geof:aggBoundingBox ,
+        geof:aggBoundingCircle ,
+        geof:aggCentroid ,
+        geof:aggConcaveHull ,
+        geof:aggConvexHull ,
         geof:aggUnion ;
     skos:prefLabel "GeoSPARQL Spatial Aggregate Functions" ;
-    owl:versionInfo "OGC GeoSPARQL 1.1" ;
-    owl:versionIRI <http://www.opengis.net/def/geosparql/safuncs/1.1> ;
 .
 
-geof:aggBoundingCircle a skos:Concept ;
+geof:aggBoundingCircle
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A spatial aggregate function that calculates the minimum bounding circle of set of geometries."@en ;
-    skos:prefLabel "bounding circle"@en .
+    skos:prefLabel "bounding circle"@en ;
+.
 
-geof:aggCentroid a skos:Concept ;
+geof:aggCentroid
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A spatial aggregate function that calculates a centroid of a set of geometries."@en ;
-    skos:prefLabel "centroid"@en .
+    skos:prefLabel "centroid"@en ;
+.
 
-geof:aggConcaveHull a skos:Concept ;
+geof:aggConcaveHull
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A spatial aggregate function that calculates the concave hull of a set of geometries."@en ;
-    skos:prefLabel "concave hull"@en .
+    skos:prefLabel "concave hull"@en ;
+.
 
-geof:aggConvexHull a skos:Concept ;
+geof:aggConvexHull
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A spatial aggregate function that calculates the convex hull of a set of geometries."@en ;
-    skos:prefLabel "convex hull aggregate function"@en .    
+    skos:prefLabel "convex hull aggregate function"@en ;
+.
 
-geof:aggUnion a skos:Concept ;
+geof:aggUnion
+    a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "A spatial aggregate function that calculates the union of a set of geometries."@en ;
-    skos:prefLabel "union aggregate function"@en .
+    skos:prefLabel "union aggregate function"@en ;
+.

--- a/1.1/sa_functions.ttl
+++ b/1.1/sa_functions.ttl
@@ -32,7 +32,10 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         geof:aggConcaveHull,
         geof:aggConvexHull,
         geof:aggUnion ;
-    skos:prefLabel "GeoSPARQL Spatial Aggregate Functions" .
+    skos:prefLabel "GeoSPARQL Spatial Aggregate Functions" ;
+    owl:versionInfo "OGC GeoSPARQL 1.1" ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/safuncs/1.1> ;
+.
 
 geof:aggBoundingCircle a skos:Concept ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;

--- a/1.1/servicedescription/servicedescription_all_functions.ttl
+++ b/1.1/servicedescription/servicedescription_all_functions.ttl
@@ -1,89 +1,90 @@
-@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
-@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+PREFIX ent: <http://www.w3.org/ns/entailment/>
+PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix geof: <http://www.opengis.net/def/function/geosparql/> .
-@prefix ent: <http://www.w3.org/ns/entailment/> .
-@prefix prof: <http://www.w3.org/ns/owl-profile/> .
-@prefix void: <http://rdfs.org/ns/void#> .
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-<http://www.opengis.net/def/geosparql/servicedescallfunctions> 
-	a sd:Service, skos:ConceptScheme ;
-	owl:versionInfo "OGC GeoSPARQL 1.1" ;
+<http://www.opengis.net/def/geosparql/servicedescallfunctions>
+    a
+        skos:ConceptScheme ,
+        sd:Service ;
     owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescallfunctions/1.1> ;
+    owl:versionInfo "OGC GeoSPARQL 1.1" ;
     skos:prefLabel "GeoSPARQL 1.1 SPARQL Service Description: All Functions" ;
+    sd:defaultEntailmentRegime ent:RDFS ;
+    sd:extensionAggregate
+        geof:aggBoundingCircle ,
+        geof:aggCentroid ,
+        geof:aggConcaveHull ,
+        geof:aggConvexHull ,
+        geof:aggUnion ;
+    sd:extensionFunction
+        geof:area ,
+        geof:asDGGS ,
+        geof:asGML ,
+        geof:asGeoJSON ,
+        geof:asKML ,
+        geof:asWKT ,
+        geof:boundary ,
+        geof:boundingCircle ,
+        geof:buffer ,
+        geof:centroid ,
+        geof:concaveHull ,
+        geof:convexHull ,
+        geof:coordinateDimension ,
+        geof:difference ,
+        geof:dimension ,
+        geof:distance ,
+        geof:ehContains ,
+        geof:ehCoveredBy ,
+        geof:ehCovers ,
+        geof:ehDisjoint ,
+        geof:ehEquals ,
+        geof:ehInside ,
+        geof:ehMeet ,
+        geof:ehOverlap ,
+        geof:envelope ,
+        geof:geometryN ,
+        geof:geometryType ,
+        geof:getSRID ,
+        geof:intersection ,
+        geof:is3D ,
+        geof:isEmpty ,
+        geof:isMeasured ,
+        geof:isSimple ,
+        geof:length ,
+        geof:maxX ,
+        geof:maxY ,
+        geof:maxZ ,
+        geof:metricBuffer ,
+        geof:metricDistance ,
+        geof:minX ,
+        geof:minY ,
+        geof:minZ ,
+        geof:numGeometries ,
+        geof:rcc8dc ,
+        geof:rcc8ec ,
+        geof:rcc8eq ,
+        geof:rcc8ntpp ,
+        geof:rcc8ntppi ,
+        geof:rcc8po ,
+        geof:rcc8tpp ,
+        geof:rcc8tppi ,
+        geof:relate ,
+        geof:sfContains ,
+        geof:sfCrosses ,
+        geof:sfDisjoint ,
+        geof:sfEquals ,
+        geof:sfIntersects ,
+        geof:sfOverlaps ,
+        geof:sfTouches ,
+        geof:sfWithin ,
+        geof:spatialDimension ,
+        geof:symDifference ,
+        geof:transform ,
+        geof:union ;
+    sd:resultFormat
+        <http://www.w3.org/ns/formats/RDF_XML> ,
+        <http://www.w3.org/ns/formats/Turtle> ;
     sd:supportedLanguage sd:SPARQL11Query ;
-	sd:extensionAggregate geof:aggBoundingCircle;
-	sd:extensionAggregate geof:aggCentroid;
-	sd:extensionAggregate geof:aggConcaveHull;
-	sd:extensionAggregate geof:aggConvexHull;
-	sd:extensionAggregate geof:aggUnion;
-	sd:extensionFunction geof:area;
-	sd:extensionFunction geof:asDGGS;
-	sd:extensionFunction geof:asKML;
-	sd:extensionFunction geof:asGeoJSON;
-	sd:extensionFunction geof:asGML;
-	sd:extensionFunction geof:asWKT;
-	sd:extensionFunction geof:boundary;
-	sd:extensionFunction geof:boundingCircle;
-	sd:extensionFunction geof:buffer;
-	sd:extensionFunction geof:centroid;
-	sd:extensionFunction geof:concaveHull;
-	sd:extensionFunction geof:convexHull;
-	sd:extensionFunction geof:coordinateDimension;
-	sd:extensionFunction geof:difference;
-	sd:extensionFunction geof:dimension;
-	sd:extensionFunction geof:distance;
-	sd:extensionFunction geof:ehContains;
-	sd:extensionFunction geof:ehCoveredBy;
-	sd:extensionFunction geof:ehCovers;
-	sd:extensionFunction geof:ehDisjoint;
-	sd:extensionFunction geof:ehEquals;
-	sd:extensionFunction geof:ehInside;
-	sd:extensionFunction geof:ehMeet;
-	sd:extensionFunction geof:ehOverlap;
-	sd:extensionFunction geof:envelope;
-	sd:extensionFunction geof:getSRID;
-	sd:extensionFunction geof:geometryN;
-	sd:extensionFunction geof:geometryType;
-	sd:extensionFunction geof:intersection;
-	sd:extensionFunction geof:is3D;
-	sd:extensionFunction geof:isEmpty;
-	sd:extensionFunction geof:isMeasured;
-	sd:extensionFunction geof:isSimple;
-	sd:extensionFunction geof:length;
-	sd:extensionFunction geof:metricBuffer;
-	sd:extensionFunction geof:metricDistance;
-	sd:extensionFunction geof:minX;
-	sd:extensionFunction geof:minY;
-	sd:extensionFunction geof:minZ;
-	sd:extensionFunction geof:maxX;
-	sd:extensionFunction geof:maxY;
-	sd:extensionFunction geof:maxZ;
-	sd:extensionFunction geof:numGeometries;
-	sd:extensionFunction geof:transform;
-	sd:extensionFunction geof:rcc8dc;
-	sd:extensionFunction geof:rcc8ec;
-	sd:extensionFunction geof:rcc8eq;
-	sd:extensionFunction geof:rcc8ntpp;
-	sd:extensionFunction geof:rcc8ntppi;
-	sd:extensionFunction geof:rcc8po;
-	sd:extensionFunction geof:rcc8tpp;
-	sd:extensionFunction geof:rcc8tppi;
-	sd:extensionFunction geof:relate;
-	sd:extensionFunction geof:spatialDimension;
-	sd:extensionFunction geof:sfContains;
-	sd:extensionFunction geof:sfCrosses;
-	sd:extensionFunction geof:sfDisjoint;
-	sd:extensionFunction geof:sfEquals;
-	sd:extensionFunction geof:sfIntersects;
-	sd:extensionFunction geof:sfOverlaps;
-	sd:extensionFunction geof:sfTouches;
-	sd:extensionFunction geof:sfWithin;
-	sd:extensionFunction geof:symDifference;
-	sd:extensionFunction geof:union;
-    sd:resultFormat <http://www.w3.org/ns/formats/RDF_XML>, <http://www.w3.org/ns/formats/Turtle> ;
-    sd:defaultEntailmentRegime ent:RDFS
 .
-
-

--- a/1.1/servicedescription/servicedescription_all_functions.ttl
+++ b/1.1/servicedescription/servicedescription_all_functions.ttl
@@ -1,12 +1,16 @@
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix geof: <http://www.opengis.net/def/function/geosparql/> .
 @prefix ent: <http://www.w3.org/ns/entailment/> .
 @prefix prof: <http://www.w3.org/ns/owl-profile/> .
 @prefix void: <http://rdfs.org/ns/void#> .
 
-<http://www.opengis.net/def/geosparql/servicedescallfunctions> a sd:Service, skos:ConceptScheme ;
+<http://www.opengis.net/def/geosparql/servicedescallfunctions> 
+	a sd:Service, skos:ConceptScheme ;
+	owl:versionInfo "OGC GeoSPARQL 1.1" ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescallfunctions/1.1> ;
     skos:prefLabel "GeoSPARQL 1.1 SPARQL Service Description: All Functions" ;
     sd:supportedLanguage sd:SPARQL11Query ;
 	sd:extensionAggregate geof:aggBoundingCircle;

--- a/1.1/servicedescription/servicedescription_conformanceclasses.ttl
+++ b/1.1/servicedescription/servicedescription_conformanceclasses.ttl
@@ -1,80 +1,77 @@
-@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
-@prefix geo: <http://www.opengis.net/ont/geosparql#> .
-@prefix ent: <http://www.w3.org/ns/entailment/> .
+PREFIX conf10core: <http://www.opengis.net/spec/geosparql/1.0/conf/core/>
+PREFIX conf10gtx: <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-topology-extension/>
+PREFIX conf10gx: <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-extension/>
+PREFIX conf10qre: <http://www.opengis.net/spec/geosparql/1.0/conf/query-rewrite-extension/>
+PREFIX conf11core: <http://www.opengis.net/spec/geosparql/1.1/conf/core/>
+PREFIX conf11gx: <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension/>
+PREFIX ent: <http://www.w3.org/ns/entailment/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
-@prefix prof: <http://www.w3.org/ns/owl-profile/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix conf10core: <http://www.opengis.net/spec/geosparql/1.0/conf/core/> .
-@prefix conf11core: <http://www.opengis.net/spec/geosparql/1.1/conf/core/> .
-@prefix conf10gx: <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-extension/> .
-@prefix conf11gx: <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension/> .
-@prefix conf10gtx: <http://www.opengis.net/spec/geosparql/1.0/conf/geometry-topology-extension/> .
-@prefix conf11gtx: <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-topology-extension/> .
-@prefix conf10qre: <http://www.opengis.net/spec/geosparql/1.0/conf/query-rewrite-extension/> .
-@prefix conf11qre: <http://www.opengis.net/spec/geosparql/1.1/conf/query-rewrite-extension/> .
-@prefix conf10ree: <http://www.opengis.net/spec/geosparql/1.0/conf/rdfs-entailment-extension/> .
-@prefix conf11ree: <http://www.opengis.net/spec/geosparql/1.1/conf/rdfs-entailment-extension/> .
-@prefix conf10tve: <http://www.opengis.net/spec/geosparql/1.0/conf/topology-vocab-extension/> .
-@prefix conf11tve: <http://www.opengis.net/spec/geosparql/1.1/conf/topology-vocab-extension/> .
-@prefix void: <http://rdfs.org/ns/void#> .
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-<http://www.opengis.net/def/geosparql/servicedescconformanceclasses> 
-    a sd:Service, skos:ConceptScheme ;
-	owl:versionInfo "OGC GeoSPARQL 1.1" ;
-    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescconformanceclasses/1.1> ;    
+<http://www.opengis.net/def/geosparql/servicedescconformanceclasses>
+    a
+        skos:ConceptScheme ,
+        sd:Service ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescconformanceclasses/1.1> ;
+    owl:versionInfo "OGC GeoSPARQL 1.1" ;
     skos:prefLabel "GeoSPARQL 1.1 SPARQL Service Description: All Conformance Classes" ;
+    sd:defaultEntailmentRegime ent:RDFS ;
+    sd:feature
+        conf10core:feature-class ,
+        conf10core:spatial-object-class ,
+        conf10gx:feature-properties ,
+        conf10gx:geometry-as-gml-literal ,
+        conf10gx:geometry-as-wkt-literal ,
+        conf10gx:geometry-class ,
+        conf10gx:geometry-properties ,
+        conf10gx:gml-literal ,
+        conf10gx:gml-literal-empty ,
+        conf10gx:gml-profile ,
+        conf10gx:query-functions ,
+        conf10gx:srid-function ,
+        conf10gx:wkt-axis-order ,
+        conf10gx:wkt-literal ,
+        conf10gx:wkt-literal-default-srs ,
+        conf10gx:wkt-literal-empty ,
+        conf10gtx:eh-query-functions ,
+        conf10gtx:rcc8-query-functions ,
+        conf10gtx:relate-query-function ,
+        conf10gtx:sf-query-functions ,
+        conf10qre:eh-query-rewrite ,
+        conf10qre:rcc8-query-rewrite ,
+        conf10qre:sf-query-rewrite ,
+        conf11core:feature-collection-class ,
+        conf11core:sparql-protocol ,
+        conf11core:spatial-object-class ,
+        conf11core:spatial-object-collection-class ,
+        conf11core:spatial-object-properties ,
+        conf11gx:dggs-literal ,
+        conf11gx:dggs-literal-empty ,
+        conf11gx:dggs-literal-srs ,
+        conf11gx:feature-properties ,
+        conf11gx:geojson-literal ,
+        conf11gx:geojson-literal-empty ,
+        conf11gx:geojson-literal-srs ,
+        conf11gx:geometry-as-dggs-function ,
+        conf11gx:geometry-as-dggs-literal ,
+        conf11gx:geometry-as-geojson-function ,
+        conf11gx:geometry-as-geojson-literal ,
+        conf11gx:geometry-as-gml-function ,
+        conf11gx:geometry-as-kml-function ,
+        conf11gx:geometry-as-kml-literal ,
+        conf11gx:geometry-as-wkt-function ,
+        conf11gx:geometry-properties ,
+        conf11gx:kml-literal ,
+        conf11gx:kml-literal-empty ,
+        conf11gx:kml-literal-srs ,
+        conf11gx:query-functions ,
+        conf11gx:query-functions-dggs ,
+        conf11gx:query-functions-non-sf ,
+        conf11gx:query-functions-non-sf-dggs ,
+        conf11gx:sa-functions ;
+    sd:resultFormat
+        <http://www.w3.org/ns/formats/RDF_XML> ,
+        <http://www.w3.org/ns/formats/Turtle> ;
     sd:supportedLanguage sd:SPARQL11Query ;
-    sd:feature conf11core:feature-collection-class ;
-    sd:feature conf11core:spatial-object-class ;
-    sd:feature conf11core:sparql-protocol ;
-    sd:feature conf11core:spatial-object-collection-class ;
-    sd:feature conf11core:spatial-object-properties ;
-    sd:feature conf11gx:dggs-literal ;
-    sd:feature conf11gx:dggs-literal-empty ;
-    sd:feature conf11gx:dggs-literal-srs ;
-    sd:feature conf11gx:geometry-as-dggs-function ;
-    sd:feature conf11gx:feature-properties ;
-    sd:feature conf11gx:geometry-as-wkt-function ;
-    sd:feature conf11gx:geometry-as-gml-function ;
-    sd:feature conf11gx:geojson-literal ;
-    sd:feature conf11gx:geojson-literal-empty ;
-    sd:feature conf11gx:geojson-literal-srs ;
-    sd:feature conf11gx:geometry-as-geojson-function ;
-    sd:feature conf11gx:geometry-as-dggs-literal ;
-    sd:feature conf11gx:geometry-as-geojson-literal ;
-    sd:feature conf11gx:geometry-as-kml-literal ;
-    sd:feature conf11gx:geometry-properties ;
-    sd:feature conf11gx:kml-literal ;
-    sd:feature conf11gx:kml-literal-empty ;
-    sd:feature conf11gx:kml-literal-srs ;
-    sd:feature conf11gx:geometry-as-kml-function ;
-    sd:feature conf11gx:query-functions ;
-    sd:feature conf11gx:query-functions-non-sf ;
-    sd:feature conf11gx:sa-functions ;
-    sd:feature conf10core:feature-class ;
-    sd:feature conf10core:spatial-object-class ;
-    sd:feature conf10gx:geometry-class ;
-    sd:feature conf10gx:geometry-properties ;
-    sd:feature conf10gx:feature-properties ;
-    sd:feature conf10gx:geometry-as-gml-literal ;
-    sd:feature conf10gx:geometry-as-wkt-literal ;
-    sd:feature conf10gx:gml-literal ;
-    sd:feature conf10gx:gml-literal-empty ;
-    sd:feature conf10gx:gml-profile ;
-    sd:feature conf10gx:query-functions ;
-    sd:feature conf11gx:query-functions-dggs ;
-    sd:feature conf11gx:query-functions-non-sf-dggs ;
-    sd:feature conf10gx:srid-function ;
-    sd:feature conf10gx:wkt-axis-order ;
-    sd:feature conf10gx:wkt-literal ;
-    sd:feature conf10gx:wkt-literal-default-srs ;
-    sd:feature conf10gx:wkt-literal-empty ;
-    sd:feature conf10gtx:eh-query-functions ;
-    sd:feature conf10gtx:rcc8-query-functions ;
-    sd:feature conf10gtx:relate-query-function ;
-    sd:feature conf10gtx:sf-query-functions ;
-    sd:feature conf10qre:eh-query-rewrite ;
-    sd:feature conf10qre:rcc8-query-rewrite ;
-    sd:feature conf10qre:sf-query-rewrite ;
-    sd:resultFormat <http://www.w3.org/ns/formats/RDF_XML>, <http://www.w3.org/ns/formats/Turtle> ;
-    sd:defaultEntailmentRegime ent:RDFS .
+.

--- a/1.1/servicedescription/servicedescription_conformanceclasses.ttl
+++ b/1.1/servicedescription/servicedescription_conformanceclasses.ttl
@@ -1,6 +1,7 @@
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix ent: <http://www.w3.org/ns/entailment/> .
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 @prefix prof: <http://www.w3.org/ns/owl-profile/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix conf10core: <http://www.opengis.net/spec/geosparql/1.0/conf/core/> .
@@ -17,7 +18,10 @@
 @prefix conf11tve: <http://www.opengis.net/spec/geosparql/1.1/conf/topology-vocab-extension/> .
 @prefix void: <http://rdfs.org/ns/void#> .
 
-<http://www.opengis.net/def/geosparql/servicedescconformanceclasses> a sd:Service, skos:ConceptScheme ;
+<http://www.opengis.net/def/geosparql/servicedescconformanceclasses> 
+    a sd:Service, skos:ConceptScheme ;
+	owl:versionInfo "OGC GeoSPARQL 1.1" ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescconformanceclasses/1.1> ;    
     skos:prefLabel "GeoSPARQL 1.1 SPARQL Service Description: All Conformance Classes" ;
     sd:supportedLanguage sd:SPARQL11Query ;
     sd:feature conf11core:feature-collection-class ;

--- a/1.1/servicedescription/servicedescription_extensions.ttl
+++ b/1.1/servicedescription/servicedescription_extensions.ttl
@@ -1,11 +1,15 @@
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix ent: <http://www.w3.org/ns/entailment/> .
 @prefix prof: <http://www.w3.org/ns/owl-profile/> .
 @prefix void: <http://rdfs.org/ns/void#> .
 
-<http://www.opengis.net/def/geosparql/servicedescextensions> a sd:Service, skos:ConceptScheme ;
+<http://www.opengis.net/def/geosparql/servicedescextensions>
+	a sd:Service, skos:ConceptScheme ;
+	owl:versionInfo "OGC GeoSPARQL 1.1" ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescextensions/1.1> ;	
     skos:prefLabel "GeoSPARQL 1.1 SPARQL Service Description: All Extensions" ;
     sd:supportedLanguage sd:SPARQL11Query ;
 	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-topology-extension/> ;
@@ -13,7 +17,7 @@
 	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/rdfs-entailment-extension/> ;
 	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/topology-vocab-extension/> ;
 	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension/> ;
-        sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension-dggs/> ;
+    sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension-dggs/> ;
 	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/core/> ;
     sd:resultFormat <http://www.w3.org/ns/formats/RDF_XML>, <http://www.w3.org/ns/formats/Turtle> ;
     sd:defaultEntailmentRegime ent:RDFS

--- a/1.1/servicedescription/servicedescription_extensions.ttl
+++ b/1.1/servicedescription/servicedescription_extensions.ttl
@@ -1,24 +1,26 @@
-@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
-@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+PREFIX ent: <http://www.w3.org/ns/entailment/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix ent: <http://www.w3.org/ns/entailment/> .
-@prefix prof: <http://www.w3.org/ns/owl-profile/> .
-@prefix void: <http://rdfs.org/ns/void#> .
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 <http://www.opengis.net/def/geosparql/servicedescextensions>
-	a sd:Service, skos:ConceptScheme ;
-	owl:versionInfo "OGC GeoSPARQL 1.1" ;
-    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescextensions/1.1> ;	
+    a
+        skos:ConceptScheme ,
+        sd:Service ;
+    owl:versionIRI <http://www.opengis.net/def/geosparql/servicedescextensions/1.1> ;
+    owl:versionInfo "OGC GeoSPARQL 1.1" ;
     skos:prefLabel "GeoSPARQL 1.1 SPARQL Service Description: All Extensions" ;
+    sd:defaultEntailmentRegime ent:RDFS ;
+    sd:feature
+        <http://www.opengis.net/spec/geosparql/1.1/conf/core/> ,
+        <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension-dggs/> ,
+        <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension/> ,
+        <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-topology-extension/> ,
+        <http://www.opengis.net/spec/geosparql/1.1/conf/query-rewrite-extension/> ,
+        <http://www.opengis.net/spec/geosparql/1.1/conf/rdfs-entailment-extension/> ,
+        <http://www.opengis.net/spec/geosparql/1.1/conf/topology-vocab-extension/> ;
+    sd:resultFormat
+        <http://www.w3.org/ns/formats/RDF_XML> ,
+        <http://www.w3.org/ns/formats/Turtle> ;
     sd:supportedLanguage sd:SPARQL11Query ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-topology-extension/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/query-rewrite-extension/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/rdfs-entailment-extension/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/topology-vocab-extension/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension/> ;
-    sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/geometry-extension-dggs/> ;
-	sd:feature <http://www.opengis.net/spec/geosparql/1.1/conf/core/> ;
-    sd:resultFormat <http://www.w3.org/ns/formats/RDF_XML>, <http://www.w3.org/ns/formats/Turtle> ;
-    sd:defaultEntailmentRegime ent:RDFS
 .

--- a/1.1/sf_geometries.ttl
+++ b/1.1/sf_geometries.ttl
@@ -1,34 +1,18 @@
-BASE <http://www.opengis.net/ont/sf>
-
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX sf: <http://www.opengis.net/ont/sf#>
 PREFIX sdo: <https://schema.org/>
-PREFIX xsd:<http://www.w3.org/2001/XMLSchema#>
-PREFIX skos:<http://www.w3.org/2004/02/skos/core#>
+PREFIX sf: <http://www.opengis.net/ont/sf#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-
-<http://www.opengis.net/ont/sf> a owl:Ontology ;
-    dcterms:title "Simple Features Vocabulary" ;
-	dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
-	dcterms:modified "2022-06-16"^^xsd:date ;
-	dcterms:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types" ;
-    dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
-	dcterms:publisher [
-		a sdo:Organization ;
-		sdo:name "Open Geospatial Consortium" ;
-		sdo:url "https://www.ogc.org"^^xsd:anyURI ;
-	] ;    
-	dcterms:rights "(c) 2022 Open Geospatial Consortium" ;    
-	owl:versionInfo "OGC GeoSPARQL 1.1" ;
-    owl:versionIRI <http://www.opengis.net/ont/sf/1.1> ;
-.
-
-sf:Curve a rdfs:Class,
+sf:Curve
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Curve"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:Geometry ;
     skos:definition """A Curve is a 1-dimensional geometric object usually stored as a sequence of Points, with the subtype of Curve specifying the form of the interpolation between Points. This specification defines only one subclass of Curve, LineString, which uses linear interpolation between Points.
 
 A Curve is a 1-dimensional geometric object that is the homeomorphic image of a real, closed, interval.
@@ -45,49 +29,37 @@ A Curve that is simple and closed is a Ring.
 The boundary of a non-closed Curve consists of its two end Points.
 
 A Curve is defined as topologically closed, that is, it contains its endpoints f(a) and f(b)."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Geometry .
+    skos:prefLabel "Curve"@en ;
+.
 
 sf:Envelope
-  a rdfs:Class ;
-  a owl:Class ;
-  skos:definition """Shape defined by the corner points of the bounding box of a geometry.
-The corner points may be in any dimension (usually 2D or 3D) but the two corners must have the same dimension."""@en ;
-  rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-  skos:prefLabel "Envelope or Bounding Box"@en ;
-  rdfs:subClassOf sf:Polygon ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:cardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty sf:maximum ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:cardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty sf:minimum ;
-    ] ;
-.
-
-sf:maximum
-  a owl:ObjectProperty ;
-  skos:definition "Point containing the maximum values of the coordinates of an envelope or bounding box"@en ;
-  rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-  rdfs:domain sf:Envelope ;
-  skos:prefLabel "maximum"@en ;
-  rdfs:range sf:Point ;
-.
-sf:minimum
-  a owl:ObjectProperty ;
-  skos:definition "Point containing the minimum values of the coordinates of an envelope or bounding box"@en ;
-  rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-  rdfs:domain sf:Envelope ;
-  skos:prefLabel "minimum"@en ;
-  rdfs:range sf:Point ;
-.
-
-sf:Geometry a rdfs:Class,
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Geometry"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf
+        [
+            a owl:Restriction ;
+            owl:cardinality "1"^^xsd:nonNegativeInteger ;
+            owl:onProperty sf:maximum
+        ] ,
+        [
+            a owl:Restriction ;
+            owl:cardinality "1"^^xsd:nonNegativeInteger ;
+            owl:onProperty sf:minimum
+        ] ,
+        sf:Polygon ;
+    skos:definition """Shape defined by the corner points of the bounding box of a geometry.
+The corner points may be in any dimension (usually 2D or 3D) but the two corners must have the same dimension."""@en ;
+    skos:prefLabel "Envelope or Bounding Box"@en ;
+.
+
+sf:Geometry
+    a
+        rdfs:Class ,
+        owl:Class ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf geo:Geometry ;
     skos:definition """Geometry is the root class of the hierarchy.
 
 The instantiable subclasses of Geometry are restricted to 0, 1 and 2-dimensional geometric objects that exist in 2, 3 or 4-dimensional coordinate space (R2, R3 or R4). Geometry values in R2 have points with coordinate values for x and y. Geometry values in R3 have points with coordinate values for x, y and z or for x, y and m. Geometry values in R4 have points with coordinate values for x, y, z and m.
@@ -95,43 +67,58 @@ The instantiable subclasses of Geometry are restricted to 0, 1 and 2-dimensional
 The interpretation of the coordinates is subject to the coordinate reference systems associated to the point. All coordinates within a geometry object should be in the same coordinate reference systems. Each coordinate shall be unambiguously associated to a coordinate reference system either directly or through its containing geometry. The z coordinate of a point is typically, but not necessarily, represents altitude or elevation. The m coordinate represents a measurement.
 
 All Geometry classes described in this specification are defined so that instances of Geometry are topologically closed, i.e. all represented geometries include their boundary as point sets. This does not affect their representation, and open version of the same classes may be used in other circumstances, such as topological representations."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf geo:Geometry .
+    skos:prefLabel "Geometry"@en ;
+.
 
-sf:GeometryCollection a rdfs:Class,
+sf:GeometryCollection
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Geometry Collection"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:Geometry ;
     skos:definition """A GeometryCollection is a geometric object that is a collection of some number of geometric objects.
 
 All the elements in a GeometryCollection shall be in the same Spatial Reference System. This is also the Spatial Reference System for the GeometryCollection.
 GeometryCollection places no other constraints on its elements. Subclasses of GeometryCollection may restrict membership based on dimension and may also place other constraints on the degree of spatial overlap between elements."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Geometry .
+    skos:prefLabel "Geometry Collection"@en ;
+.
 
-sf:Line a rdfs:Class,
+sf:Line
+    a
+        rdfs:Class ,
         owl:Class ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:LineString ;
+    skos:definition "A Line is a LineString with exactly 2 Points."@en ;
     skos:prefLabel "Line"@en ;
-    skos:definition """A Line is a LineString with exactly 2 Points."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:LineString .
+.
 
-sf:LineString a rdfs:Class,
+sf:LineString
+    a
+        rdfs:Class ,
         owl:Class ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:Curve ;
+    skos:definition "A LineString is a Curve with linear interpolation between Points. Each consecutive pair of Points defines a Line segment."@en ;
     skos:prefLabel "Line String"@en ;
-    skos:definition """A LineString is a Curve with linear interpolation between Points. Each consecutive pair of Points defines a Line segment."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Curve .
+.
 
-sf:LinearRing a rdfs:Class,
+sf:LinearRing
+    a
+        rdfs:Class ,
         owl:Class ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:LineString ;
+    skos:definition "A LinearRing is a LineString that is both closed and simple."@en ;
     skos:prefLabel "Linear Ring"@en ;
-    skos:definition """A LinearRing is a LineString that is both closed and simple."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:LineString .
+.
 
-sf:MultiCurve a rdfs:Class,
+sf:MultiCurve
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Multi Curve"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:GeometryCollection ;
     skos:definition """A MultiCurve is a 1-dimensional GeometryCollection whose elements are Curves.
 
 A MultiCurve defines a set of methods for its subclasses and is included for reasons of extensibility.
@@ -143,19 +130,25 @@ The boundary of a MultiCurve is obtained by applying the mod 2 union rule: A Poi
 A MultiCurve is closed if all of its elements are closed. The boundary of a closed MultiCurve is always empty.
 
 A MultiCurve is defined as topologically closed."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:GeometryCollection .
+    skos:prefLabel "Multi Curve"@en ;
+.
 
-sf:MultiLineString a rdfs:Class,
+sf:MultiLineString
+    a
+        rdfs:Class ,
         owl:Class ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:MultiCurve ;
+    skos:definition "A MultiLineString is a MultiCurve whose elements are LineStrings."@en ;
     skos:prefLabel "Multi Line String"@en ;
-    skos:definition """A MultiLineString is a MultiCurve whose elements are LineStrings."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:MultiCurve .
+.
 
-sf:MultiPoint a rdfs:Class,
+sf:MultiPoint
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Multi Point"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:GeometryCollection ;
     skos:definition """A MultiPoint is a 0-dimensional GeometryCollection. The elements of a MultiPoint are restricted to Points. ThePoints are not connected or ordered in any semantically important way.
 
 A MultiPoint is simple if no two Points in the MultiPoint are equal (have identical coordinate values in X and Y).
@@ -163,12 +156,15 @@ A MultiPoint is simple if no two Points in the MultiPoint are equal (have identi
 Every MultiPoint is spatially equal to a simple Multipoint.
 
 The boundary of a MultiPoint is the empty set."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:GeometryCollection .
+    skos:prefLabel "Multi Point"@en ;
+.
 
-sf:MultiPolygon a rdfs:Class,
+sf:MultiPolygon
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Multi Polygon"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:MultiSurface ;
     skos:definition """A MultiPolygon is a MultiSurface whose elements are Polygons.
 
 The assertions for MultiPolygons are as follows.
@@ -180,30 +176,39 @@ d) A MultiPolygon may not have cut lines, spikes or punctures, a MultiPolygon is
 e) The interior of a MultiPolygon with more than 1 Polygon is not connected; the number of connected components of the interior of a MultiPolygon is equal to the number of Polygons in the MultiPolygon. 
 
 The boundary of a MultiPolygon is a set of closed Curves (LineStrings) corresponding to the boundaries of its element Polygons. Each Curve in the boundary of the MultiPolygon is in the boundary of exactly 1 element Polygon, and every Curve in the boundary of an element Polygon is in the boundary of the MultiPolygon."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:MultiSurface .
+    skos:prefLabel "Multi Polygon"@en ;
+.
 
-sf:MultiSurface a rdfs:Class,
+sf:MultiSurface
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Multi Surface"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:GeometryCollection ;
     skos:definition """A MultiSurface is a 2-dimensional GeometryCollection whose elements are Surfaces, all using coordinates from the same coordinate reference system. The geometric interiors of any two Surfaces in a MultiSurface may not intersect in the full coordinate system. The boundaries of any two coplanar elements in a MultiSurface may intersect, at most, at a finite number of Points. If they were to meet along a curve, they could be merged into a single surface.
 
 A MultiSurface may be used to represent heterogeneous surfaces collections of polygons and polyhedral surfaces. It defines a set of methods for its subclasses. The subclass of MultiSurface is MultiPolygon corresponding to a collection of Polygons only. Other collections shall use MultiSurface."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:GeometryCollection .
+    skos:prefLabel "Multi Surface"@en ;
+.
 
-sf:Point a rdfs:Class,
+sf:Point
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Point"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:Geometry ;
     skos:definition """A Point is a 0-dimensional geometric object and represents a single location in coordinate space. 
 A Point has an x-coordinate value, a y-coordinate value. If called for by the associated Spatial Reference System, it may also have coordinate values for z and m.
 The boundary of a Point is the empty set."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Geometry .
+    skos:prefLabel "Point"@en ;
+.
 
-sf:Polygon a rdfs:Class,
+sf:Polygon
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Polygon"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:Surface ;
     skos:definition """A Polygon is a planar Surface defined by 1 exterior boundary and 0 or more interior boundaries. Each interior boundary defines a hole in the Polygon.
 The exterior boundary LinearRing defines the top of the surface which is the side of the surface from which the exterior boundary appears to traverse the boundary in a counter clockwise direction. The interior LinearRings will have the opposite orientation, and appear as clockwise when viewed from the top,
 The assertions for Polygons (the rules that define valid Polygons) are as follows:
@@ -214,23 +219,29 @@ c) No two Rings in the boundary cross and the Rings in the boundary of a Polygon
 d) A Polygon may not have cut lines, spikes or punctures.
 e) The interior of every Polygon is a connected point set;
 f) The exterior of a Polygon with 1 or more holes is not connected. Each hole defines a connected component of the exterior."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Surface .
+    skos:prefLabel "Polygon"@en ;
+.
 
-sf:PolyhedralSurface a rdfs:Class,
+sf:PolyhedralSurface
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Polyhedral Surface"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:Surface ;
     skos:definition """A PolyhedralSurface is a contiguous collection of polygons, which share common boundary segments. For each pair of polygons that touch, the common boundary shall be expressible as a finite collection of LineStrings. Each such LineString shall be part of the boundary of at most 2 Polygon patches. 
 
 For any two polygons that share a common boundary, the top of the polygon shall be consistent. This means that when two LinearRings from these two Polygons traverse the common boundary segment, they do so in opposite directions. Since the Polyhedral surface is contiguous, all polygons will be thus consistently oriented. This means that a non-oriented surface (such as Mbius band) shall not have single surface representations. They may be represented by a MultiSurface.
 
 If each such LineString is the boundary of exactly 2 Polygon patches, then the PolyhedralSurface is a simple, closed polyhedron and is topologically isomorphic to the surface of a sphere. By the Jordan Surface Theorem (Jordans Theorem for 2-spheres), such polyhedrons enclose a solid topologically isomorphic to the interior of a sphere; the ball. In this case, the top of the surface will either point inward or outward of the enclosed finite solid. If outward, the surface is the exterior boundary of the enclosed surface. If inward, the surface is the interior of the infinite complement of the enclosed solid. A Ball with some number of voids (holes) inside can thus be presented as one exterior boundary shell, and some number in interior boundary shells."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Surface .
+    skos:prefLabel "Polyhedral Surface"@en ;
+.
 
-sf:Surface a rdfs:Class,
+sf:Surface
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Surface"@en ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:Geometry ;
     skos:definition """A Surface is a 2-dimensional geometric object.
 A simple Surface may consists of a single patch that is associated with one exterior boundary and 0 or more interior boundaries. A single such Surface patch in 3-dimensional space is isometric to planar Surfaces, by a simple affine rotation matrix that rotates the patch onto the plane z = 0. If the patch is not vertical, the projection onto the same plane is an isomorphism, and can be represented as a linear transformation, i.e. an affine.
 
@@ -239,20 +250,61 @@ Polyhedral Surfaces are formed by stitching together such simple Surfaces patche
 The boundary of a simple Surface is the set of closed Curves corresponding to its exterior and interior boundaries.
 
 A Polygon is a simple Surface that is planar. A PolyhedralSurface is a simple surface, consisting of some number of Polygon patches or facets. If a PolyhedralSurface is closed, then it bounds a solid. A MultiSurface containing a set of closed PolyhedralSurfaces can be used to represent a Solid object with holes."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Geometry .
+    skos:prefLabel "Surface"@en ;
+.
 
-sf:TIN a rdfs:Class,
+sf:TIN
+    a
+        rdfs:Class ,
         owl:Class ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:subClassOf sf:PolyhedralSurface ;
+    skos:definition "A TIN (triangulated irregular network) is a PolyhedralSurface consisting only of Triangle patches."@en ;
     skos:prefLabel "Triangulated Irregular Network"@en ;
-    skos:definition """A TIN (triangulated irregular network) is a PolyhedralSurface consisting only of Triangle patches."""@en ;
-    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:PolyhedralSurface .
+.
 
-sf:Triangle a rdfs:Class,
+sf:Triangle
+    a
+        rdfs:Class ,
         owl:Class ;
-    skos:prefLabel "Triangle"@en ;
-    skos:definition """A Triangle is a polygon with 3 distinct, non-collinear vertices and no interior boundary."""@en ;
     rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
-    rdfs:subClassOf sf:Polygon .
+    rdfs:subClassOf sf:Polygon ;
+    skos:definition "A Triangle is a polygon with 3 distinct, non-collinear vertices and no interior boundary."@en ;
+    skos:prefLabel "Triangle"@en ;
+.
+
+sf:maximum
+    a owl:ObjectProperty ;
+    rdfs:domain sf:Envelope ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:range sf:Point ;
+    skos:definition "Point containing the maximum values of the coordinates of an envelope or bounding box"@en ;
+    skos:prefLabel "maximum"@en ;
+.
+
+sf:minimum
+    a owl:ObjectProperty ;
+    rdfs:domain sf:Envelope ;
+    rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+    rdfs:range sf:Point ;
+    skos:definition "Point containing the minimum values of the coordinates of an envelope or bounding box"@en ;
+    skos:prefLabel "minimum"@en ;
+.
+
+<http://www.opengis.net/ont/sf>
+    a owl:Ontology ;
+    dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
+    dcterms:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types" ;
+    dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
+    dcterms:modified "2022-06-16"^^xsd:date ;
+    dcterms:publisher [
+            a sdo:Organization ;
+            sdo:name "Open Geospatial Consortium" ;
+            sdo:url "https://www.ogc.org"^^xsd:anyURI
+        ] ;
+    dcterms:rights "(c) 2022 Open Geospatial Consortium" ;
+    dcterms:title "Simple Features Vocabulary" ;
+    owl:versionIRI <http://www.opengis.net/ont/sf/1.1> ;
+    owl:versionInfo "OGC GeoSPARQL 1.1" ;
+.
 

--- a/1.1/sf_geometries.ttl
+++ b/1.1/sf_geometries.ttl
@@ -14,7 +14,7 @@ PREFIX skos:<http://www.w3.org/2004/02/skos/core#>
     dcterms:title "Simple Features Vocabulary" ;
 	dcterms:creator "OGC GeoSPARQL Standards Working Group" ;
 	dcterms:modified "2022-06-16"^^xsd:date ;
-	dcterms:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types"^^xsd:string ;
+	dcterms:description "An RDF/OWL vocabulary for defining SimpleFeature geometry types" ;
     dcterms:license "https://www.ogc.org/license"^^xsd:anyURI ;
 	dcterms:publisher [
 		a sdo:Organization ;
@@ -22,7 +22,9 @@ PREFIX skos:<http://www.w3.org/2004/02/skos/core#>
 		sdo:url "https://www.ogc.org"^^xsd:anyURI ;
 	] ;    
 	dcterms:rights "(c) 2022 Open Geospatial Consortium" ;    
-	owl:versionInfo "OGC GeoSPARQL 1.1"^^xsd:string .
+	owl:versionInfo "OGC GeoSPARQL 1.1" ;
+    owl:versionIRI <http://www.opengis.net/ont/sf/1.1> ;
+.
 
 sf:Curve a rdfs:Class,
         owl:Class ;


### PR DESCRIPTION
This PR does two things:

1. Ensures all RDF files have `versionInfo` and `versionIRI` properties
2. Applying consisted formatting to the Turtle in all RDF files - "LongTurtle", as per RDFlib's serializer (see http://rdftools.kurrawong.net/convert)

This is an editorial PR - no content changes!

Closes #373 