### PR TITLE
1.1 alignments: Add missing prefixes and fix most typos

### DIFF
--- a/1.1/alignments/bfo-alignments.ttl
+++ b/1.1/alignments/bfo-alignments.ttl
@@ -4,8 +4,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 geo:SpatialObject rdfs:subClassOf obo:BFO_0000004 .
-obo:BFO_0000040 rdf:subClassOf geo:Feature .
-obo:BFO_0000029 df:subClassOf geo:Feature .
+obo:BFO_0000040 rdfs:subClassOf geo:Feature .
+obo:BFO_0000029 rdfs:subClassOf geo:Feature .
 geo:Feature owl:equivalentClass obo:BFO_0000006 .
 geo:hasGeometry rdfs:subPropertyOf obo:BFO_0000211 .
 geo:hasGeometry rdfs:subPropertyOf obo:BFO_0000210 .

--- a/1.1/alignments/osmrdf-alignments.ttl
+++ b/1.1/alignments/osmrdf-alignments.ttl
@@ -1,9 +1,11 @@
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix osmm: <https://www.openstreetmap.org/meta/> .
+@prefix sf: <http://www.opengis.net/ont/sf#> .
 
 osmm:loc owl:equivalentProperty geo:asWKT .
 osmm:has owl:equivalentProperty geo:sfContains .

--- a/1.1/alignments/routabletiles-alignments.ttl
+++ b/1.1/alignments/routabletiles-alignments.ttl
@@ -3,8 +3,9 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix osmm: <https://www.openstreetmap.org/meta/> .
 @prefix osmt: <https://wiki.openstreetmap.org/wiki/Key:> .
+@prefix sf: <http://www.opengis.net/ont/sf#> .
 
-osm:Element owl:equivalentClass geo:Geometry .
-osm:Node owl:equivalentClass sf:Point .
-osm:Way owl:equivalentClass sf:LineString .
-osm:Relation owl:equivalentClass sf:GeometryCollection .
+osmm:Element owl:equivalentClass geo:Geometry .
+osmm:Node owl:equivalentClass sf:Point .
+osmm:Way owl:equivalentClass sf:LineString .
+osmm:Relation owl:equivalentClass sf:GeometryCollection .

--- a/1.1/alignments/wgs84geo-alignments.ttl
+++ b/1.1/alignments/wgs84geo-alignments.ttl
@@ -8,4 +8,4 @@ geo:SpatialObject owl:equivalentClass pos:SpatialThing .
 pos:Point rdfs:subClassOf geo:Geometry .
 pos:Point owl:equivalentClass sf:Point .
 pos:lat_long rdfs:subPropertyOf geo:hasSerialization .
-pos:location rdfs:subPropertyOf rgeo:hasGeometry .
+pos:location rdfs:subPropertyOf geo:hasGeometry .


### PR DESCRIPTION
This Pull Request includes fixes that I request be included before the 1.1 release is "Stamped", and reports one last issue where I am uncertain of the resolution.

I believe these changes are near-0 risk bugfixes.  (Not 0, because I did not know all of the concepts referenced that needed a coding typo correction.)

The first patch logs the summary of the issue corrections and outstanding need, but I'll repeat the message in the hope that someone's memory is quickly jogged.

> This patch addresses issues discovered when attempting to load all of the alignment files into a Turtle file with an RDF processing tool.
>
> One issue was NOT addressed: osiuk-alignments.ttl contains this line:
>
> ```turtle
> spatialukgeom:AbstractGeometry geo:Geometry .
> ```
>
> This is an incomplete triple, and as a non-member of the development group for this repository, I did not know what aligning predicate would be appropriate.

Please feel free to push additional patches on top of my branch for this PR.