### PR TITLE
More topological relation equivalences

### DIFF
--- a/spec/sections/10-topology_extension.adoc
+++ b/spec/sections/10-topology_extension.adoc
@@ -140,11 +140,11 @@ Topological relations in the _RCC8_ family are summarized in <<rcc8_relations>>.
 |===
 |Simple Features | RCC8 | Egenhofer
 
-|equals | equals | equals
-|disjoint | disconnected | disjoint
-|intersects | `¬` disconnected | `¬` disjoint
-|touches | externally connected | meet
-|within | non-tangential proper part `+` tangential proper part | inside `+` coveredBy
-|contains | non-tangential proper part inverse `+` tangential proper part inverse | contains `+` covers
-|overlaps | partially overlapping | overlap
+|[[geo:sfEquals]]equals | equals | equals
+|[[geo:sfDisjoint]]disjoint | [[Property:geo:rcc8dc]]disconnected | [[Property:geo:ehDisjoint]]disjoint
+|[[geo:sfIntersects]]intersects | `¬` [[Property:geo:rcc8dc]]disconnected | `¬` [[Property:geo:ehDisjoint]]disjoint
+|[[geo:sfTouches]]touches | [[Property:geo:rcc8ec]]externally connected | [[Property:geo:ehMeet]]meet
+|[[geo:sfWithin]]within | [[Property:geo:rcc8ntpp]]non-tangential proper part `+` [[Property:geo:rcc8tpp]]tangential proper part | [[Property:geo:ehInside]]inside `+` [[Property:geo:ehCoveredBy]]covered by
+|[[geo:sfContains]]contains | [[Property:geo:rcc8ntppi]]non-tangential proper part inverse `+` [[Property:geo:rcc8tppi]]tangential proper part inverse | [[Property:geo:ehContains]]contains `+` [[Property:geo:ehCovers]]covers
+|[[geo:sfOoverlaps]]overlaps | [[Property:geo:rcc8po]]partially overlapping | [[Property:geo:ehOverlap]]overlap
 |===

--- a/spec/sections/10-topology_extension.adoc
+++ b/spec/sections/10-topology_extension.adoc
@@ -51,7 +51,7 @@ Topological relations in the _Simple Features_ family are summarized in <<sf_rel
 |[[geo:sfTouches]]touches | http://www.opengis.net/ont/geosparql#sfTouches[`geo:sfTouches`] | <<Class: geo:SpatialObject, `geo:SpatialObject`>> | `All except P/P` | `+(FT******* F**T***** F***T****)+`
 |[[geo:sfWithin]]within | http://www.opengis.net/ont/geosparql#sfWithin[`geo:sfWithin`] | <<Class: geo:SpatialObject, `geo:SpatialObject`>> | `All` | `+(T*F**F***)+`
 |[[geo:sfContains]]contains | http://www.opengis.net/ont/geosparql#sfContains[`geo:sfContains`] | <<Class: geo:SpatialObject, `geo:SpatialObject`>> | `All` | `+(T*****FF*)+`
-|[[geo:sfOoverlaps]]overlaps | http://www.opengis.net/ont/geosparql#sfOverlaps[`geo:sfOverlaps`] | <<Class: geo:SpatialObject, `geo:SpatialObject`>> | `A/A, P/P, L/L` | `+(T*T***T**) for A/A, P/P+`; `+(1*T***T**) for L/L+`
+|[[geo:sfOverlaps]]overlaps | http://www.opengis.net/ont/geosparql#sfOverlaps[`geo:sfOverlaps`] | <<Class: geo:SpatialObject, `geo:SpatialObject`>> | `A/A, P/P, L/L` | `+(T*T***T**) for A/A, P/P+`; `+(1*T***T**) for L/L+`
 |[[geo:sfCrosses]]crosses | http://www.opengis.net/ont/geosparql#sfCrosses[`geo:sfCrosses`] | <<Class: geo:SpatialObject, `geo:SpatialObject`>> | `P/L, P/A, L/A, L/L` | `+(T*T***T**) for P/L, P/A,
 L/A+`; `+(0********) for L/L+`
 |===

--- a/spec/sections/10-topology_extension.adoc
+++ b/spec/sections/10-topology_extension.adoc
@@ -140,7 +140,7 @@ Topological relations in the _RCC8_ family are summarized in <<rcc8_relations>>.
 |===
 |Simple Features | RCC8 | Egenhofer
 
-|[[geo:sfEquals]]equals | equals | equals
+|[[geo:sfEquals]]equals | [[Property:geo:rcc8eq]]equals | [[Property:geo:ehEquals]]equals
 |[[geo:sfDisjoint]]disjoint | [[Property:geo:rcc8dc]]disconnected | [[Property:geo:ehDisjoint]]disjoint
 |[[geo:sfIntersects]]intersects | `¬` [[Property:geo:rcc8dc]]disconnected | `¬` [[Property:geo:ehDisjoint]]disjoint
 |[[geo:sfTouches]]touches | [[Property:geo:rcc8ec]]externally connected | [[Property:geo:ehMeet]]meet

--- a/spec/sections/10-topology_extension.adoc
+++ b/spec/sections/10-topology_extension.adoc
@@ -146,5 +146,5 @@ Topological relations in the _RCC8_ family are summarized in <<rcc8_relations>>.
 |[[geo:sfTouches]]touches | [[Property:geo:rcc8ec]]externally connected | [[Property:geo:ehMeet]]meet
 |[[geo:sfWithin]]within | [[Property:geo:rcc8ntpp]]non-tangential proper part `+` [[Property:geo:rcc8tpp]]tangential proper part | [[Property:geo:ehInside]]inside `+` [[Property:geo:ehCoveredBy]]covered by
 |[[geo:sfContains]]contains | [[Property:geo:rcc8ntppi]]non-tangential proper part inverse `+` [[Property:geo:rcc8tppi]]tangential proper part inverse | [[Property:geo:ehContains]]contains `+` [[Property:geo:ehCovers]]covers
-|[[geo:sfOoverlaps]]overlaps | [[Property:geo:rcc8po]]partially overlapping | [[Property:geo:ehOverlap]]overlap
+|[[geo:sfOverlaps]]overlaps | [[Property:geo:rcc8po]]partially overlapping | [[Property:geo:ehOverlap]]overlap
 |===

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -530,6 +530,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:subPropertyOf :sfContains ;
 	rdfs:isDefinedBy 
 		:  , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , 
@@ -571,6 +572,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:subPropertyOf :sfContains ;
 	rdfs:isDefinedBy 
 		:  , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , 

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -516,6 +516,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:subPropertyOf :sfWithin ;
 	rdfs:isDefinedBy 
 		:  , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , 
@@ -556,6 +557,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:subPropertyOf :sfWithin ;
 	rdfs:isDefinedBy 
 		:  , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , 

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -278,7 +278,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :ehEquals
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :sfEquals ;
+	owl:equivalentProperty :sfEquals, :rcc8eq ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy
@@ -496,6 +496,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:equivalentProperty :sfEquals, :ehEquals
 	rdfs:isDefinedBy 
 		:  , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , 
@@ -613,7 +614,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :sfEquals
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :ehEquals ;
+	owl:equivalentProperty :ehEquals, :rcc8eq ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy 

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -240,6 +240,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:subPropertyOf :sfWithin ;
 	rdfs:isDefinedBy
 		: ,
 		<http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/eh-spatial-relations> ,
@@ -296,6 +297,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:subPropertyOf :sfWithin ;
 	rdfs:isDefinedBy
 		: ,
 		<http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/eh-spatial-relations> ,

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -266,6 +266,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	owl:equivalentProperty :sfDisjoint ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:complementOf :sfIntersects ;
 	rdfs:isDefinedBy
 		: ,
 		<http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/eh-spatial-relations> ,
@@ -599,6 +600,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	owl:equivalentProperty :ehDisjoint ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:complementOf :sfIntersects ;
 	rdfs:isDefinedBy 
 		: , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> ,
@@ -626,6 +628,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:complementOf :sfDisjoint, :ehDisjoint ;
 	rdfs:isDefinedBy 
 		: , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> ,
@@ -639,7 +642,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	owl:equivalentProperty geo:ehOverlap ;
+	owl:equivalentProperty :ehOverlap ;
 	rdfs:isDefinedBy 
 		: , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> ,

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -226,6 +226,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:subPropertyOf :sfContains ;
 	rdfs:isDefinedBy
 		: ,
 		<http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/eh-spatial-relations> ,
@@ -252,6 +253,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:subPropertyOf :sfContains ;
 	rdfs:isDefinedBy
 		: ,
 		<http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/eh-spatial-relations> ,

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -305,7 +305,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :ehMeet
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :sfTouches ;
+	owl:equivalentProperty :sfTouches, :rcc8ec ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy
@@ -483,6 +483,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:equivalentProperty :sfTouches, :ehMeet ;
 	rdfs:isDefinedBy 
 		:  , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , 
@@ -656,7 +657,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :sfTouches
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :ehMeet ;
+	owl:equivalentProperty :ehMeet, :rcc8ec ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	rdfs:isDefinedBy 

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -263,7 +263,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :ehDisjoint
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :sfDisjoint ;
+	owl:equivalentProperty :sfDisjoint, :rcc8dc ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	owl:complementOf :sfIntersects ;
@@ -469,6 +469,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:equivalentProperty :sfDisjoint, :ehDisjoint ;
 	rdfs:isDefinedBy 
 		:  , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , 
@@ -597,7 +598,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :sfDisjoint
 	a rdf:Property, owl:ObjectProperty ;
-	owl:equivalentProperty :ehDisjoint ;
+	owl:equivalentProperty :ehDisjoint, :rcc8dc ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
 	owl:complementOf :sfIntersects ;

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -268,7 +268,7 @@ geo:ehDisjoint
 	owl:equivalentProperty :sfDisjoint, :rcc8dc ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	owl:complementOf :sfIntersects ;
+	owl:propertyDisjointWith  :sfIntersects ;
 	rdfs:isDefinedBy
 		: ,
 		<http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/eh-spatial-relations> ,
@@ -612,7 +612,7 @@ geo:sfDisjoint
 	owl:equivalentProperty :ehDisjoint, :rcc8dc ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	owl:complementOf :sfIntersects ;
+	owl:propertyDisjointWith  :sfIntersects ;
 	rdfs:isDefinedBy 
 		: , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> ,
@@ -640,7 +640,7 @@ geo:sfIntersects
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	owl:complementOf :sfDisjoint, :ehDisjoint ;
+	owl:propertyDisjointWith  :sfDisjoint, :ehDisjoint ;
 	rdfs:isDefinedBy 
 		: , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> ,

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -321,6 +321,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:equivalentProperty :sfOverlaps, :rcc8po ;
 	rdfs:isDefinedBy
 		: ,
 		<http://www.opengis.net/spec/geosparql/1.0/req/geometry-extension/eh-spatial-relations> ,
@@ -537,6 +538,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:equivalentProperty :sfOverlaps, :ehOverlap ;
 	rdfs:isDefinedBy 
 		:  , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/rcc8-spatial-relations> , 
@@ -645,7 +647,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
-	owl:equivalentProperty :ehOverlap ;
+	owl:equivalentProperty :ehOverlap, :rcc8po ;
 	rdfs:isDefinedBy 
 		: , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> ,

--- a/vocabularies/geo.ttl
+++ b/vocabularies/geo.ttl
@@ -639,6 +639,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 	a rdf:Property, owl:ObjectProperty ;
 	rdfs:domain :SpatialObject ;
 	rdfs:range :SpatialObject ;
+	owl:equivalentProperty geo:ehOverlap ;
 	rdfs:isDefinedBy 
 		: , 
 		<http://www.opengis.net/spec/geosparql/1.0/req/topology-vocab-extension/sf-spatial-relations> ,


### PR DESCRIPTION
Closes #510

Adds topological relations missing from geo.ttl and updates the specification with better links in the topological relation equivalences table.

@VladimirAlexiev

