### PR TITLE
Fixing typo in Simple Features spec in our corresponding vocab

### DIFF
--- a/1.1/sf_geometries.ttl
+++ b/1.1/sf_geometries.ttl
@@ -66,7 +66,7 @@ The instantiable subclasses of Geometry are restricted to 0, 1 and 2-dimensional
 
 The interpretation of the coordinates is subject to the coordinate reference systems associated to the point. All coordinates within a geometry object should be in the same coordinate reference systems. Each coordinate shall be unambiguously associated to a coordinate reference system either directly or through its containing geometry. The z coordinate of a point is typically, but not necessarily, represents altitude or elevation. The m coordinate represents a measurement.
 
-All Geometry classes described in this specification are defined so that instances of Geometry are topologically closed, i.e. all represented geometries include their boundary as point sets. This does not affect their representation, and open version of the same classes may be used in other circumstances, such as topological representations."""@en ;
+All Geometry classes described in this specification are defined so that instances of Geometry are topologically closed, i.e. all represented geometries include their boundary as point sets. This does not affect their representation, and open versions of the same classes may be used in other circumstances, such as topological representations."""@en ;
     skos:prefLabel "Geometry"@en ;
 .
 


### PR DESCRIPTION
Responds to #270 but doesn't fix the underlying issue.