### PR TITLE
Fix wrong example links pointing to annex B instead of annex C

### DIFF
--- a/spec/ontology/vocabularies/geo.ttl
+++ b/spec/ontology/vocabularies/geo.ttl
@@ -106,7 +106,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	rdfs:seeAlso <https://portal.ogc.org/files/?artifact_id=20509> ; # TODO: replace with one that is guaranteed to be persistent
 	skos:prefLabel "GML Literal"@en ;
 	skos:example
-		spec11:B.1.2.4 ;
+		spec11:C.1.2.4 ;
 .
 
 :wktLiteral
@@ -119,7 +119,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	rdfs:seeAlso <https://portal.ogc.org/files/?artifact_id=25355> ; # TODO: replace with one that is guaranteed to be persistent
 	skos:prefLabel "Well-known Text Literal"@en ;
 	skos:example
-		spec11:B.2.2.2 ;
+		spec11:C.2.2.2 ;
 .
 
 :geoJSONLiteral
@@ -131,7 +131,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """A GeoJSON serialization of a Geometry object."""@en ;
 	skos:prefLabel "GeoJSON Literal"@en ;
 	skos:example
-		spec11:B.1.2.4 ;	
+		spec11:C.1.2.4 ;	
 .
 
 :kmlLiteral
@@ -143,7 +143,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """A KML serialization of a Geometry object."""@en ;
 	skos:prefLabel "KML Literal"@en ;
 	skos:example
-		spec11:B.1.2.4 ;	
+		spec11:C.1.2.4 ;	
 .
 
 :dggsLiteral
@@ -154,7 +154,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """A textual serialization of a Discrete Global Grid (DGGS) Geometry object."""@en ;
 	skos:example 
 		""" "<https://w3id.org/dggs/auspix> OrdinateList (R3234)"^^<http://www.opengis.net/ont/geosparql#dggsLiteral>""" ,
-		spec11:B.1.2.4 ;
+		spec11:C.1.2.4 ;
   rdfs:seeAlso <http://www.opengis.net/doc/AS/dggs/2.0> ;
 	skos:prefLabel "DGGS Literal"@en ;
 	skos:scopeNote "This datatype is not expected to be used directly but to serve as an abstract datatype for a series of specific DGGS literal types, for specific DGGS implementations"@en ;
@@ -179,8 +179,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:note """Duplicate properties defaultGeometry and hasDefaultGeometry exist because of an inconsistency between ontology and documentation in GeoSPARQL 1.0. Only hasDefaultGeometry is described in the documention."""@en ;
 	skos:prefLabel "default geometry"@en ;
 	skos:example
-		spec11:B.1.2.2 ,
-		spec11:B.2.1 ;
+		spec11:C.1.2.2 ,
+		spec11:C.2.1 ;
 .
 
 :hasDefaultGeometry 
@@ -316,18 +316,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """A spatial representation for a given Feature."""@en ;
 	skos:prefLabel "has geometry"@en ;
 	skos:example
-		spec11:B.1.1.2.2 ,
-		spec11:B.1.1.2.3 ,
-		spec11:B.1.1.2.4 ,
-		spec11:B.1.1.2.5 ,
-		spec11:B.1.1.2.6 ,
-		spec11:B.1.1.2.8 ,
-		spec11:B.1.1.3.2 ,
-		spec11:B.1.1.3.3 ,
-		spec11:B.1.2.2 ,
-		spec11:B.1.2.3 ,
-		spec11:B.1.2.4 ,
-		spec11:B.2 ;
+		spec11:C.1.1.2.2 ,
+		spec11:C.1.1.2.3 ,
+		spec11:C.1.1.2.4 ,
+		spec11:C.1.1.2.5 ,
+		spec11:C.1.1.2.6 ,
+		spec11:C.1.1.2.8 ,
+		spec11:C.1.1.3.2 ,
+		spec11:C.1.1.3.3 ,
+		spec11:C.1.2.2 ,
+		spec11:C.1.2.3 ,
+		spec11:C.1.2.4 ,
+		spec11:C.2 ;
 .
 
 :hasBoundingBox
@@ -342,7 +342,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:prefLabel "has bounding box"@en ;
 	skos:scopeNote "The target is a Geometry that defines a rectilinear region whose edges are aligned with the axes of the coordinate reference system, which exactly contains the Feature, for example an instance of http://www.opengis.net/ont/sf#envelope."@en ;
 	skos:example
-		spec11:B.1.2.2 ;
+		spec11:C.1.2.2 ;
 .
 
 :hasCentroid
@@ -357,7 +357,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:prefLabel "has centroid"@en ;
 	skos:scopeNote "The target Geometry shall describe a point, for example an instance of http://www.opengis.net/ont/sf#Point."@en ;
 	skos:example
-		spec11:B.1.2.2 ;	
+		spec11:C.1.2.2 ;	
 .
 
 :hasLength
@@ -370,8 +370,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The length of a Spatial Object."""@en ;
 	skos:prefLabel "has length"@en ;
 	skos:example
-		spec11:B.1.1.2.7 ,
-		spec11:B.1.2.2 ;
+		spec11:C.1.1.2.7 ,
+		spec11:C.1.2.2 ;
 .
 
 :hasPerimeterLength
@@ -384,7 +384,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The length of the perimeter of a Spatial Object."""@en ;
 	skos:prefLabel "has perimeter length"@en ;
 	skos:example
-		spec11:B.1.1.1.2 ;
+		spec11:C.1.1.1.2 ;
 .
 
 :hasArea
@@ -397,8 +397,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The area of a Spatial Object."""@en ;
 	skos:prefLabel "has area"@en ;
 	skos:example
-		spec11:B.1.1.2.4 ,
-		spec11:B.1.2.2 ;
+		spec11:C.1.1.2.4 ,
+		spec11:C.1.2.2 ;
 .
 
 :hasVolume
@@ -411,7 +411,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The volume of a three-dimensional Spatial Object."""@en ;
 	skos:prefLabel "has volume"@en ;
 	skos:example
-		spec11:B.1.2.2 ;	
+		spec11:C.1.2.2 ;	
 .	
 
 :hasSpatialResolution
@@ -424,7 +424,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:note """Spatial resolution specifies the level of detail of a Geometry. It the smallest distinguishable distance between spatially adjacent coordinates."""@en;
 	skos:prefLabel "has spatial resolution"@en ;
 	skos:example
-		spec11:B.1.2.2 ;		
+		spec11:C.1.2.2 ;		
 .
 
 :hasSpatialAccuracy
@@ -437,7 +437,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:note """Spatial accuracy is applicable when a Geometry is used to represent a Feature. It is expressed as a distance that indicates the truthfullness of the positions (coordinates) that define the Geometry. In this case accuracy defines a zone surrounding each coordinate within wich the real positions are known to be. The accuracy value defines this zone as a distance from the coordinate(s) in all directions (e.g. a line, a circle or a sphere, depending on spatial dimension)."""@en;
 	skos:prefLabel "has spatial accuracy"@en ;
 	skos:example
-		spec11:B.1.2.3 ;
+		spec11:C.1.2.3 ;
 .
 
 :rcc8dc
@@ -681,7 +681,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The GML serialization of a Geometry"""@en ;
 	skos:prefLabel "as GML"@en ;
 	skos:example 
-		spec11:B.1.2.4 ;	
+		spec11:C.1.2.4 ;	
 .
 
 :asWKT
@@ -696,18 +696,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The WKT serialization of a Geometry"""@en ;
 	skos:prefLabel "as WKT"@en ;
 	skos:example 
-		spec11:B.1.1.2.2 ,
-		spec11:B.1.1.2.3 ,
-		spec11:B.1.1.2.4 ,
-		spec11:B.1.1.2.5 ,
-		spec11:B.1.1.2.6 ,
-		spec11:B.1.1.2.8 ,
-		spec11:B.1.1.3.1 ,
-		spec11:B.1.1.3.2 ,
-		spec11:B.1.1.3.3 ,
-		spec11:B.1.2.2 ,
-		spec11:B.2.2.4 ,
-		spec11:B.2.1 ;
+		spec11:C.1.1.2.2 ,
+		spec11:C.1.1.2.3 ,
+		spec11:C.1.1.2.4 ,
+		spec11:C.1.1.2.5 ,
+		spec11:C.1.1.2.6 ,
+		spec11:C.1.1.2.8 ,
+		spec11:C.1.1.3.1 ,
+		spec11:C.1.1.3.2 ,
+		spec11:C.1.1.3.3 ,
+		spec11:C.1.2.2 ,
+		spec11:C.2.2.4 ,
+		spec11:C.2.1 ;
 .
 
 :asGeoJSON
@@ -722,7 +722,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The GeoJSON serialization of a Geometry"""@en ;
 	skos:prefLabel "as GeoJSON"@en ;
 	skos:example 
-		spec11:B.1.2.4 ;
+		spec11:C.1.2.4 ;
 .	
 
 :asKML
@@ -737,7 +737,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The KML serialization of a Geometry"""@en ;
 	skos:prefLabel "as KML"@en ;
 	skos:example 
-		spec11:B.1.2.4 ;
+		spec11:C.1.2.4 ;
 .	
 
 :asDGGS
@@ -751,7 +751,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The Discrete Global Grid System (DGGS) serialization of a Geometry"""@en ;	
 	skos:prefLabel "as DGGS"@en ;
 	skos:example 
-		spec11:B.1.2.4 ;
+		spec11:C.1.2.4 ;
 .	
 
 :coordinateDimension
@@ -764,7 +764,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The number of measurements or axes needed to describe the position of this Geometry in a coordinate system."""@en ;
 	skos:prefLabel "coordinate dimension"@en ;
 	skos:example 
-		spec11:B.1.2.3 ;	
+		spec11:C.1.2.3 ;	
 .
 
 :dimension
@@ -777,7 +777,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The topological dimension of this geometric object, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this will return the largest topological dimension of the contained objects."""@en ;
 	skos:prefLabel "dimension"@en ;
 	skos:example 
-		spec11:B.1.2.3 ;		
+		spec11:C.1.2.3 ;		
 .
 
 :hasSerialization
@@ -791,7 +791,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """Connects a Geometry object with its text-based serialization."""@en ;
 	skos:prefLabel "has serialization"@en ;
 	skos:example 
-		spec11:B.1.2.3 ;		
+		spec11:C.1.2.3 ;		
 .
 
 :isEmpty
@@ -805,7 +805,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """(true) if this geometric object is the empty Geometry. If true, then this geometric object represents the empty point set for the coordinate space."""@en ;
 	skos:prefLabel "is empty"@en ;
 	skos:example 
-		spec11:B.1.2.3 ;		
+		spec11:C.1.2.3 ;		
 .
 
 :isSimple
@@ -820,7 +820,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	rdfs:seeAlso <https://portal.ogc.org/files/?artifact_id=25355> ;
 	skos:prefLabel "is simple"@en ;
 	skos:example 
-		spec11:B.1.2.3 ;		
+		spec11:C.1.2.3 ;		
 .
 
 :spatialDimension
@@ -834,7 +834,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The number of measurements or axes needed to describe the spatial position of this Geometry in a coordinate system."""@en ;
 	skos:prefLabel "spatial dimension"@en ;
 	skos:example 
-		spec11:B.1.2.3 ;		
+		spec11:C.1.2.3 ;		
 .
 
 :hasMetricSpatialResolution
@@ -848,8 +848,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:note """Spatial resolution specifies the level of detail of a Geometry. It the smallest dinstinguishable distance between spatially adjacent coordinates."""@en;
 	skos:prefLabel "has spatial resolution in meters"@en ;
 	skos:example 
-		spec11:B.1.1.2.6 ,
-		spec11:B.1.2.2 ;
+		spec11:C.1.1.2.6 ,
+		spec11:C.1.2.2 ;
 .
 
 :hasMetricSpatialAccuracy
@@ -863,7 +863,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:note """Spatial accuracy is applicable when a Geometry is used to represent a Feature. It is expressed as a distance that indicates the truthfullness of the positions (coordinates) that define the Geometry. In this case accuracy defines a zone surrounding each coordinate within wich the real positions are known to be. The accuracy value defines this zone as a distance from the coordinate(s) in all directions (e.g. a line, a circle or a sphere, depending on spatial dimension)."""@en;
 	skos:prefLabel "has spatial accuracy in meters"@en ;
 	skos:example
-		spec11:B.1.2.3 ;
+		spec11:C.1.2.3 ;
 .
 
 :hasMetricLength
@@ -877,7 +877,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The length of a Spatial Object in meters."""@en ;
 	skos:prefLabel "has length in meters"@en ;
 	skos:example
-		spec11:B.1.2.2 ;	
+		spec11:C.1.2.2 ;	
 .
 
 :hasMetricPerimeterLength
@@ -891,7 +891,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The length of the perimeter of a Spatial Object in meters."""@en ;
 	skos:prefLabel "has perimeter length in meters"@en ;
 	skos:example
-		spec11:B.1.1.1.2 ;		
+		spec11:C.1.1.1.2 ;		
 .
 
 :hasMetricArea
@@ -905,10 +905,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The area of a Spatial Object in square meters."""@en ;
 	skos:prefLabel "has area in square meters"@en ;
 	skos:example
-		spec11:B.1.1.2.3 ,
-		spec11:B.1.1.2.9 ,
-		spec11:B.1.1.3.3 ,
-		spec11:B.1.2.2 ;
+		spec11:C.1.1.2.3 ,
+		spec11:C.1.1.2.9 ,
+		spec11:C.1.1.3.3 ,
+		spec11:C.1.2.2 ;
 .
 
 :hasMetricVolume
@@ -922,8 +922,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition """The volume of a Spatial Object in cubic meters."""@en ;
 	skos:prefLabel "has volume in cubic meters"@en ;
 	skos:example
-		spec11:B.1.1.2.9 ,
-		spec11:B.1.2.2 ;
+		spec11:C.1.1.2.9 ,
+		spec11:C.1.2.2 ;
 .
 
 :hasMetricSize
@@ -955,20 +955,20 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:note """A Feature represents a uniquely identifiable phenomenon, for example a river or an apple. While such phenomena (and therefore the Features used to represent them) are bounded, their boundaries may be crisp (e.g., the declared boundaries of a state), vague (e.g., the delineation of a valley versus its neighboring mountains), and change with time (e.g., a storm front). While discrete in nature, Features may be created from continuous observations, such as an isochrone that determines the region that can be reached by ambulance within 5 minutes."""@en ;
 	skos:prefLabel "Feature"@en ;
 	skos:example
-		spec11:B.1.1.2.1 ,
-		spec11:B.1.1.2.2 ,
-		spec11:B.1.1.2.3 ,
-		spec11:B.1.1.2.4 ,
-		spec11:B.1.1.2.5 ,
-		spec11:B.1.1.2.6 ,
-		spec11:B.1.1.2.7 ,
-		spec11:B.1.1.2.8 ,
-		spec11:B.1.1.2.9 ,
-		spec11:B.1.1.3.2 ,
-		spec11:B.1.1.3.3 ,
-		spec11:B.1.2.2 ,
-		spec11:B.1.2.3 ,
-		spec11:B.1.2.4 ;
+		spec11:C.1.1.2.1 ,
+		spec11:C.1.1.2.2 ,
+		spec11:C.1.1.2.3 ,
+		spec11:C.1.1.2.4 ,
+		spec11:C.1.1.2.5 ,
+		spec11:C.1.1.2.6 ,
+		spec11:C.1.1.2.7 ,
+		spec11:C.1.1.2.8 ,
+		spec11:C.1.1.2.9 ,
+		spec11:C.1.1.3.2 ,
+		spec11:C.1.1.3.3 ,
+		spec11:C.1.2.2 ,
+		spec11:C.1.2.3 ,
+		spec11:C.1.2.4 ;
 .
 
 :FeatureCollection
@@ -985,7 +985,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:prefLabel "Feature Collection"@en ;
 	skos:definition "A collection of individual Features."@en ;
 	skos:example
-		spec11:B.1.1.6 ;
+		spec11:C.1.1.6 ;
 .
 
 :Geometry
@@ -999,18 +999,18 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:note """Geometry can be used as a representation of the shape, extent or location of a Feature and may exist as a self-contained entity."""@en ;
 	skos:prefLabel "Geometry"@en ;
 	skos:example 
-		spec11:B.1.1.2.2 , 
-		spec11:B.1.1.2.3 , 
-		spec11:B.1.1.2.4 , 
-		spec11:B.1.1.2.5 , 
-		spec11:B.1.1.2.6 , 
-		spec11:B.1.1.2.8 , 
-		spec11:B.1.1.3.1 , 
-		spec11:B.1.1.3.2 , 
-		spec11:B.1.1.3.3 ,
-		spec11:B.1.2.2 ,
-		spec11:B.1.2.3 ,
-		spec11:B.1.2.4 ;
+		spec11:C.1.1.2.2 , 
+		spec11:C.1.1.2.3 , 
+		spec11:C.1.1.2.4 , 
+		spec11:C.1.1.2.5 , 
+		spec11:C.1.1.2.6 , 
+		spec11:C.1.1.2.8 , 
+		spec11:C.1.1.3.1 , 
+		spec11:C.1.1.3.2 , 
+		spec11:C.1.1.3.3 ,
+		spec11:C.1.2.2 ,
+		spec11:C.1.2.3 ,
+		spec11:C.1.2.4 ;
 .
 
 :GeometryCollection
@@ -1027,7 +1027,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:definition "A collection of individual Geometries."@en ;
 	skos:prefLabel "Geometry Collection"@en ;
 	skos:example
-		spec11:B.1.1.7 ;
+		spec11:C.1.1.7 ;
 .
 
 :SpatialObject
@@ -1040,8 +1040,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	skos:note """Subclasses of this class are expected to be used for instance data."""@en ;
 	skos:prefLabel "Spatial Object"@en ;
 	skos:example
-		spec11:B.1.1.1.1 ,
-		spec11:B.1.1.1.2 ;
+		spec11:C.1.1.1.1 ,
+		spec11:C.1.1.1.2 ;
 .
 
 :SpatialObjectCollection


### PR DESCRIPTION
The skos:example links in geo.ttl wrongly point to annex B and not annex C as pointed out by #473

Closes #473