### PR TITLE
New GeoJSON and Schema.org alignments

### DIFF
--- a/alignments/geojsonld-alignments.ttl
+++ b/alignments/geojsonld-alignments.ttl
@@ -1,0 +1,19 @@
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix geojson: <https://purl.org/geojson/vocab#> .
+@prefix sf: <http://www.opengis.net/ont/sf#> .
+
+geojson:Feature owl:equivalentClass geo:Feature .
+geojson:FeatureCollection owl:equivalentClass geo:FeatureCollection .
+geojson:GeometryCollection owl:equivalentClass geo:GeometryCollection .
+geojson:LineString owl:equivalentClass sf:LineString .
+geojson:MultiLineString owl:equivalentClass sf:MultiLineString .
+geojson:MultiPoint owl:equivalentClass sf:MultiPoint .
+geojson:MultiPolygon owl:equivalentClass sf:MultiPolygon .
+geojson:Point owl:equivalentClass sf:Point .
+geojson:features owl:equivalentProperty rdfs:member .
+geojson:geometry owl:equivalentProperty geo:hasGeometry .
+geojson:coordinates owl:equivalentProperty geo:hasSerialization .
+geojson:bbox owl:equivalentProperty geo:hasBoundingBox .
+

--- a/alignments/schemaorg-alignments.ttl
+++ b/alignments/schemaorg-alignments.ttl
@@ -7,6 +7,9 @@
 geo:Geometry rdfs:subClassOf sdo:GeoShape .
 sdo:GeospatialGeometry owl:equivalentClass geo:SpatialObject .
 sdo:GeoCoordinates rdfs:subClassOf geo:Geometry .
+sdo:Place rdfs:subClassOf geo:Feature .
+sdo:containedInPlace rdfs:subPropertyOf geo:sfWithin .
+sdo:containsPlace rdfs:subPropertyOf geo:sfContains .
 sdo:geo rdfs:subPropertyOf geo:hasGeometry .
 sdo:geoCoveredBy owl:equivalentProperty geo:ehCoveredBy .
 sdo:geoCovers owl:equivalentProperty geo:ehCovers .
@@ -18,3 +21,6 @@ sdo:geoOverlaps owl:equivalentProperty geo:sfOverlaps .
 sdo:geoTouches owl:equivalentProperty geo:sfTouches .
 sdo:geoWithin owl:equivalentProperty geo:sfWithin .
 sdo:Landform rdfs:subClassOf geo:Feature .
+sdo:longitude owl:equivalentProperty geo:northing .
+sdo:latitude owl:equivalentProperty geo:easting .
+


### PR DESCRIPTION
Closes #538 #540

@nicholascar 
Open questions:

- [ ] sdo:location how does it relate to GeoSPARQL?
- [ ] sdo:contentLocation how does it relate to GeoSPARQL?
- [ ] sdo:hasMap how does it relate to GeoSPARQL?
- [ ] sdo:latitude and sdo:longitude could relate to properties for northing and easting. Should we define them? We only have functions for them now.
- [ ]  geojson:bbox links to a list of coordinates, geo:hasBoundingBox links to a geometry. Are these properties related?
- [ ] geojson:coordinates is it equivalent to any of the literal properties such as geo:asWKT?

Once these questions are clarified:

- [ ] Waiting for PR #527 to be merged since the alignments need to be documented in the new alignments document and not as a Annex