### PR TITLE
Default parameter for transform function

### DIFF
--- a/spec/sections/11-geometry_extension.adoc
+++ b/spec/sections/11-geometry_extension.adoc
@@ -1225,7 +1225,8 @@ Implementations shall support the functions
 <<Function: geof:isSimple, `geof:isSimple`>>, 
 <<Function: geof:spatialDimension, `geof:spatialDimension`>>, 
 <<Function: geof:symDifference, `geof:symDifference`>>, 
-<<Function: geof:transform, `geof:transform`>> and
+<<Function: geof:transform, `geof:transform`>>,
+<<Function: geof:transformCRS84, `geof:transformCRS84`>>and
 <<Function: geof:union, `geof:union`>>
 as SPARQL extension functions, consistent with definitions of these functions in Simple Features <<OGC06-103r4>> <<ISO19125-1>>, for non-DGGS geometry literals.
 ====
@@ -1837,10 +1838,25 @@ The function http://www.opengis.net/def/function/geosparql/symDifference[`geof:s
 [%unnumbered]
 [source,turtle]
 ----
-geof:transform (geom: ogc:geomLiteral, srsIRI="http://www.opengis.net/def/crs/OGC/1.3/CRS84": xsd:anyURI): ogc:geomLiteral
+geof:transform (geom: ogc:geomLiteral, srsIRI: xsd:anyURI): ogc:geomLiteral
 ----
 
 The function http://www.opengis.net/def/function/geosparql/transform[geof:transform] converts `geom` to a spatial reference system defined by srsIRI. The function raises an error if a transformation is not mathematically possible.
+
+[NOTE,keep-separate=true]
+====
+We recommend that implementers use the same literal type as a result of this function as the type of the input literal.
+====
+
+==== Function: geof:transformCRS84
+
+[%unnumbered]
+[source,turtle]
+----
+geof:transformCRS84 (geom: ogc:geomLiteral): ogc:geomLiteral
+----
+
+The function http://www.opengis.net/def/function/geosparql/transformCRS84[geof:transformCRS84] converts `geom` to the CRS84 coordinate system. The function raises an error if a transformation is not mathematically possible.
 
 [NOTE,keep-separate=true]
 ====

--- a/spec/sections/11-geometry_extension.adoc
+++ b/spec/sections/11-geometry_extension.adoc
@@ -1837,7 +1837,7 @@ The function http://www.opengis.net/def/function/geosparql/symDifference[`geof:s
 [%unnumbered]
 [source,turtle]
 ----
-geof:transform (geom: ogc:geomLiteral, srsIRI: xsd:anyURI="http://www.opengis.net/def/crs/OGC/1.3/CRS84"): ogc:geomLiteral
+geof:transform (geom: ogc:geomLiteral, srsIRI="http://www.opengis.net/def/crs/OGC/1.3/CRS84": xsd:anyURI): ogc:geomLiteral
 ----
 
 The function http://www.opengis.net/def/function/geosparql/transform[geof:transform] converts `geom` to a spatial reference system defined by srsIRI. The function raises an error if a transformation is not mathematically possible.

--- a/spec/sections/11-geometry_extension.adoc
+++ b/spec/sections/11-geometry_extension.adoc
@@ -1837,7 +1837,7 @@ The function http://www.opengis.net/def/function/geosparql/symDifference[`geof:s
 [%unnumbered]
 [source,turtle]
 ----
-geof:transform (geom: ogc:geomLiteral, srsIRI: xsd:anyURI): ogc:geomLiteral
+geof:transform (geom: ogc:geomLiteral, srsIRI: xsd:anyURI="http://www.opengis.net/def/crs/OGC/1.3/CRS84"): ogc:geomLiteral
 ----
 
 The function http://www.opengis.net/def/function/geosparql/transform[geof:transform] converts `geom` to a spatial reference system defined by srsIRI. The function raises an error if a transformation is not mathematically possible.

--- a/vocabularies/functions.ttl
+++ b/vocabularies/functions.ttl
@@ -420,7 +420,8 @@ geofp:transform_param1 a fno:Parameter ;
 
 geofp:transform_param2 a fno:Parameter ;
     fno:type xsd:anyURI ;
-    fno:required "true"^^xsd:boolean ;
+    fno:required "false"^^xsd:boolean ;
+    rdf:value "http://www.opengis.net/def/crs/OGC/1.3/CRS84"^^xsd:anyURI ;
     skos:prefLabel "srsIRI"@en .
 
 geofo:transform_output a fno:Output ;

--- a/vocabularies/functions.ttl
+++ b/vocabularies/functions.ttl
@@ -420,7 +420,7 @@ geofp:transform_param1 a fno:Parameter ;
 
 geofp:transform_param2 a fno:Parameter ;
     fno:type xsd:anyURI ;
-    fno:required "false"^^xsd:boolean ;
+    fno:required "true"^^xsd:boolean ;
     skos:prefLabel "srsIRI"@en .
 
 geofo:transform_output a fno:Output ;

--- a/vocabularies/functions.ttl
+++ b/vocabularies/functions.ttl
@@ -421,10 +421,33 @@ geofp:transform_param1 a fno:Parameter ;
 geofp:transform_param2 a fno:Parameter ;
     fno:type xsd:anyURI ;
     fno:required "false"^^xsd:boolean ;
-    rdf:value "http://www.opengis.net/def/crs/OGC/1.3/CRS84"^^xsd:anyURI ;
     skos:prefLabel "srsIRI"@en .
 
 geofo:transform_output a fno:Output ;
+    fno:required "true"^^xsd:boolean ;    
+    fno:type geo:wktLiteral, geo:ewkbLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral .
+
+
+geof:transformCRS84
+    a sd:Function, fno:Function , skos:Concept ;
+    skos:inScheme cs: ;
+    dcterms:source <http://www.opengis.net/doc/geosparql/1.1> ;
+    fno:expects (geofp:transformCRS84_param1 geofp:transformCRS84_param2 ) ;
+    fno:returns (geofo:transformCRS84_output ) ;
+    policy:status status:valid ;
+    rdfs:isDefinedBy <http://www.opengis.net/spec/geosparql/1.1/req/geometry-extension/query-functions> ;
+    rdfs:seeAlso <http://www.opengis.net/doc/geosparql/1.1> ;
+    skos:definition "A query function that converts a given geometry to the CRS84 coordinate reference system. The function raises an error if a transformation is not mathematically possible."@en ;
+    skos:prefLabel "transformCRS84"@en ;
+.
+
+
+geofp:transformCRS84_param1 a fno:Parameter ;
+    fno:type geo:wktLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral, geo:geocodeLiteral ;
+    fno:required "true"^^xsd:boolean ;
+    skos:prefLabel "geom"@en .
+
+geofo:transformCRS84_output a fno:Output ;
     fno:required "true"^^xsd:boolean ;    
     fno:type geo:wktLiteral, geo:ewkbLiteral, geo:gmlLiteral, geo:geoJSONLiteral, geo:kmlLiteral, geo:dggsLiteral .
 


### PR DESCRIPTION
Closes #503

This pull request attempts to define a default parameter in the transform function.

My main question here is:

Is that the way you define a default parameter in the spec?
Or is the correct way to do that to define two function definitions?

If we define default parameters like this in the future, is that understandable enough for implementers?

Also; A good idea to revisit #110 in this discussion