### PR TITLE
Addressing Issue 447

### DIFF
--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -1167,7 +1167,7 @@ The function http://www.opengis.net/def/function/geosparql/numGeometries[`geof:n
 ==== Function: geof:perimeter
 
 ```
-geof:perimeter (geom: ogc:geomLiteral, unit: xsd:anyURI): xsd:double
+geof:perimeter (geom: ogc:geomLiteral, unit: rdfs:Resource): xsd:double
 ```
 
 The function http://www.opengis.net/def/function/geosparql/perimeter[`geof:perimeter`] returns the perimeter of  `geom` in the unit specified by the unit parameter for areal geometries. For non-areal geometries the result is equivalent to geof:hasLength. 

--- a/1.1/spec/11-Part-08.adoc
+++ b/1.1/spec/11-Part-08.adoc
@@ -902,7 +902,7 @@ The function http://www.opengis.net/def/function/geosparql/metricArea[`geof:metr
 ==== Function: geof:area
 
 ```
-geof:area (geom: ogc:geomLiteral, units: xsd:anyURI): rdf:Resource
+geof:area (geom: ogc:geomLiteral, units: rdfs:Resource): xsd:double
 ```
 
 The function http://www.opengis.net/def/function/geosparql/area[`geof:area`] returns the area of `geom`. Must return zero for all geometry types other than Polygon. This function is similar to <<Function: geof:metricArea, `geof:metricArea`>>, which does not need a specification of measurement unit.
@@ -1101,7 +1101,7 @@ The function http://www.opengis.net/def/function/geosparql/metricLength[`geof:me
 ==== Function: geof:length
 
 ```
-geof:length (geom: ogc:geomLiteral, units: xsd:anyURI): xsd:double
+geof:length (geom: ogc:geomLiteral, units: rdfs:Resource): xsd:double
 ```
 
 The function http://www.opengis.net/def/function/geosparql/length[`geof:length`] returns the length of `geom`. The longest length from any one dimension is returned. This function is similar to <<Function: geof:metricLength, `geof:metricLength`>>, which does not need a specification of measurement unit.


### PR DESCRIPTION
Closes #447

I think @wouterbeek is correct so adopting his suggestions.

Also, I think it's wrong to expect UoM to be specified as an `xsd:anyURI` literal given UoM specification is usually like this

```
:some-length [
    qudt:value "350" ;
    qudt: unit <https://qudt.org/vocab/unit/KiloM> ;  # kilometres
] ;
```

where an IRI, not a URL literal, is used, so I have changes all units to `rdfs:Resource` too.