### PR TITLE
Area function definition

### DIFF
--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -638,7 +638,6 @@ funcs:asWKT
     skos:prefLabel "asWKT"@en ;
 .
 
-
 funcs:asWKT_param1 a fno:Parameter ;
     fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral ;
     fno:required "true"^^xsd:boolean ;
@@ -732,7 +731,7 @@ funcs:area
     fno:returns (funcs:area_output ) ;
     rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
-    skos:definition "Returns the area of a geometry in squaremeters."@en ;
+    skos:definition "Returns the area of a geometry in square meters."@en ;
     skos:prefLabel "area"@en ;
 .
 

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -871,7 +871,7 @@ NOTE: Several non-topological query functions use a unit of measure IRI. See the
 geof:area (geom: ogc:geomLiteral): xsd:double
 ```
 
-Returns the area of `geom` in square meters. Must return zero for all geometry types other than Polygon.
+Returns the area of `geom` in square meters. Must return zero for geometries that are not geometrically closed.
 
 ==== Function: geof:boundary
 


### PR DESCRIPTION
Updates the definition of geof:area. Fixes [issue 381](https://github.com/opengeospatial/ogc-geosparql/issues/381).