### PR TITLE
Incorporating changes to ConcaveHull description in specification

### DIFF
--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -947,7 +947,7 @@ The function http://www.opengis.net/def/function/geosparql/convexHull[`geof:conv
 geof:concaveHull (geom: ogc:geomLiteral): ogc:geomLiteral
 ```
 
-The function http://www.opengis.net/def/function/geosparql/concaveHull[`geof:concaveHull`] returns a geometric object that represents all Points in the concave hull of `geom`. Calculations are in the spatial reference system of `geom`.
+The function http://www.opengis.net/def/function/geosparql/concaveHull[`geof:concaveHull`] returns a geometric object that represents all Points in the concave hull of `geom`. Calculations are in the spatial reference system of `geom`. Various implementers use parameters to calculate a concave hull. As such, two implementations may return different results from their concave hull functions for the same geometry. Implementers should make clear any default values used to calculate a concave hull in their documentation.
 
 ==== Function: geof:coordinateDimension
 


### PR DESCRIPTION
We're only handling the case of a ConcaveHull without any parameters because various implementers use different parameters and trying to handle all permutations of these is outside of the scope of the standard. As such, implementers will elect to set default values, and we wish to ensure that these are documented by them for their users.

Fixes #270