### PR TITLE
Fix typo in schemaorg-alignments.ttl

### DIFF
--- a/alignments/schemaorg-alignments.ttl
+++ b/alignments/schemaorg-alignments.ttl
@@ -5,7 +5,7 @@
 @prefix sf: <http://www.opengis.net/ont/sf#> .
 
 geo:Geometry rdfs:subClassOf sdo:GeoShape .
-sdo:GeospatialGeomery owl:equivalentClass geo:SpatialObject .
+sdo:GeospatialGeometry owl:equivalentClass geo:SpatialObject .
 sdo:GeoCoordinates rdfs:subClassOf geo:Geometry .
 sdo:geo rdfs:subPropertyOf geo:hasGeometry .
 sdo:geoCoveredBy owl:equivalentProperty geo:ehCoveredBy .


### PR DESCRIPTION
One instance of "Geometry" was spelled "Geomery"

(See also: https://schema.org/GeospatialGeometry )