### PR TITLE
Clarifications for minXYZ functions

### DIFF
--- a/spec/11-Part-08.adoc
+++ b/spec/11-Part-08.adoc
@@ -1114,7 +1114,7 @@ NOTE: See the <<Recommendation for specification of units of measurement, Recomm
 geof:maxX (geom: ogc:geomLiteral): xsd:double
 ```
 
-The function http://www.opengis.net/def/function/geosparql/maxX[`geof:maxX`] returns the maximum X coordinate for `geom`.
+The function http://www.opengis.net/def/function/geosparql/maxX[`geof:maxX`] returns the maximum X coordinate for `geom` using the SRS of `geom` .
 
 ==== Function: geof:maxY
 
@@ -1122,7 +1122,7 @@ The function http://www.opengis.net/def/function/geosparql/maxX[`geof:maxX`] ret
 geof:maxY (geom: ogc:geomLiteral): xsd:double
 ```
 
-The function http://www.opengis.net/def/function/geosparql/maxY[`geof:maxY`] returns the maximum Y coordinate for `geom`.
+The function http://www.opengis.net/def/function/geosparql/maxY[`geof:maxY`] returns the maximum Y coordinate for `geom` using the SRS of `geom` .
 
 ==== Function: geof:maxZ
 
@@ -1130,7 +1130,7 @@ The function http://www.opengis.net/def/function/geosparql/maxY[`geof:maxY`] ret
 geof:maxZ (geom: ogc:geomLiteral): xsd:double
 ```
 
-The function http://www.opengis.net/def/function/geosparql/maxZ[`geof:maxZ`] returns the maximum Z coordinate for `geom`.
+The function http://www.opengis.net/def/function/geosparql/maxZ[`geof:maxZ`] returns the maximum Z coordinate for `geom` using the SRS of `geom` .
 
 ==== Function: geof:minX
 
@@ -1138,7 +1138,7 @@ The function http://www.opengis.net/def/function/geosparql/maxZ[`geof:maxZ`] ret
 geof:minX (geom: ogc:geomLiteral): xsd:double
 ```
 
-The function http://www.opengis.net/def/function/geosparql/minX[`geof:minX`] returns the minimum X coordinate for `geom`.
+The function http://www.opengis.net/def/function/geosparql/minX[`geof:minX`] returns the minimum X coordinate for `geom` using the SRS of `geom` .
 
 ==== Function: geof:minY
 
@@ -1146,7 +1146,7 @@ The function http://www.opengis.net/def/function/geosparql/minX[`geof:minX`] ret
 geof:minY (geom: ogc:geomLiteral): xsd:double
 ```
 
-The function http://www.opengis.net/def/function/geosparql/minY[`geof:minY`] returns the minimum Y coordinate for `geom`.
+The function http://www.opengis.net/def/function/geosparql/minY[`geof:minY`] returns the minimum Y coordinate for `geom` using the SRS of `geom` .
 
 ==== Function: geof:minZ
 
@@ -1154,7 +1154,7 @@ The function http://www.opengis.net/def/function/geosparql/minY[`geof:minY`] ret
 geof:minZ (geom: ogc:geomLiteral): xsd:double
 ```
 
-The function http://www.opengis.net/def/function/geosparql/minZ[`geof:minZ`] returns the minimum Z coordinate for `geom`.
+The function http://www.opengis.net/def/function/geosparql/minZ[`geof:minZ`] returns the minimum Z coordinate for `geom` using the SRS of `geom` .
 
 ==== Function: geof:numGeometries
 


### PR DESCRIPTION
Issue #477 suggested to clarify that the minimum and maximum XYZ coordinate functions return the coordinate in the SRS of the geometry which was given as a parameter

Closes #477