### PR TITLE
Add perimeter to spec

### DIFF
--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -55,9 +55,11 @@ funcs:
         funcs:metricBuffer ,
         funcs:metricDistance ,
         funcs:metricLength ,
+        funcs:metricPerimeter ,
         funcs:minx ,
         funcs:miny ,
         funcs:minz ,
+        funcs:perimeter ,
         funcs:rcc8dc ,
         funcs:rcc8ec ,
         funcs:rcc8eq ,
@@ -178,11 +180,14 @@ funcs:nonTopo
         funcs:maxx ,
         funcs:maxy ,
         funcs:maxz ,
+        funcs:metricArea ,
         funcs:metricBuffer ,
         funcs:metricDistance ,
+        funcs:metricPerimeter ,
         funcs:minx ,
         funcs:miny ,
         funcs:minz ,
+        funcs:perimeter ,
         funcs:numGeometries ,
         funcs:symDifference ,
         funcs:union ;
@@ -252,7 +257,7 @@ funcs:sf
     rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
     owl:imports <http://www.opengis.net/def/ogc-na> ;
     owl:versionIRI <http://www.opengis.net/def/geosparql/funcsrules/1.1> ;
-    owl:versionInfo "OGC GeosPARQL 1.1" ;
+    owl:versionInfo "OGC GeoSPARQL 1.1" ;
     skos:definition "A vocabulary (taxonomy) of the functions and rules defined within the GeoSPARQL 1.1 specification"@en ;
     skos:hasTopConcept
         funcs:area ,
@@ -285,12 +290,15 @@ funcs:sf
         funcs:maxx ,
         funcs:maxy ,
         funcs:maxz ,
+        funcs:metricArea ,
         funcs:metricBuffer ,
         funcs:metricDistance ,
+        funcs:metricPerimeter ,
         funcs:minx ,
         funcs:miny ,
         funcs:minz ,
         funcs:numGeometries ,
+        funcs:perimeter ,
         funcs:rcc8dc ,
         funcs:rcc8ec ,
         funcs:rcc8eq ,

--- a/1.1/funcsrules.ttl
+++ b/1.1/funcsrules.ttl
@@ -759,6 +759,57 @@ funcs:numGeometries_output a fno:Output ;
     fno:required "true"^^xsd:boolean ;    
     fno:type xsd:integer  .
 
+
+
+funcs:metricPerimeter
+    a sd:Function, fno:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    fno:expects (funcs:metricPerimeter_param1 ) ;
+    fno:returns (funcs:metricPerimeter_output ) ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "Returns the perimeter of a geometry in meters."@en ;
+    skos:prefLabel "metric perimeter"@en ;
+.
+
+funcs:metricPerimeter_param1 a fno:Parameter ;
+    fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral ;
+    fno:required "true"^^xsd:boolean ;
+    skos:prefLabel "geom"@en .
+
+funcs:metricPerimeter_output a fno:Output ;
+    fno:required "true"^^xsd:boolean ;    
+    fno:type xsd:double  .
+    
+ 
+ funcs:perimeter
+    a sd:Function, fno:Function ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    policy:status status:valid ;
+    fno:expects (funcs:perimeter_param1 funcs:perimeter_param2) ;
+    fno:returns (funcs:perimeter_output ) ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "Returns the perimeter of a geometry in meters."@en ;
+    skos:prefLabel "perimeter"@en ;
+.
+
+funcs:perimeter_param1 a fno:Parameter ;
+    fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral ;
+    fno:required "true"^^xsd:boolean ;
+    skos:prefLabel "geom"@en .
+
+funcs:perimeter_param2 a fno:Parameter ;
+    fno:type xsd:anyURI ;
+    fno:required "true"^^xsd:boolean ;
+    skos:prefLabel "unit"@en .
+
+funcs:perimeter_output a fno:Output ;
+    fno:required "true"^^xsd:boolean ;    
+    fno:type xsd:double  .
+ 
+
 funcs:metricArea
     a sd:Function, fno:Function ;
     dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
@@ -774,7 +825,7 @@ funcs:metricArea
 funcs:metricArea_param1 a fno:Parameter ;
     fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral ;
     fno:required "true"^^xsd:boolean ;
-    skos:prefLabel "units"@en .
+    skos:prefLabel "geom"@en .
 
 funcs:metricArea_output a fno:Output ;
     fno:required "true"^^xsd:boolean ;    

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -875,7 +875,7 @@ NOTE: Several non-topological query functions use a unit of measure IRI. See the
 geof:metricArea (geom: ogc:geomLiteral): xsd:double
 ```
 
-Returns the area of `geom` in square meters. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:area, `geof:area`>> but does not need a specification of measurement unit.
+The function http://www.opengis.net/def/function/geosparql/metricArea[`geof:metricArea`] returns the area of `geom` in square meters. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:area, `geof:area`>> but does not need a specification of measurement unit.
 
 ==== Function: geof:area
 
@@ -883,7 +883,7 @@ Returns the area of `geom` in square meters. Must return zero for all geometry t
 geof:area (geom: ogc:geomLiteral, units: xsd:anyURI): rdf:Resource
 ```
 
-Returns the area of `geom`. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:metricArea, `geof:metricArea`>>, which does not need a specification of measurement unit.
+The function http://www.opengis.net/def/function/geosparql/area[`geof:area`] returns the area of `geom`. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:metricArea, `geof:metricArea`>>, which does not need a specification of measurement unit.
 
 NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
@@ -893,7 +893,7 @@ NOTE: See the <<Recommendation for specification of units of measurement, Recomm
 geof:boundary (geom: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns the closure of the boundary of `geom`. Calculations are in the spatial reference system of `geom`.
+The function http://www.opengis.net/def/function/geosparql/boundary[`geof:boundary`] returns the closure of the boundary of `geom`. Calculations are in the spatial reference system of `geom`.
 
 ==== Function: geof:boundingCircle
 
@@ -901,7 +901,7 @@ This function returns the closure of the boundary of `geom`. Calculations are in
 geof:boundingCircle (geom: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns the minimum bounding circle around `geom`. Calculations are in the spatial reference system of `geom`.
+The function http://www.opengis.net/def/function/geosparql/boundingCircle[`geof:boundingCircle`] returns the minimum bounding circle around `geom`. Calculations are in the spatial reference system of `geom`.
 
 ==== Function: geof:metricBuffer
 
@@ -910,7 +910,7 @@ geof:metricBuffer (geom: ogc:geomLiteral,
                    radius: xsd:double): ogc:geomLiteral
 ```
 
-Returns a geometric object that represents all Points whose distance from `geom` is less than or equal to the `radius` measured in meters. Calculations are in the coordinate reference system of `geom`. This function is similar to <<Function: geof:buffer, `geof:buffer`>>, but does not need a specification of measurement unit.
+The function http://www.opengis.net/def/function/geosparql/metricBuffer[`geof:metricBuffer`] returns a geometric object that represents all Points whose distance from `geom` is less than or equal to the `radius` measured in meters. Calculations are in the coordinate reference system of `geom`. This function is similar to <<Function: geof:buffer, `geof:buffer`>>, but does not need a specification of measurement unit.
 
 ==== Function: geof:buffer
 
@@ -920,7 +920,7 @@ geof:buffer (geom: ogc:geomLiteral,
              units: xsd:anyURI): ogc:geomLiteral
 ```
 
-Returns a geometric object that represents all Points whose distance from `geom` is less than or equal to the `radius` measured in `units`. Calculations are in the spatial reference system of `geom`. This function is similar to <<Function: geof:metricBuffer, `geof:metricBuffer`>>, which does not need a specification of measurement unit.
+The function http://www.opengis.net/def/function/geosparql/buffer[`geof:buffer`] returns a geometric object that represents all Points whose distance from `geom` is less than or equal to the `radius` measured in `units`. Calculations are in the spatial reference system of `geom`. This function is similar to <<Function: geof:metricBuffer, `geof:metricBuffer`>>, which does not need a specification of measurement unit.
 
 NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
@@ -946,7 +946,7 @@ The function http://www.opengis.net/def/function/geosparql/concaveHull[`geof:con
 geof:coordinateDimension (geom: ogc:geomLiteral): xsd:integer
 ```
 
-Returns the coordinate dimension of `geom`.
+The function http://www.opengis.net/def/function/geosparql/coordinateDimension[`geof:coordinateDimension`] returns the coordinate dimension of `geom`.
 
 ==== Function: geof:difference
 
@@ -955,7 +955,7 @@ geof:difference (geom1: ogc:geomLiteral,
                  geom2: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns a geometric object that represents all Points in the set difference of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
+The function http://www.opengis.net/def/function/geosparql/difference[`geof:difference`] returns a geometric object that represents all Points in the set difference of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
 
 ==== Function: geof:dimension
 
@@ -963,7 +963,7 @@ This function returns a geometric object that represents all Points in the set d
 geof:dimension (geom: ogc:geomLiteral): xsd:integer
 ```
 
-Returns the dimension of `geom`. In non-homogeneous geometry collections, this will return the largest topological dimension of the contained objects.
+The function http://www.opengis.net/def/function/geosparql/dimension[`geof:dimensions`] returns the dimension of `geom`. In non-homogeneous geometry collections, this will return the largest topological dimension of the contained objects.
 
 ==== Function: geof:metricDistance
 
@@ -972,7 +972,7 @@ geof:metricDistance (geom1: ogc:geomLiteral,
                      geom2: ogc:geomLiteral): xsd:double
 ```
 
-Returns the shortest distance in meters between any two Points in the two geometric objects. Calculations are in the coordinate reference system of `geom1`. This function is similar to <<Function: geof:distance, `geof:distance`>>, but does not need a specification of measurement unit.
+The function http://www.opengis.net/def/function/geosparql/metricDistance[`geof:metricDistance`] returns the shortest distance in meters between any two Points in the two geometric objects. Calculations are in the coordinate reference system of `geom1`. This function is similar to <<Function: geof:distance, `geof:distance`>>, but does not need a specification of measurement unit.
 
 
 ==== Function: geof:distance
@@ -983,7 +983,7 @@ geof:distance (geom1: ogc:geomLiteral,
                units: xsd:anyURI): xsd:double
 ```
 
-Returns the shortest distance in `units` between any two Points in the two geometric objects. Calculations are in the spatial reference system of `geom1`. This function is similar to <<Function: geof:metricDistance, `geof:metricDistance`>>, which does not need a specification of measurement unit.
+The function http://www.opengis.net/def/function/geosparql/distance[`geof:distance`] returns the shortest distance in `units` between any two Points in the two geometric objects. Calculations are in the spatial reference system of `geom1`. This function is similar to <<Function: geof:metricDistance, `geof:metricDistance`>>, which does not need a specification of measurement unit.
 
 NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
@@ -993,7 +993,7 @@ NOTE: See the <<Recommendation for specification of units of measurement, Recomm
 geof:envelope (geom: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns the minimum bounding box - a rectangle - of `geom`. Calculations are in the spatial reference system of `geom`.
+The function http://www.opengis.net/def/function/geosparql/envelope[`geof:envelope`] returns the minimum bounding box - a rectangle - of `geom`. Calculations are in the spatial reference system of `geom`.
 
 ==== Function: geof:geometryN
 
@@ -1001,7 +1001,7 @@ This function returns the minimum bounding box - a rectangle - of `geom`. Calcul
 geof:geometryN (geom: ogc:geomLiteral, geomindex: xsd:integer): ogc:geomLiteral
 ```
 
-Returns the nth geometry of `geom` if it is a GeometryCollection that is defined in a literal type (such as in the case of a sf:GeometryCollection) or `geom` if it is a Geometry. This function is not applicable to the type geo:GeometryCollection, as elements in geo:GeometryCollection are not guaranteed to be ordered.
+The function http://www.opengis.net/def/function/geosparql/geometryN[`geof:geometryN`] returns the nth geometry of `geom` if it is a GeometryCollection that is defined in a literal type (such as in the case of a sf:GeometryCollection) or `geom` if it is a Geometry. This function is not applicable to the type geo:GeometryCollection, as elements in geo:GeometryCollection are not guaranteed to be ordered.
 
 ==== Function: geof:geometryType
 
@@ -1009,7 +1009,7 @@ Returns the nth geometry of `geom` if it is a GeometryCollection that is defined
 geof:geometryType (geom: ogc:geomLiteral): xsd:anyURI
 ```
 
-Returns the URI of the subtype of Geometry of which this geometric object is an member. No attempt to reconcile different geometry subtypes across all support literals need be made.
+The function http://www.opengis.net/def/function/geosparql/geometryType[`geof:geometryType`] returns the URI of the subtype of Geometry of which this geometric object is an member. No attempt to reconcile different geometry subtypes across all support literals need be made.
 
 ==== Function: geof:getSRID
 
@@ -1017,7 +1017,7 @@ Returns the URI of the subtype of Geometry of which this geometric object is an 
 geof:getSRID (geom: ogc:geomLiteral): xsd:anyURI
 ```
 
-Returns the spatial reference system IRI for `geom`.
+The function http://www.opengis.net/def/function/geosparql/getSRID[`geof:getSRID`] returns the spatial reference system IRI for `geom`.
 
 ==== Function: geof:intersection
 
@@ -1026,7 +1026,7 @@ geof:intersection (geom1: ogc:geomLiteral,
                    geom2: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-Returns a geometric object that represents all Points in the intersection of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
+The function http://www.opengis.net/def/function/geosparql/intersection[`geof:intersection`] returns a geometric object that represents all Points in the intersection of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
 
 ==== Function: geof:is3D
 
@@ -1034,7 +1034,7 @@ Returns a geometric object that represents all Points in the intersection of `ge
 geof:is3D (geom: ogc:geomLiteral): xsd:boolean
 ```
 
-Returns true if `geom` has z coordinate values.
+The function http://www.opengis.net/def/function/geosparql/is3D[`geof:is3D`] Returns true if `geom` has z coordinate values.
 
 ==== Function: geof:isEmpty
 
@@ -1042,7 +1042,7 @@ Returns true if `geom` has z coordinate values.
 geof:isEmpty (geom: ogc:geomLiteral): xsd:boolean
 ```
 
-Returns true if `geom` is an empty geometry, i.e. contains no coordinates.
+The function http://www.opengis.net/def/function/geosparql/isEmpty[`geof:isEmpty`] returns true if `geom` is an empty geometry, i.e. contains no coordinates.
 
 ==== Function: geof:isMeasured
 
@@ -1050,7 +1050,7 @@ Returns true if `geom` is an empty geometry, i.e. contains no coordinates.
 geof:isMeasured (geom: ogc:geomLiteral): xsd:boolean
 ```
 
-Returns true if `geom` has m coordinate values.
+The function http://www.opengis.net/def/function/geosparql/isMeasured[`geof:isMeasured`] Returns true if `geom` has m coordinate values.
 
 ==== Function: geof:isSimple
 
@@ -1058,7 +1058,7 @@ Returns true if `geom` has m coordinate values.
 geof:isSimple (geom: ogc:geomLiteral): xsd:boolean
 ```
 
-Returns true if `geom` is a simple geometry, i.e. has no anomalous geometric points, such as self intersection or self tangency.
+The function http://www.opengis.net/def/function/geosparql/isSimple[`geof:isSimple`] Returns true if `geom` is a simple geometry, i.e. has no anomalous geometric points, such as self intersection or self tangency.
 
 ==== Function: geof:metricLength
 
@@ -1066,7 +1066,7 @@ Returns true if `geom` is a simple geometry, i.e. has no anomalous geometric poi
 geof:metricLength (geom: ogc:geomLiteral): xsd:double
 ```
 
-Returns the length of `geom` in meters. The longest length from any one dimension is returned. This function is similar to <<Function: geof:length, `geof:length`>> but does not need a specification of measurement unit.
+The function http://www.opengis.net/def/function/geosparql/metricLength[`geof:metricLength`] returns the length of `geom` in meters. The longest length from any one dimension is returned. This function is similar to <<Function: geof:length, `geof:length`>> but does not need a specification of measurement unit.
 
 ==== Function: geof:length
 
@@ -1074,7 +1074,7 @@ Returns the length of `geom` in meters. The longest length from any one dimensio
 geof:length (geom: ogc:geomLiteral, units: xsd:anyURI): xsd:double
 ```
 
-Returns the length of `geom`. The longest length from any one dimension is returned. This function is similar to <<Function: geof:metricLength, `geof:metricLength`>>, which does not need a specification of measurement unit.
+The function http://www.opengis.net/def/function/geosparql/length[`geof:length`] returns the length of `geom`. The longest length from any one dimension is returned. This function is similar to <<Function: geof:metricLength, `geof:metricLength`>>, which does not need a specification of measurement unit.
 
 NOTE: See the <<Recommendation for specification of units of measurement, Recommendation for specification of units of measurement>>.
 
@@ -1132,7 +1132,24 @@ The function http://www.opengis.net/def/function/geosparql/minZ[`geof:minZ`] ret
 geof:numGeometries (geom: ogc:geomLiteral): xsd:integer
 ```
 
-Returns the number of geometries of `geom`.
+The function http://www.opengis.net/def/function/geosparql/numGeometries[`geof:numGeometries`] returns the number of geometries of `geom`.
+
+==== Function: geof:perimeter
+
+```
+geof:perimeter (geom: ogc:geomLiteral, unit: xsd:anyURI): xsd:double
+```
+
+The function http://www.opengis.net/def/function/geosparql/perimeter[`geof:perimeter`] returns the perimeter of  `geom` in the unit specified by the unit parameter for areal geometries. For non-areal geometries the result is equivalent to geof:hasLength. If no unit parameter is given, the result is returned in the unit of the spatial reference system.
+
+==== Function: geof:metricPerimeter
+
+```
+geof:metricPerimeter (geom: ogc:geomLiteral): xsd:double
+```
+
+The function http://www.opengis.net/def/function/geosparql/metricPerimeter[`geof:metricPerimeter`] returns the perimeter is similar to the function geof:perimeter, but always returns the result in meter.
+
 
 ==== Function: geof:spatialDimension
 
@@ -1140,7 +1157,7 @@ Returns the number of geometries of `geom`.
 geof:spatialDimension (geom: ogc:geomLiteral): xsd:integer
 ```
 
-Returns the spatial dimension of `geom`.
+The function http://www.opengis.net/def/function/geosparql/spatialDimension[`geof:spatialDimension`] returns the spatial dimension of `geom`.
 
 ==== Function: geof:symDifference
 
@@ -1149,7 +1166,7 @@ geof:symDifference (geom1: ogc:geomLiteral,
                     geom2: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns a geometric object that represents all Points in the set symmetric difference of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
+The function http://www.opengis.net/def/function/geosparql/symDifference[`geof:symDifference`] returns a geometric object that represents all Points in the set symmetric difference of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
 
 ==== Function: geof:transform
 
@@ -1157,7 +1174,7 @@ This function returns a geometric object that represents all Points in the set s
 geof:transform (geom: ogc:geomLiteral, srsIRI: xsd:anyURI): ogc:geomLiteral
 ```
 
-http://www.opengis.net/def/function/geosparql/transform[geof:transform] converts `geom` to a spatial reference system defined by srsIRI. The function raises an error if a transformation is not mathematically possible.
+The function http://www.opengis.net/def/function/geosparql/transform[geof:transform] converts `geom` to a spatial reference system defined by srsIRI. The function raises an error if a transformation is not mathematically possible.
 
 NOTE: We recommend that implementers use the same literal type as a result of this function as the type of the input literal.
 
@@ -1168,7 +1185,7 @@ geof:union (geom1: ogc:geomLiteral,
             geom2: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-This function returns a geometric object that represents all Points in the union of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
+This function http://www.opengis.net/def/function/geosparql/union[`geof:union`] returns a geometric object that represents all Points in the union of `geom1` with `geom2`. Calculations are in the spatial reference system of `geom1`.
 
 [#req_geometry_extension_srid-function]
 |===

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -1148,7 +1148,7 @@ The function http://www.opengis.net/def/function/geosparql/perimeter[`geof:perim
 geof:metricPerimeter (geom: ogc:geomLiteral): xsd:double
 ```
 
-The function http://www.opengis.net/def/function/geosparql/metricPerimeter[`geof:metricPerimeter`] returns the perimeter is similar to the function geof:perimeter, but always returns the result in meter.
+The function http://www.opengis.net/def/function/geosparql/metricPerimeter[`geof:metricPerimeter`] returns the perimeter of `geom`. It is similar to the function geof:perimeter, but always returns the result in meters.
 
 
 ==== Function: geof:spatialDimension

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -1050,7 +1050,7 @@ The function http://www.opengis.net/def/function/geosparql/isEmpty[`geof:isEmpty
 geof:isMeasured (geom: ogc:geomLiteral): xsd:boolean
 ```
 
-The function http://www.opengis.net/def/function/geosparql/isMeasured[`geof:isMeasured`] Returns true if `geom` has m coordinate values.
+The function http://www.opengis.net/def/function/geosparql/isMeasured[`geof:isMeasured`] returns true if `geom` has m coordinate values.
 
 ==== Function: geof:isSimple
 
@@ -1058,7 +1058,7 @@ The function http://www.opengis.net/def/function/geosparql/isMeasured[`geof:isMe
 geof:isSimple (geom: ogc:geomLiteral): xsd:boolean
 ```
 
-The function http://www.opengis.net/def/function/geosparql/isSimple[`geof:isSimple`] Returns true if `geom` is a simple geometry, i.e. has no anomalous geometric points, such as self intersection or self tangency.
+The function http://www.opengis.net/def/function/geosparql/isSimple[`geof:isSimple`] returns true if `geom` is a simple geometry, i.e. has no anomalous geometric points, such as self intersection or self tangency.
 
 ==== Function: geof:metricLength
 

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -1140,7 +1140,7 @@ The function http://www.opengis.net/def/function/geosparql/numGeometries[`geof:n
 geof:perimeter (geom: ogc:geomLiteral, unit: xsd:anyURI): xsd:double
 ```
 
-The function http://www.opengis.net/def/function/geosparql/perimeter[`geof:perimeter`] returns the perimeter of  `geom` in the unit specified by the unit parameter for areal geometries. For non-areal geometries the result is equivalent to geof:hasLength. If no unit parameter is given, the result is returned in the unit of the spatial reference system.
+The function http://www.opengis.net/def/function/geosparql/perimeter[`geof:perimeter`] returns the perimeter of  `geom` in the unit specified by the unit parameter for areal geometries. For non-areal geometries the result is equivalent to geof:hasLength. 
 
 ==== Function: geof:metricPerimeter
 


### PR DESCRIPTION
Closes #401

I also added corrections to the function definitions, so that each function now has a clickable function URI.

One question:
I added the phrase, "If no unit parameter is given, the result is returned in the unit of the spatial reference system"
Should we add that to all other non-metric functions as well, or should I remove it?
We have not talked about optional parameters yet, but it seemed logical to me to add it and comparable implementations like PostGIS also work this way.