### PR TITLE
Fix Non-Top functions listing and SFA comparison

### DIFF
--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -50,8 +50,10 @@ funcs:
         funcs:maxx ,
         funcs:maxy ,
         funcs:maxz ,
+        funcs:metricArea ,
         funcs:metricBuffer ,
         funcs:metricDistance ,
+        funcs:metricLength ,
         funcs:minx ,
         funcs:miny ,
         funcs:minz ,
@@ -164,6 +166,10 @@ funcs:nonTopo
         funcs:envelope ,
         funcs:geometryN ,
         funcs:getSRID ,
+        funcs:metricArea ,
+        funcs:metricBuffer ,
+        funcs:metricDistance ,
+        funcs:metricLength ,
         funcs:intersection ,
         funcs:isEmpty ,
         funcs:isSimple ,
@@ -455,11 +461,32 @@ funcs:concaveHull_output a fno:Output ;
     fno:required "true"^^xsd:boolean ;    
     fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral  .
 
+funcs:metricLength
+    a sd:Function, fno:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    fno:expects (funcs:metricLength_param1 ) ;
+    fno:returns (funcs:metricLength_output ) ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "Returns the length of a geometry in meters."@en ;
+    skos:prefLabel "metric length"@en ;
+.
+
+funcs:metricLength_param1 a fno:Parameter ;
+    fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral ;
+    fno:required "true"^^xsd:boolean ;
+    skos:prefLabel "geom"@en .
+
+funcs:metricLength_output a fno:Output ;
+    fno:required "true"^^xsd:boolean ;    
+    fno:type xsd:double  .
+
 funcs:length
     a sd:Function, fno:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
-    fno:expects (funcs:length_param1 ) ;
+    fno:expects (funcs:length_param1 funcs:length_param2) ;
     fno:returns (funcs:length_output ) ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
@@ -469,6 +496,11 @@ funcs:length
 
 funcs:length_param1 a fno:Parameter ;
     fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral ;
+    fno:required "true"^^xsd:boolean ;
+    skos:prefLabel "geom"@en .
+
+funcs:length_param1 a fno:Parameter ;
+    fno:type xsd:anyURI ;
     fno:required "true"^^xsd:boolean ;
     skos:prefLabel "geom"@en .
 
@@ -724,22 +756,49 @@ funcs:numGeometries_output a fno:Output ;
     fno:required "true"^^xsd:boolean ;    
     fno:type xsd:integer  .
 
+funcs:metricArea
+    a sd:Function, fno:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    fno:expects (funcs:metricArea_param1 ) ;
+    fno:returns (funcs:metricArea_output ) ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "Returns the area of a geometry in squaremeters."@en ;
+    skos:prefLabel "metric area"@en ;
+.
+
+funcs:metricArea_param1 a fno:Parameter ;
+    fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral ;
+    fno:required "true"^^xsd:boolean ;
+    skos:prefLabel "units"@en .
+
+funcs:metricArea_output a fno:Output ;
+    fno:required "true"^^xsd:boolean ;    
+    fno:type xsd:integer  .
+
+
 funcs:area
     a sd:Function, fno:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
     policy:status status:valid ;
-    fno:expects (funcs:area_param1 ) ;
+    fno:expects (funcs:area_param1 funcs:area_param2) ;
     fno:returns (funcs:area_output ) ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     skos:definition "Returns the area of a geometry in squaremeters."@en ;
-    skos:prefLabel "area"@en ;
+    skos:prefLabel "metric area"@en ;
 .
 
 funcs:area_param1 a fno:Parameter ;
     fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral ;
     fno:required "true"^^xsd:boolean ;
     skos:prefLabel "geom"@en .
+
+funcs:area_param2 a fno:Parameter ;
+    fno:type xsd:anyURI ;
+    fno:required "true"^^xsd:boolean ;
+    skos:prefLabel "units"@en .
 
 funcs:area_output a fno:Output ;
     fno:required "true"^^xsd:boolean ;    

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -869,10 +869,10 @@ This extension mechanism enables GeoSPARQL implementations to simultaneously sup
 
 NOTE: Several non-topological query functions use a unit of measure IRI. See the <<Recommendation for specification of units of measurement,  Recommendation for specification of units of measurement>>. Also, the OGC has recommended units of measure vocabularies for use, see the OGC Definitions Serverfootnote:[https://www.ogc.org/def-server].
 
-==== Function: geof:mericArea
+==== Function: geof:metricArea
 
 ```
-geof:mericArea (geom: ogc:geomLiteral): xsd:double
+geof:metricArea (geom: ogc:geomLiteral): xsd:double
 ```
 
 Returns the area of `geom` in square meters. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:area, `geof:area`>> but does not need a specification of measurement unit.

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -880,7 +880,7 @@ Returns the area of `geom` in square meters. Must return zero for all geometry t
 ==== Function: geof:area
 
 ```
-geof:area (geom: ogc:geomLiteral): rdf:Resource
+geof:area (geom: ogc:geomLiteral, units: xsd:anyURI): rdf:Resource
 ```
 
 Returns the area of `geom`. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:metricArea, `geof:metricArea`>>, which does not need a specification of measurement unit.
@@ -1071,7 +1071,7 @@ Returns the length of `geom` in meters. The longest length from any one dimensio
 ==== Function: geof:length
 
 ```
-geof:length (geom: ogc:geomLiteral): xsd:double
+geof:length (geom: ogc:geomLiteral, units: xsd:anyURI): xsd:double
 ```
 
 Returns the length of `geom`. The longest length from any one dimension is returned. This function is similar to <<Function: geof:metricLength, `geof:metricLength`>>, which does not need a specification of measurement unit.

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -808,8 +808,6 @@ as SPARQL extension functions, consistent with definitions of these functions in
 <<Function: geof:perimeter, `geof:perimeter`>>,
 <<Function: geof:metricArea, `geof:metricArea`>>, 
 <<Function: geof:area, `geof:area`>>, 
-// <<Function: geof:metricVolume, `geof:metricVolume`>>,
-// <<Function: geof:volume, `geof:volume`>>,
 <<Function: geof:geometryN, `geof:geometryN`>>, 
 <<Function: geof:maxX, `geof:maxX`>>,
 <<Function: geof:maxY, `geof:maxY`>>, 
@@ -1171,24 +1169,6 @@ geof:union (geom1: ogc:geomLiteral,
 ```
 
 This function returns a geometric object that represents all Points in the union of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
-
-// ==== Function: geof:mericVolume
-
-// ```
-// geof:mericVolume (geom: ogc:geomLiteral): xsd:double
-// ```
-
-// Returns the volume of `geom` in cube meters. Must return zero for all geometry types other than 3D Polygon. This function is similar to <<Function: geof:volume, `geof:volume`>> but does not need a specification of measurement unit.
-
-// ==== Function: geof:volume
-
-// ```
-// geof:volume (geom: ogc:geomLiteral): rdf:Resource
-// ```
-
-// Returns the volume of `geom`. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:metricVolume, `geof:metricVolume`>>, which does not need a specification of measurement unit.
-
-// NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
 [#req_geometry_extension_srid-function]
 |===

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -802,9 +802,15 @@ as SPARQL extension functions, consistent with definitions of these functions in
 
 |===
 | *Req 41* Implementations shall support the functions 
-<<Function: geof:area, `geof:area`>>, 
-<<Function: geof:geometryN, `geof:geometryN`>>, 
+<<Function: geof:metricLength, `geof:metricLength`>>,
 <<Function: geof:length, `geof:length`>>,
+<<Function: geof:metricPerimeter, `geof:metricPerimeter`>>,
+<<Function: geof:perimeter, `geof:perimeter`>>,
+<<Function: geof:metricArea, `geof:metricArea`>>, 
+<<Function: geof:area, `geof:area`>>, 
+// <<Function: geof:metricVolume, `geof:metricVolume`>>,
+// <<Function: geof:volume, `geof:volume`>>,
+<<Function: geof:geometryN, `geof:geometryN`>>, 
 <<Function: geof:maxX, `geof:maxX`>>,
 <<Function: geof:maxY, `geof:maxY`>>, 
 <<Function: geof:maxZ, `geof:maxZ`>>,  
@@ -865,13 +871,23 @@ This extension mechanism enables GeoSPARQL implementations to simultaneously sup
 
 NOTE: Several non-topological query functions use a unit of measure IRI. See the <<Recommendation for specification of units of measurement,  Recommendation for specification of units of measurement>>. Also, the OGC has recommended units of measure vocabularies for use, see the OGC Definitions Serverfootnote:[https://www.ogc.org/def-server].
 
+==== Function: geof:mericArea
+
+```
+geof:mericArea (geom: ogc:geomLiteral): xsd:double
+```
+
+Returns the area of `geom` in square meters. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:area, `geof:area`>> but does not need a specification of measurement unit.
+
 ==== Function: geof:area
 
 ```
-geof:area (geom: ogc:geomLiteral): xsd:double
+geof:area (geom: ogc:geomLiteral): rdf:Resource
 ```
 
-Returns the area of `geom` in square meters. Must return zero for all geometry types other than Polygon.
+Returns the area of `geom`. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:metricArea, `geof:metricArea`>>, which does not need a specification of measurement unit.
+
+NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
 ==== Function: geof:boundary
 
@@ -896,17 +912,17 @@ geof:metricBuffer (geom: ogc:geomLiteral,
                    radius: xsd:double): ogc:geomLiteral
 ```
 
-Returns a geometric object that represents all Points whose distance from `geom` is less than or equal to the `radius` measured in meters. Calculations are in the coordinate reference system of `geom`. This function is similar to <<Function: geof:buffer, `geof:buffer`>>, but does not need a specification of distance unit.
+Returns a geometric object that represents all Points whose distance from `geom` is less than or equal to the `radius` measured in meters. Calculations are in the coordinate reference system of `geom`. This function is similar to <<Function: geof:buffer, `geof:buffer`>>, but does not need a specification of measurement unit.
 
 ==== Function: geof:buffer
 
 ```
 geof:buffer (geom: ogc:geomLiteral, 
-             radius: xsd:double, 
+             radius: rdf:Resource, 
              units: xsd:anyURI): ogc:geomLiteral
 ```
 
-Returns a geometric object that represents all Points whose distance from `geom` is less than or equal to the `radius` measured in `units`. Calculations are in the spatial reference system of `geom`. This function is similar to <<Function: geof:metricBuffer, `geof:metricBuffer`>>, which does not need a specification of distance unit.
+Returns a geometric object that represents all Points whose distance from `geom` is less than or equal to the `radius` measured in `units`. Calculations are in the spatial reference system of `geom`. This function is similar to <<Function: geof:metricBuffer, `geof:metricBuffer`>>, which does not need a specification of measurement unit.
 
 NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
@@ -958,7 +974,7 @@ geof:metricDistance (geom1: ogc:geomLiteral,
                      geom2: ogc:geomLiteral): xsd:double
 ```
 
-Returns the shortest distance in meters between any two Points in the two geometric objects. Calculations are in the coordinate reference system of `geom1`. This function is similar to <<Function: geof:distance, `geof:distance`>>, but does not need a specification of distance unit.
+Returns the shortest distance in meters between any two Points in the two geometric objects. Calculations are in the coordinate reference system of `geom1`. This function is similar to <<Function: geof:distance, `geof:distance`>>, but does not need a specification of measurement unit.
 
 
 ==== Function: geof:distance
@@ -969,7 +985,7 @@ geof:distance (geom1: ogc:geomLiteral,
                units: xsd:anyURI): xsd:double
 ```
 
-Returns the shortest distance in `units` between any two Points in the two geometric objects. Calculations are in the spatial reference system of `geom1`. This function is similar to <<Function: geof:metricDistance, `geof:metricDistance`>>, which does not need a specification of distance unit.
+Returns the shortest distance in `units` between any two Points in the two geometric objects. Calculations are in the spatial reference system of `geom1`. This function is similar to <<Function: geof:metricDistance, `geof:metricDistance`>>, which does not need a specification of measurement unit.
 
 NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
@@ -1046,13 +1062,23 @@ geof:isSimple (geom: ogc:geomLiteral): xsd:boolean
 
 Returns true if `geom` is a simple geometry, i.e. has no anomalous geometric points, such as self intersection or self tangency.
 
+==== Function: geof:metricLength
+
+```
+geof:metricLength (geom: ogc:geomLiteral): xsd:double
+```
+
+Returns the length of `geom` in meters. The longest length from any one dimension is returned. This function is similar to <<Function: geof:length, `geof:length`>> but does not need a specification of measurement unit.
+
 ==== Function: geof:length
 
 ```
 geof:length (geom: ogc:geomLiteral): xsd:double
 ```
 
-Returns the length of `geom` in meters. The longest length from any one dimension is returned.
+Returns the length of `geom`. The longest length from any one dimension is returned. This function is similar to <<Function: geof:metricLength, `geof:metricLength`>>, which does not need a specification of measurement unit.
+
+NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
 ==== Function: geof:maxX
 
@@ -1145,6 +1171,24 @@ geof:union (geom1: ogc:geomLiteral,
 ```
 
 This function returns a geometric object that represents all Points in the union of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
+
+// ==== Function: geof:mericVolume
+
+// ```
+// geof:mericVolume (geom: ogc:geomLiteral): xsd:double
+// ```
+
+// Returns the volume of `geom` in cube meters. Must return zero for all geometry types other than 3D Polygon. This function is similar to <<Function: geof:volume, `geof:volume`>> but does not need a specification of measurement unit.
+
+// ==== Function: geof:volume
+
+// ```
+// geof:volume (geom: ogc:geomLiteral): rdf:Resource
+// ```
+
+// Returns the volume of `geom`. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:metricVolume, `geof:metricVolume`>>, which does not need a specification of measurement unit.
+
+// NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
 [#req_geometry_extension_srid-function]
 |===

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -916,7 +916,7 @@ Returns a geometric object that represents all Points whose distance from `geom`
 
 ```
 geof:buffer (geom: ogc:geomLiteral, 
-             radius: rdf:Resource, 
+             radius: xsd:double, 
              units: xsd:anyURI): ogc:geomLiteral
 ```
 

--- a/1.1/spec/17-Annex-B.adoc
+++ b/1.1/spec/17-Annex-B.adoc
@@ -65,7 +65,8 @@ CellList (DGGS)
 CellList (DGGS) 
 5+| **Non-topological Query Functions**
 | *Function* | *Input Datatypes* | *Input Subtypes* | *Output Datatype* | *Output Subtype* 
-| <<Function: geof:area, area>> | 1x ogc:geomLiteral | Polygon | http://www.w3.org/2001/XMLSchema#double[xsd:double] | http://www.w3.org/2001/XMLSchema#double[xsd:double] 
+| <<Function: geof:metricArea, metricArea>> | 1x ogc:geomLiteral | Polygon | http://www.w3.org/2001/XMLSchema#double[xsd:double] |
+| <<Function: geof:area, area>> | 1x ogc:geomLiteral | Polygon | http://www.w3.org/2001/XMLSchema#double[xsd:double] | 
 | <<Function: geof:boundary, boundary>> | 1x ogc:geomLiteral | Geometry | ogc:geomLiteral | LineString (not DGGS),
 
 OrderedCellList (DGGS) 
@@ -81,16 +82,19 @@ CellList (DGGS)
 | <<Function: geof:difference, difference>> | 2x ogc:geomLiteral | 2x Geometry | ogc:geomLiteral | (Multi)Polygon (not DGGS),
 
 CellList (DGGS) 
-| <<Function: geof:dimension, dimension>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#double[xsd:double] | http://www.w3.org/2001/XMLSchema#double[xsd:double] 
+| <<Function: geof:dimension, dimension>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#double[xsd:double] | 
+| <<Function: geof:metricDistance, metricDistance>> | 2x ogc:geomLiteral, 
+
+1x xsd:anyURI | 2x Geometry | http://www.w3.org/2001/XMLSchema#double[xsd:double] | 
 | <<Function: geof:distance, distance>> | 2x ogc:geomLiteral, 
 
-1x xsd:anyURI | 2x Geometry | http://www.w3.org/2001/XMLSchema#double[xsd:double] | http://www.w3.org/2001/XMLSchema#double[xsd:double] 
+1x xsd:anyURI | 2x Geometry | http://www.w3.org/2000/01/rdf-schema#Resource[rdfs:Resource] | 
 | <<Function: geof:envelope, envelope>> | 1x ogc:geomLiteral, 
 
 1x xsd:anyURI | Geometry | ogc:geomLiteral | (Multi)Polygon (not DGGS),
 
 CellList (DGGS) 
-| <<Function: geof:geometryN, geometryN>> | 1x ogc:geomLiteral | GeometryCollection (not DGGS) | http://www.w3.org/2001/XMLSchema#double[xsd:double] | http://www.w3.org/2001/XMLSchema#double[xsd:double] 
+| <<Function: geof:geometryN, geometryN>> | 1x ogc:geomLiteral | GeometryCollection (not DGGS) | http://www.w3.org/2001/XMLSchema#double[xsd:double] | 
 | <<Function: geof:geometryType, geometryType>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#anyURI[xsd:anyURI] | 
 | <<Function: geof:getSRID, getSRID>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#anyURI[xsd:anyURI] | 
 | <<Function: geof:intersection, intersection>> | 2x ogc:geomLiteral | 2x Geometry | ogc:geomLiteral | Polygon (not DGGS),
@@ -100,8 +104,11 @@ CellList (DGGS)
 | <<Function: geof:isEmpty, isEmpty>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#boolean[xsd:boolean] | 
 | <<Function: geof:isMeasured, isMeasured>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#boolean[xsd:boolean] | 
 | <<Function: geof:isSimple, isSimple>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#boolean[xsd:boolean] | 
-| <<Function: geof:length, length>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#double[xsd:double] | http://www.w3.org/2001/XMLSchema#double[xsd:double] 
-| <<Function: geof:numGeometries, numGeometries>> | 1x ogc:geomLiteral | Geometry (not DGGS) | http://www.w3.org/2001/XMLSchema#double[xsd:double] | http://www.w3.org/2001/XMLSchema#double[xsd:double] 
+| <<Function: geof:metricLength, metricLength>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#double[xsd:double] | 
+| <<Function: geof:length, length>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2000/01/rdf-schema#Resource[rdfs:Resource] |
+| <<Function: geof:numGeometries, numGeometries>> | 1x ogc:geomLiteral | Geometry (not DGGS) | http://www.w3.org/2001/XMLSchema#double[xsd:double] | 
+| <<Function: geof:metricPerimeter, metricPerimeter>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#double[xsd:double] | 
+| <<Function: geof:perimeter, perimeter>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2000/01/rdf-schema#Resource[rdfs:Resource] |
 | <<Function: geof:spatialDimension, spatialDimension>> | 1x ogc:geomLiteral | Geometry | http://www.w3.org/2001/XMLSchema#integer[xsd:integer] | 
 | <<Function: geof:symDifference, symDifference>> | 2x ogc:geomLiteral | 2x Geometry | ogc:geomLiteral | (Multi)Polygon (not DGGS),
 
@@ -141,37 +148,54 @@ Where the Simple Features Access function has the same name as the GeoSPARQL fun
 |===
 | GeoSPARQL Function | in 1.0 | in 1.1 | SFA
 
-| area | | x | 
-| | | | asBinary
-| asWKT* | x | x | asText
-| boundary | x | x | x
-| buffer | x | x | x
-| convexHull | x | x | x
-| coordinateDimension | | x | x
-| difference | x | x | x
-| dimension | | x | x
-| distance | x | x | x
-| envelope | x | x | x
-| geometryN | | x | 
-| geometryType | | x | x
+| metricArea | | x | Area
+| area | | x | Area
+| | | | AsBinary
+| asWKT* | x | x | AsText
+| boundary | x | x | Boundary
+| buffer | x | x | Buffer
+| | | | Centroid
+| convexHull | x | x | ConvexHull
+| coordinateDimension | | x | 
+| difference | x | x | Difference
+| dimension | | x | Dimension
+| metricDistance | | x | Distance
+| distance | x | x | Distance
+| | | | EndPoint
+| envelope | x | x | Envelope
+| geometryN | | x | GeometryN
+| geometryType | | x | GeometryType
 | getSRID | x | x | SRID
-| intersection | x | x | x
-| is3D | | | x
-| isEmpty | | x | x
-| isMeasured | | x | x
-| isSimple | | x | x
-| length | | x | 
+| | | | InteriorRingN
+| intersection | x | x | Intersection
+| is3D | | x | 
+| | | | IsClosed
+| isEmpty | | x | IsEmpty
+| isMeasured | | x | 
+| | | | IsRing
+| isSimple | | x | IsSimple
+| metricLength | | x | Length
+| length | | x | Length
 | maxX | | x | 
 | maxY | | x | 
 | maxZ | | x | 
 | minX | | x | 
 | minY | | x | 
 | minZ | | x | 
-| numGeometries | | x |  
-| spatialDimension | | x | x 
-| symDifference | x | x | x
-| transform | | x | x
-| union | x | x | x
+| numGeometries | | x | NumGeometries 
+| | | | NumInteriorRing
+| | | | NumPoints
+| perimeterLength | | x | 
+| perimeter | | x | 
+| | | | PointN
+| | | | PointOnSurface
+| spatialDimension | | x |
+| | | | StartPoint
+| symDifference | x | x | SymDifference
+| transform | | x | 
+| union | x | x | Union
+| | | | X
+| | | | Y
 |===
 
 $$*$$ GeoSPARQL's `asWKT` is only a partial implementation of `asText` since `asWKT` only returns WKT, not textual geometry literal data in general.


### PR DESCRIPTION
Ensures we have 

* paired functions with properties
    * e.g. `geof:perimeter` for `geo:hasPerimeter`
* metric/non-metric pairs 
    * e.g. `geof:perimeter` & `geof:metricPerimeter`
* return types matching function
    * e.g. `geof:perimeter`  returns an `rdf:Resource` where as `geof:metricPerimeter` returns an `xsd:double`

Also adds all SFA functions to Table _B.2 GeoSPARQL to SFA Functions Mapping_. We were missing lots.

In your reviews, please indicate what we should do about the un-supported SFA functions. 