### PR TITLE
[notes] Adding meeting notes for newer meetings

### DIFF
--- a/_posts/2024-06-26-notes.md
+++ b/_posts/2024-06-26-notes.md
@@ -1,0 +1,53 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/06/26
+---
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 06/26/2024  
+
+**Meeting Time:** 2005–2119 UTC  
+
+**Meeting Location:** Online  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matt Perry | MP |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+| Joseph Abhayaratna | JA |
+| Paul Cripps | PC |
+
+**Apologies:** None  
+
+**Absent:** None
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+|  | — | — | — |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2005 | Roll call and call for patents | All | Roll call completed. Call for patents held. Quorum confirmed. |
+| 2010 | Pull Requests | All | {::nomarkdown}<ul><li>Extend hasGeometry to allow for GeometryCollections (#525).</li><li>Union expressions in range expressions are forbidden in OWL2 RL; need for a concrete superclass identified.</li><li>NC suggested <code>:Geometry :havePart :Geometry</code> with an intermediate Geometry instance.</li><li>Alternative proposed: make GeometryCollection a subclass of Geometry.</li><li>NC to work on writing up a subclass proposal.</li><li>Latitude and Longitude Functions (#526): function defined only for points.</li><li>TH updated specification to state the function applies only to points.</li><li>Discussion on projected CRSs, axis order differences, and limitations of getX/getY.</li><li>JA suggested easting and northing as applicable to both projected and geodetic systems.</li><li>[Alignments] Isolating alignments from main specification (#527): waiting for input from OGC.</li></ul>{:/} |
+| 2045 | Other Business | All | {::nomarkdown}<ul><li>NC and TH reported on a talk given to the Building Group.</li><li>Group expressed interest in specific handling of 3D and potential validation of a candidate scheme.</li><li>Request for geometries referencing external files due to large 3D geometry literals.</li><li>NC to look at formalising geometry literals stored in external files.</li><li>Discussion on ISO Group on Ontology Maintenance and possible ISO serialisation of ontologies.</li><li>Example referenced: https://github.com/ISO-TC211/GOM/tree/master/isotc211_GOM_harmonizedOntology/iso19111/2019</li><li>KG & Ontologies in Defense and Security Symposium reported.</li><li>PC presented GeoSPARQL work; positive reception noted.</li><li>NGA and BFO community raised issues; BFO mapping issues incorporated.</li><li>Reference to ISO 21838‑1 (BFO).</li></ul>{:/} |
+| 2119 | | | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Correct SPARQL syntax highlighting in MASTER and merge into 1.1, 1.2, and 1.3 | TH | TBD |
+| <span name="action_2">2</span> | Create a 1.1.1 branch to implement alignment suggestions from Issue 511 | TH | TBD |
+| <span name="action_3">3</span> | Create issues outlining plans for 3D work | NC | TBD |
+| <span name="action_4">4</span> | Review 3D issues | All | TBD |
+

--- a/_posts/2024-07-10-notes.md
+++ b/_posts/2024-07-10-notes.md
@@ -1,0 +1,50 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/07/10
+---
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 07/10/2024  
+
+**Meeting Time:** 2005–2110 UTC  
+
+**Meeting Location:** Online  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matt Perry | MP |
+| Nicholas Car | NC |
+| Joseph Abhayaratna | JA |
+| Paul Cripps | PC |
+
+**Apologies:**  
+- Timo Homburg (TH)
+
+**Absent:** None
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+|  | — | — | — |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2005 | Roll call and call for patents | All | Roll call completed. Call for patents held. Quorum confirmed. |
+| 2010 | Pull Requests | All | {::nomarkdown}<ul><li>Extend hasGeometry to allow for GeometryCollections (#525): approvals granted.</li><li>Latitude and Longitude functions (#526): approvals granted.</li><li>[Alignments] Isolating alignments from main specification (#527): waiting for input from OGC.</li></ul>{:/} |
+| 2045 | Other Business | All | {::nomarkdown}<ul><li>Vladimir raised an issue that GitHub is sunsetting the old project type.</li><li>Group migrated to the new GitHub project type.</li></ul>{:/} |
+| 2110 | | | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+|  | None |  |  |
+

--- a/_posts/2024-07-24-notes.md
+++ b/_posts/2024-07-24-notes.md
@@ -1,0 +1,49 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/07/24
+---
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 07/24/2024  
+
+**Meeting Time:** 2005–2104 UTC  
+
+**Meeting Location:** Online  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matt Perry | MP |
+| Nicholas Car | NC |
+
+**Apologies:**  
+- Joseph Abhayaratna (JA)  
+- Paul Cripps (PC)
+
+**Absent:** None
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+|  | — | — | — |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2005 | Roll call and call for patents | All | Roll call completed. Call for patents held. Quorum confirmed. |
+| 2010 | Pull Requests | All | {::nomarkdown}<ul><li>More topological relation equivalences (#532): TH implemented suggestions from Vladimir Alexiev; MP and NC to review.</li><li>Change empty namespace in geo.ttl to geo: (#533); closes #509 and #474; merged.</li><li>Default parameter for transform function (#534); closes #503. Discussion on how to define default parameters in the specification.</li><li>NC suggested reviewing OGC Features API conventions; group noted flexibility if conventions are clearly explained. Reference: https://docs.ogc.org/is/17-069r3/17-069r3.html</li><li>NC questioned whether this was the only default parameter; TH confirmed it currently is.</li><li>NC noted default parameters might have been used instead of defining metric variants; TH to review wider set of GeoSPARQL functions for applicability.</li><li>Intersection Geometry Vocabulary (#535); closes #239. NC questioned need for a class for intersection geometries and suggested provenance could be used to indicate derivation.</li><li>Including common non‑SFA functions (#536); TH added missing functions; requires review.</li><li>Geocoding Vocabulary (#537); TH requested review and comments; NC noted contact with OGC Naming Authority.</li></ul>{:/} |
+| 2045 | Other Business | All | {::nomarkdown}<ul><li>TH reported on GeoSPARQL 1.1 paper in the MDPI Journal for Geospatial Information.</li><li>Journal requested an abstract for featured paper exposure.</li><li>Discussion on possibility of submitting a review paper on geospatial semantics.</li><li>Noted ongoing research on geospatial ontologies could support such a paper.</li></ul>{:/} |
+| 2104 | | | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+|  | None |  |  |
+

--- a/_posts/2024-08-07-notes.md
+++ b/_posts/2024-08-07-notes.md
@@ -1,0 +1,50 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/08/07
+---
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 08/07/2024  
+
+**Meeting Time:** 2005–2104 UTC  
+
+**Meeting Location:** Online  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matt Perry | MP |
+| Joseph Abhayaratna | JA |
+| Paul Cripps | PC |
+| Timo Homburg | TH |
+| Vladimir Alexiev | VA |
+| Arkadiusz Chadzynski | AC |
+
+**Apologies:** None  
+
+**Absent:** None
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+|  | — | — | — |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2005 | Roll call and call for patents | All | Roll call completed. Call for patents held. Quorum confirmed. |
+| 2010 | Pull Requests | All | {::nomarkdown}<ul><li>Ran through pull requests.</li><li>Issue raised regarding GeoSPARQL implementations performing geometry transformations across different CRSs (e.g. for distance calculations).</li><li>Noted that use of a bridging CRS (such as WGS84) can introduce artefacts.</li><li>Group agreed this behaviour should be left to implementers, but that end users should be made aware of the methodology used.</li><li>Discussed adding information to the service description to improve transparency.</li></ul>{:/} |
+| 2104 | | | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Create issue relating to adding a methodology for performing calculations across different CRSs to the service description | VA | TBD |
+

--- a/_posts/2024-09-04-notes.md
+++ b/_posts/2024-09-04-notes.md
@@ -1,0 +1,53 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/09/04
+---
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 09/04/2024  
+
+**Meeting Time:** 2005–2104 UTC  
+
+**Meeting Location:** Online  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matt Perry | MP |
+| Joseph Abhayaratna | JA |
+| Timo Homburg | TH |
+| Arkadiusz Chadzynski | AC |
+
+**Apologies:** None  
+
+**Absent:**  
+- Paul Cripps (PC)  
+- Nicholas Car (NC)  
+- Vladimir Alexiev (VA)
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+|  | Update PR splitting alignments based on OGC feedback | JA | TBD |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2005 | Roll call and call for patents | All | Roll call completed. Call for patents held. Quorum confirmed. |
+| 2010 | Pull Requests and issues | All | Ran through PRs and issues; all detailed discussion documented in GitHub. |
+| 2104 | | | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Invite Luis De Souza to the SWG | TH | TBD |
+| <span name="action_2">2</span> | Review minz and maxz for suitability for 3D UC2 | AC | TBD |
+| <span name="action_3">3</span> | Update PR splitting alignments based on OGC feedback | JA | TBD |
+

--- a/_posts/2024-09-18-notes.md
+++ b/_posts/2024-09-18-notes.md
@@ -1,0 +1,54 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/09/18
+---
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 09/18/2024  
+
+**Meeting Time:** 2015–2101 UTC  
+
+**Meeting Location:** Online  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Paul Cripps | PC |
+| Nicholas Car | NC |
+| Joseph Abhayaratna | JA |
+| Timo Homburg | TH |
+| Arkadiusz Chadzynski | AC |
+
+**Apologies:**  
+- Matt Perry (MP)
+
+**Absent:**  
+- Vladimir Alexiev (VA)
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+|  | Update PR splitting alignments based on OGC feedback (carry over) | JA | TBD |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2015 | Roll call and call for patents | All | Roll call completed. Call for patents held. Quorum confirmed. |
+| 2015 | W3C SDW WG work list update | TH | CRS Ontology and GeoSPARQL work added to the W3C Spatial Data on the Web Working Group work list. Reference: https://w3c.github.io/charter-drafts/2024/sdw-wg.html |
+| 2027 | W3C Data Shapes WG proposal | NC | Data Shapes Working Group proposed in W3C to progress SHACL to cover updates to RDF and SPARQL. Reference: https://w3c.github.io/shacl/charter-1.2/shacl-wg.html |
+| 2030 | Pull Requests and issues | All | PRs and issues reviewed; all detailed discussion documented in GitHub. |
+| 2059 | Issue #59 update | NC | Updating https://github.com/opengeospatial/ogc-geosparql/issues/59 with current contributors, implementation status, and related knowledge. |
+| 2101 | | | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Update PR splitting alignments based on OGC feedback (carry over) | JA | TBD |
+

--- a/_posts/2024-10-02-notes.md
+++ b/_posts/2024-10-02-notes.md
@@ -1,0 +1,55 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/10/02
+---
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 10/02/2024  
+
+**Meeting Time:** 2005–2102 UTC  
+
+**Meeting Location:** Online  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matt Perry | MP |
+| Nicholas Car | NC |
+| Joseph Abhayaratna | JA |
+| Timo Homburg | TH |
+| Arkadiusz Chadzynski | AC |
+
+**Apologies:** None  
+
+**Absent:**  
+- Vladimir Alexiev (VA)  
+- Paul Cripps (PC)
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+|  | Update PR splitting alignments based on OGC feedback (carry over) | JA | TBD |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2005 | Roll call and call for patents | All | Roll call completed. Call for patents held; none declared. Quorum confirmed. |
+| 2010 | Review of previous actions | All | {::nomarkdown}<ul><li>JA to update PR splitting alignments based on OGC feedback (carried forward).</li><li>AC asked when alignments should be added; group agreed they can be added whenever someone considers them useful.</li></ul>{:/} |
+| 2015 | 3D Use Cases | NC, AC | {::nomarkdown}<ul><li>Queensland Government (Australia) looking to utilise 3D GeoSPARQL use cases.</li><li>Geonovum indicated interest in contributing use cases.</li><li>Reference: https://geonovum-github-io.translate.goog/wp-3DGSP/?_x_tr_sl=nl&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp</li></ul>{:/} |
+| 2030 | Run through new issues | All | New issues reviewed by the group. |
+| 2055 | Other Business | NC, TH, JA | {::nomarkdown}<ul><li>Discussion on current status of ISO co-publication.</li><li>CRS ontology update: ontology has progressed and is now set up for continuous integration.</li><li>Next steps include consolidation of definitions.</li><li>Group agreed to keep meeting time fixed in UTC due to upcoming daylight savings changes, as it is convenient for Europe and APAC and no less convenient for US participants.</li></ul>{:/} |
+| 2102 | | | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Clarify OGC approval process for publication of Alignments Best Practice | JA | TBD |
+| <span name="action_2">2</span> | Check status of ISO co-publication and next steps with Scott Simmons | JA | TBD |
+

--- a/_posts/2024-10-16-notes.md
+++ b/_posts/2024-10-16-notes.md
@@ -1,0 +1,58 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/10/16
+---
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 10/16/2024  
+
+**Meeting Time:** 1905–2006 UTC  
+
+**Meeting Location:** Online (per calendar entry)  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matt Perry | MP |
+| Paul Cripps | PC |
+| Timo Homburg | TH |
+| Arkadiusz Chadzynski | AC |
+
+**Apologies:**  
+- Joseph Abhayaratna (JA)
+
+**Absent:**  
+- Vladimir Alexiev (VA)  
+- Nicholas Car (NC)
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+|  | Clarify OGC approval process for publication of Alignments Best Practice | JA | TBD |
+|  | Check status of ISO co-publication and next steps with Scott Simmons | JA | TBD |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 1905 | Roll call and call for patents | All | Roll call completed. Call for patents held; none declared. Quorum confirmed. |
+| 1910 | Review of previous actions | All | {::nomarkdown}&lt;ul&gt;&lt;li&gt;JA to obtain information from OGC on approval and governance of the Alignments Best Practice as a living document.&lt;/li&gt;&lt;li&gt;JA to contact Scott Simmons regarding ISO co-publication status and next steps.&lt;/li&gt;&lt;/ul&gt;{:/} |
+| 1908 | Pull Request #536 | All | {::nomarkdown}&lt;ul&gt;&lt;li&gt;Discussion of PR: https://github.com/opengeospatial/ogc-geosparql/pull/536&lt;/li&gt;&lt;li&gt;TH noted comments from VA and the need for ogc:geomLiteral[] to be an ordered list.&lt;/li&gt;&lt;li&gt;Options discussed:&lt;ul&gt;&lt;li&gt;Wrap output with transform()&lt;/li&gt;&lt;li&gt;Add an additional target_crs argument&lt;/li&gt;&lt;li&gt;Leave it up to implementers&lt;/li&gt;&lt;li&gt;Specify the order criteria in the specification&lt;/li&gt;&lt;/ul&gt;&lt;/li&gt;&lt;li&gt;AC suggested two versions of withinDistance (metric and with units argument).&lt;/li&gt;&lt;li&gt;AC noted the withinDistance change would satisfy an identified use case.&lt;/li&gt;&lt;/ul&gt;{:/} |
+| 1915 | 3D Use Cases | All | TH reported Geonovum interest in running a workshop in November to present existing 3D GeoSPARQL use cases. |
+| 1927 | New 3D issues | All | {::nomarkdown}&lt;ul&gt;&lt;li&gt;Several new 3D issues added by Ontotext (AC).&lt;/li&gt;&lt;li&gt;ONTO17: Return type (GML, KML, etc.) should match first input geometry.&lt;/li&gt;&lt;li&gt;ONTO14: Clarification needed on example output value of 200 (should be 200%).&lt;/li&gt;&lt;li&gt;ONTO18: Compactness noted as useful for construction industry.&lt;/li&gt;&lt;li&gt;Discussion on standard algorithms for tessellation and compactness.&lt;/li&gt;&lt;/ul&gt;{:/} |
+| 1943 | Other Business | All | {::nomarkdown}&lt;ul&gt;&lt;li&gt;TH reported on CRS Working Group activities under Spatial Data on the Web WG.&lt;/li&gt;&lt;li&gt;Plans to publish a modular ontology with separate TTL files per module.&lt;/li&gt;&lt;li&gt;Discussion on availability of 3D functions in other spatial databases.&lt;/li&gt;&lt;li&gt;Question raised on whether 3D functions should be explicitly named or inferred from input.&lt;/li&gt;&lt;/ul&gt;{:/} |
+| 2006 | | | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Clarify OGC approval process for publication of Alignments Best Practice (carry over) | JA | TBD |
+| <span name="action_2">2</span> | Check status of ISO co-publication and next steps with Scott Simmons (carry over) | JA | TBD |
+| <span name="action_3">3</span> | Survey 3D functions available in spatial databases | All | TBD |
+

--- a/_posts/2024-11-13-notes.md
+++ b/_posts/2024-11-13-notes.md
@@ -1,0 +1,59 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/11/13
+---
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 11/13/2024  
+
+**Meeting Time:** 1903–2007 UTC  
+
+**Meeting Location:** Online (per calendar entry)  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Matt Perry | MP |
+| Paul Cripps | PC |
+| Timo Homburg | TH |
+| Arkadiusz Chadzynski | AC |
+
+**Apologies:** None  
+
+**Absent:**  
+- Vladimir Alexiev (VA)  
+- Nicholas Car (NC)
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+|  | Clarify OGC approval process for publication of Alignments Best Practice | JA | TBD |
+|  | Check status of ISO co-publication and next steps with Scott Simmons | JA | TBD |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 1903 | Roll call and call for patents | All | Roll call completed. Call for patents held; none declared. Quorum confirmed. |
+| 1905 | Review of previous actions | All | {::nomarkdown}&lt;ul&gt;&lt;li&gt;JA to obtain information from OGC on approval and governance of the Alignments Best Practice as a living document.&lt;/li&gt;&lt;li&gt;JA to contact Scott Simmons regarding ISO co-publication status and next steps.&lt;/li&gt;&lt;/ul&gt;{:/} |
+| 1914 | 3D requirements for GeoSPARQL | TH | Geonovum organising a meeting to discuss requirements for 3D in GeoSPARQL. TH, PC, and AC will attend. |
+| 1908 | Pull Request #536 | All | {::nomarkdown}&lt;ul&gt;&lt;li&gt;Discussion of PR: https://github.com/opengeospatial/ogc-geosparql/pull/536&lt;/li&gt;&lt;li&gt;Vote options:&lt;ul&gt;&lt;li&gt;Wrap output with transform()&lt;/li&gt;&lt;li&gt;Add an additional target_crs argument&lt;/li&gt;&lt;li&gt;Leave it up to implementers&lt;/li&gt;&lt;li&gt;Specify the order criteria in the specification&lt;/li&gt;&lt;/ul&gt;&lt;/li&gt;&lt;/ul&gt;{:/} |
+| 1930 | Issues | All | Recent issues discussed using Timo’s presentation: https://docs.google.com/presentation/d/1geamAtelhSwCRwOrYbvwDE50WHKrM-zNtPWLm1FPkP0/edit?usp=sharing |
+| 1943 | Other Business | PC | Peter Rabley visiting DSTL. |
+| 2007 | | | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Determine how publication of alignments in Rainbow should work | JA | TBD |
+| <span name="action_2">2</span> | Organise presentation to JAG | JA, NC | TBD |
+| <span name="action_3">3</span> | Forward Geonovum 3D meeting invitation | TH | Next Meeting |
+| <span name="action_4">4</span> | Vote on Pull Request #536 | AC, NC, PC | Next Meeting |
+

--- a/_posts/2024-12-11-notes.md
+++ b/_posts/2024-12-11-notes.md
@@ -1,0 +1,55 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2024/12/11
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 12/11/2024  
+**Meeting Time:** 1909–2000  
+**Meeting Location:** Microsoft Teams  
+
+> Note: Quorum present.  
+> Note: Meeting started 1 hour earlier (UTC) as per calendar entry.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Matthew Perry | MP |
+| Paul Cripps | PC |
+| Timo Homburg | TH |
+
+## Apologies
+- Nicholas Car (NC)
+
+## Absent
+- Vladimir Alexiev (VA)  
+- Arkadiusz Chadzynski (AC)
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 19:09 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 19:12 | Previous actions | All | {::nomarkdown}<ul><li>Discussion on how to publish alignments as a living document.</li><li>Options considered included Best Practice documents, with concerns about governance.</li><li>Alternative approach proposed: a registry of alignments hosted in OGC Rainbow under SWG authority, with a link from the Standard.</li><li>Outlined steps required for alignments:</li><li>– Convert alignments into a ConceptScheme.</li><li>– Annotate entries with notes (suggested use of RDF*).</li><li>– Define a discovery and usage approach suitable for Rainbow.</li><li>JA to reach out to Scott Simmons to clarify ISO co‑publication status and next steps.</li></ul>{:/} |
+| 19:36 | Geonovum meeting update | TH | {::nomarkdown}<ul><li>Geonovum meeting on 3D GeoSPARQL requirements was well attended and highly engaged.</li><li>Attendees included TH, PC, and AC.</li><li>Strong interest expressed in writing a paper similar to “Benefits of Representing Geospatial Data using Graph and Semantic Web Technologies”, focusing on 3D use cases and requirements.</li></ul>{:/} |
+| 19:50 | Other business | All | {::nomarkdown}<ul><li>Next meeting scheduled for January 8.</li><li>MP to chair the next meeting.</li></ul>{:/} |
+| 20:00 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Work out what publication of the alignments in OGC Rainbow looks like | NC | — |
+| <span name="action_2">2</span> | Present GeoSPARQL alignment material to JAG | JA, NC | — |
+| <span name="action_3">3</span> | Book recurring fortnightly meetings for 2025 starting January 8 | JA | — |

--- a/_posts/2025-01-08-notes.md
+++ b/_posts/2025-01-08-notes.md
@@ -1,0 +1,56 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/01/08
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 01/08/2025  
+**Meeting Time:** 1907–1943  
+**Meeting Location:** Microsoft Teams  
+
+> Note: Quorum present.  
+> Note: Meeting started 1 hour earlier (UTC) as per calendar entry.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Paul Cripps | PC |
+| Timo Homburg | TH |
+| Arkadiusz Chadzynski | AC |
+
+## Apologies
+- Joseph Abhayaratna (JA)
+
+## Absent
+- Vladimir Alexiev (VA)  
+- Nicholas Car (NC)
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Work out what publication of alignments in OGC Rainbow looks like | NC | Carried forward |
+| ⬜ | Prepare and present GeoSPARQL material to JAG | JA, NC | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 19:07 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 19:12 | Previous actions | All | {::nomarkdown}<ul><li>No updates from JA or NC.</li><li>NC to work out what publication of alignments in Rainbow looks like.</li><li>JA and NC to present GeoSPARQL material to JAG.</li></ul>{:/} |
+| 19:14 | Other updates | TH | {::nomarkdown}<ul><li>Geonovum meeting scheduled for January 22 at 10:00 a.m. CET.</li><li>Geonovum requested contributors by December 19.</li><li>TH wrote a script to generate JSON and HTML consistency reports from the specification.</li></ul>{:/} |
+| 19:20 | Issues | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/608.</li><li>Consensus that expressing full geometry contents as pure RDF would be extremely verbose and difficult to work with.</li><li>Agreement to discuss approach further with Peter at the Geonovum meeting.</li><li>General agreement that more geometry types could be useful, but concerns remain about encoding full geometry components in RDF.</li><li>Example referenced: https://rdf.bg/geometry.ttl.</li></ul>{:/} |
+| 19:20 | Next items | TH, MP, AC | {::nomarkdown}<ul><li>TH to review and consolidate collected 3D use cases into a set of GeoSPARQL 3D requirements as time permits.</li><li>MP suggested compiling a survey of 3D functions available in spatial databases.</li><li>AC volunteered to work on building this list.</li><li>AC identified an additional use case: calculating shadows of 3D geometries.</li></ul>{:/} |
+| 19:43 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| — | No new action items recorded | — | — |

--- a/_posts/2025-01-22-notes.md
+++ b/_posts/2025-01-22-notes.md
@@ -1,0 +1,54 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/01/22
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 01/22/2025  
+**Meeting Time:** 2004–2107  
+**Meeting Location:** Microsoft Teams  
+
+> Note: Not a quorum.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Paul Cripps | PC |
+| Timo Homburg | TH |
+
+## Apologies
+- Joseph Abhayaratna (JA)  
+- Nicholas Car (NC)
+
+## Absent
+- Vladimir Alexiev (VA)  
+- Arkadiusz Chadzynski (AC)
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Work out what publication of alignments in OGC Rainbow looks like | NC | Carried forward |
+| ⬜ | Present GeoSPARQL alignment material to JAG | JA, NC | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:04 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:05 | Previous actions | All | {::nomarkdown}<ul><li>No updates from JA or NC.</li><li>NC to work out what publication of alignments in Rainbow looks like.</li><li>JA and NC to present to JAG.</li></ul>{:/} |
+| 20:06 | Other updates | TH, PC | {::nomarkdown}<ul><li>Geonovum meeting attended by TH, NC, PC, AC, Louis, and Rolf Jonker.</li><li>Six participants plus additional volunteers agreed to write a GeoSPARQL 3D white paper on theory and applications.</li><li>Group to meet fortnightly.</li><li>TH to email JA about setting up a repository for white paper work.</li><li>PC reported interesting discussions on extending RCC8 to 3D (RCC25).</li><li>Discussion on scope of work and possibility of a reference implementation of RCC25 for a single literal type.</li><li>TH noted lack of a de‑facto standard set of 3D spatial functions.</li><li>TH suggested identifying equivalences between Simple Features and RCC25.</li><li>PC noted equivalences for 2D relations are well understood.</li><li>Reference to paper covering RCC25, RCC29, and RCC31: https://core.ac.uk/download/pdf/62645857.pdf</li><li>TH referenced related GeoSPARQL issue: https://github.com/opengeospatial/ogc-geosparql/issues/416</li><li>Additional references shared: https://www.mdpi.com/2220-9964/13/1/25 and https://www.semanticscholar.org/paper/3D-Topological-Relations-for-3D-Spatial-Analysis-Supangkat-Machbub/4879e45f30712f6966017db74daad675255226df</li><li>TH discussed CityOWL use of GML literals for geometry representation.</li><li>TH presented slides on possible representations for 3D objects in GeoSPARQL.</li><li>TH added 3D vocabulary and alignments to the GitHub repository.</li><li>Identified need for vocabularies, relations, and functions.</li></ul>{:/} |
+| 20:54 | Issues and PRs | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/610 — PC to post additional updates; discussion on disjoint concepts and distinctions between actual space, representation, and serialisation.</li><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/609 — work in progress by AC.</li><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/604 — TH queried how to represent matrices in GeoSPARQL; PC suggested RDF Data Cube approach.</li><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/556 — TH raised question about extrusion in other dimensions (e.g. time, colour).</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/536 — TH still working on wording for implementers converting output to desired CRS.</li></ul>{:/} |
+| 21:07 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| — | No new action items recorded | — | — |

--- a/_posts/2025-02-05-notes.md
+++ b/_posts/2025-02-05-notes.md
@@ -1,0 +1,57 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/02/05
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 02/05/2025  
+**Meeting Time:** 2005–2103  
+**Meeting Location:** Microsoft Teams  
+
+> Note: Not a quorum.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Nicholas Car | NC |
+| Matthew Perry | MP |
+| Arkadiusz Chadzynski | AC |
+| Timo Homburg | TH |
+
+## Apologies
+- None
+
+## Absent
+- Paul Cripps (PC)  
+- Vladimir Alexiev (VA)
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Work out what publication of alignments in OGC Rainbow looks like | NC | Carried forward |
+| ⬜ | Prepare presentation for JAG | JA, NC | — |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:06 | Previous actions | All | {::nomarkdown}<ul><li>No updates from JA or NC.</li><li>NC to work out what publication of alignments in OGC Rainbow would look like (carried forward).</li><li>JA and NC to prepare a presentation for JAG (scheduled for 4 p.m. Friday).</li></ul>{:/} |
+| 20:12 | Other updates | TH | {::nomarkdown}<ul><li>Work starting on the CRS ontology using Metanorma (for ISO) and AsciiDoc with co‑branding (for W3C).</li><li>SHACL Working Group currently active; opportunity identified to test SHACL and provide feedback/CRs to assist GeoSPARQL.</li><li>SHACL profiles enable specification of constraint profiles.</li></ul>{:/} |
+| 20:18 | Issues and PRs | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/610 — PC to post further updates; discussion on mapping to disjoint concepts and distinction between actual space, representation, and serialisation.</li><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/609 — work in progress by AC.</li><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/604 — TH queried representation of matrices in GeoSPARQL; PC suggested RDF Data Cube approach and will investigate further.</li><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/556 — TH asked about extrusion in other dimensions (e.g., time, colour).</li><li>PRs noted: outstanding changes and reviews for Geocoding Vocabulary and Including common Non‑SFA functions.</li><li>Discussion referenced 3D Primitives Vocabulary and alignments to IFC, CityRDF, and X3D (see Actions).</li></ul>{:/} |
+| 21:03 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Investigate working within CityRDF WG to meet requirements of 3D Primitives Vocabulary and alignments to IFC, CityRDF, and X3D | AC | — |
+| <span name="action_2">2</span> | Investigate interest from OGC in extending Simple Features to include 3D and identify current chair | JA | — |
+| <span name="action_3">3</span> | Follow up with Rob Atkinson on review of the 3D primitives | NC | — |

--- a/_posts/2025-02-19-notes.md
+++ b/_posts/2025-02-19-notes.md
@@ -1,0 +1,54 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/02/19
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 02/19/2025  
+**Meeting Time:** 2005–2106  
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Arkadiusz Chadzynski | AC |
+| Timo Homburg | TH |
+| Paul Cripps | PC |
+| Nicholas Car | NC |
+
+## Apologies
+- Joseph Abhayaratna (JA)
+
+## Absent
+- Vladimir Alexiev (VA)
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Investigate interest in extending Simple Features to include 3D | JA | Carried forward |
+| ⬜ | Follow up with Rob Atkinson on review of 3D primitives | NC | On hold (Rob on leave) |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:06 | Previous actions | All | {::nomarkdown}<ul><li>No updates from JA or NC.</li><li>AC investigating work within CityRDF WG to meet requirements of the 3D Primitives Vocabulary and alignments to IFC, CityRDF, and X3D.</li><li>AC proposed refactoring and extracting the appearance module into a new ontology to broaden applicability beyond city use cases; no objections raised.</li><li>AC noted that placement of the new ontology within OGC is still to be determined.</li><li>NC advised that OGC Rainbow should be online soon, enabling a registry of ontologies (e.g., GeoSPARQL, CityRDF, CRS).</li><li>TH reported that appearance has been removed from the 3D primitives ontology into appearance.ttl.</li><li>JA to continue investigating interest from OGC in extending Simple Features to include 3D.</li><li>NC unable to follow up with Rob Atkinson as Rob is on leave.</li><li>ISO publication update: NC and JA prepared presentation; JA arranging time with Scott, likely at next JAG meeting.</li><li>NC advised next ISO TC211 meeting is in May (Korea); objective is to complete alignment and formally inform the group prior to that meeting.</li></ul>{:/} |
+| 20:12 | Other updates | TH, NC, MP | {::nomarkdown}<ul><li>Linda requested a presentation at the GeoSemantics DWG; TH planning to prepare and present on GeoSPARQL and the CRS ontology (March 4, 2 p.m. CET).</li><li>NC reported a new engineer planning to implement GeoSPARQL 1.1 in Jena and potentially RDFLib (https://github.com/RDFLib/rdflib-geosparql).</li><li>NC noted frequent use of QGIS in this work.</li><li>MP advised that Oracle 23ai includes GeoSPARQL 1.1 support.</li><li>NC referenced an RDF‑to‑GeoJSON tool: https://github.com/Kurrawong/rdf2geojson.</li><li>TH provided CRS ontology update, including a Python script that generates a JSON‑LD context; OGC creating a new JSON CRS format similar to WKT.</li><li>TH and NC raised discussion on RCC25 and possible DE‑9IM or Simple Features equivalents.</li><li>PC to follow up with Anthony Cohn.</li><li>Recent paper referenced: https://www.mdpi.com/2220-9964/13/1/25.</li></ul>{:/} |
+| 20:39 | Issues and PRs | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/609 — AC summarised open‑source implementations in RDF; TH suggested adding a table in addition to RDF.</li><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/610 — PC reviewing; geometry bits should point to spatial region; BFO information content entity considered as geometry serialisation.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/537 — TH ready for review again.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/613 — TH added parameters for extrude (not extrudeInTime); AC requested re‑check and addition to geometry extension section.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/536 — TH ready for another review.</li></ul>{:/} |
+| 21:06 | Other business | All | {::nomarkdown}<ul><li>PC noted that the OGC Data Cube initiative is seeking sponsors for testbed activities: https://www.ogc.org/requests/seeking-sponsors-for-testbed-21/</li></ul>{:/} |
+| 21:06 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Investigate interest in extending Simple Features to include 3D | JA | Carried forward |
+| <span name="action_2">2</span> | Follow up with Rob Atkinson on review of 3D primitives | NC | On hold (Rob on leave) |

--- a/_posts/2025-03-05-notes.md
+++ b/_posts/2025-03-05-notes.md
@@ -1,0 +1,55 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/03/05
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 03/05/2025  
+**Meeting Time:** 2005–2106  
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Arkadiusz Chadzynski | AC |
+| Timo Homburg | TH |
+| Paul Cripps | PC |
+| Joseph Abhayaratna | JA |
+
+## Apologies
+- Nicholas Car (NC)
+
+## Absent
+- Vladimir Alexiev (VA)
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Investigate interest in extending Simple Features to include 3D | JA | Carried forward |
+| ⬜ | Follow up with Rob Atkinson on review of 3D primitives | NC | On hold (Rob on leave) |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:06 | Previous actions | All | {::nomarkdown}<ul><li>No updates from JA or NC.</li><li>JA reported that Simple Features currently has no chair; Scott Simmons managing interim and planning a call for chairs.</li><li>Interest confirmed in extending Simple Features to include 3D.</li><li>JA and TH noted the need for a 3D namespace; TH has created http://www.opengis.net/ont/sf3d#.</li><li>Agreement that SF‑3D alignment will be required; JA suggested proposing use of this namespace.</li><li>NC unable to follow up with Rob Atkinson as Rob is on leave.</li><li>ISO publication update: JA and NC prepared presentation; JA arranging time with Scott, likely at next JAG meeting.</li><li>NC advised next ISO TC211 meeting is in May (Korea); goal is to complete alignment and formally inform ISO group ahead of that meeting.</li></ul>{:/} |
+| 20:15 | Other updates | TH, AC | {::nomarkdown}<ul><li>GeoSemantics DWG update: TH presented GeoSPARQL status.</li><li>K. Jano presented work on foundation ontologies to improve Generative AI for Geo.</li><li>Rob Atkinson presented on Spatial Data on the Web; need identified for closer W3C–OGC collaboration.</li><li>Interest expressed in generating specifications from OWL ontologies to reduce text/ontology inconsistencies.</li><li>TH reported receiving feedback on CRS ontology.</li><li>Work underway on JSON‑LD contexts and interaction between ontologies and CRS DWG artefacts.</li><li>TH updated on GeoSPARQL Compliance Benchmark: ~206 queries previously; now expected to exceed 1,000.</li><li>TH reported queries are created; next step is generating answers.</li><li>Benchmark referenced: https://situx.github.io/GeoSPARQLBenchmark/</li><li>AC presented CityRDF webinar using GeoSPARQL to validate land‑use constraints via logical reasoning.</li><li>AC reported work on separation of appearance properties; separate appearance ontology will remain in CityRDF repo and be imported via a separate namespace.</li></ul>{:/} |
+| 20:36 | Issues and PRs | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/615 — Req 17 of GeoSPARQL 1.0; discussion on documenting supported GML version.</li><li>TH suggested documenting this via SPARQL service description; MP queried need for additional vocabulary.</li><li>TH to investigate service description vocabulary; AC to check GML / CityGML namespaces for 3D concepts.</li><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/609 — AC continuing data processing; interest in alignment with GeoSPARQL functions.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/616 — AC ready for review and will add a requirement.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/611 — work in progress.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/537 — MP and NC to review.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/536 — MP, VA, and NC to review.</li></ul>{:/} |
+| 21:02 | Other business | All | {::nomarkdown}<ul><li>Upcoming time change noted: US will move ahead one hour next week.</li><li>Agreement to keep meeting time unchanged for next week.</li></ul>{:/} |
+| 21:06 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Investigate RCC25 equivalents (DE‑9IM / Simple Features) | All | — |
+| <span name="action_2">2</span> | Follow up with Anthony Cohn | PC | Carried forward |
+| <span name="action_3">3</span> | Review recent RCC‑related paper | All | — |

--- a/_posts/2025-03-19-notes.md
+++ b/_posts/2025-03-19-notes.md
@@ -1,0 +1,54 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/03/19
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 03/19/2025  
+**Meeting Time:** 2005–2100  
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Arkadiusz Chadzynski | AC |
+| Timo Homburg | TH |
+| Paul Cripps | PC |
+| Joseph Abhayaratna | JA |
+| Nicholas Car | NC |
+
+## Apologies
+- None
+
+## Absent
+- Vladimir Alexiev (VA)
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Follow up with Anthony Cohn | PC | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:06 | Previous actions | All | {::nomarkdown}<ul><li>No updates from JA or NC.</li><li>JA investigated interest from OGC in extending Simple Features to include 3D; interest confirmed pending election of a chair.</li><li>SF currently has no chair; Scott Simmons managing interim and planning a call for chairs.</li><li>JA and TH noted the need for a 3D namespace; TH has created http://www.opengis.net/ont/sf3d#.</li><li>Alignment with SF‑3D discussed; Simple Features may use this namespace with further ontology alignment once work commences.</li><li>NC to follow up with Rob Atkinson on review of 3D primitives; Rob on leave, follow‑up planned after return.</li><li>Discussion on RCC25 and possible DE‑9IM or Simple Features equivalents.</li><li>PC to follow up with Anthony Cohn; no response so far.</li></ul>{:/} |
+| 20:15 | Other updates | TH, NC, AC | {::nomarkdown}<ul><li>TH provided an update on the GeoSPARQL 3D white paper; limited progress due to lack of awareness of the GitHub repository.</li><li>NC working with JENA (Andy Seaborne) to investigate handling of GeoSPARQL 1.1 and GeoSPARQL indexes.</li><li>AC reported on W3C Linked Building Data (LBD) Working Group work using GeoSPARQL ontology to link land parcel and building data.</li><li>TH reported near completion of the GeoSPARQL 1.1 benchmark validator.</li></ul>{:/} |
+| 20:36 | Issues and PRs | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/617 — overload requested for asDGGS to incorporate resolution.</li><li>PR discussed: PR #616 (geometry extrusion) — agreement to add geof:extrudeToHeight.</li><li>PR discussed: Geocoding Vocabulary PR #537 — two approvals received; returning to original creator.</li><li>PR discussed: PR #536 (common non‑SFA functions) — VA and NC to review.</li></ul>{:/} |
+| 21:00 | Other business | All | {::nomarkdown}<ul><li>No additional business.</li></ul>{:/} |
+| 21:00 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| — | No new action items recorded | — | — |
+

--- a/_posts/2025-04-02-notes.md
+++ b/_posts/2025-04-02-notes.md
@@ -1,0 +1,52 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/04/02
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 04/02/2025  
+**Meeting Time:** 2005–2100  
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Arkadiusz Chadzynski | AC |
+| Timo Homburg | TH |
+| Joseph Abhayaratna | JA |
+
+## Apologies
+- None
+
+## Absent
+- Paul Cripps (PC)  
+- Nicholas Car (NC)
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Follow up with Anthony Cohn | PC | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:06 | Previous actions | All | {::nomarkdown}<ul><li>No updates from JA or NC.</li><li>NC to follow up with Rob Atkinson on review of 3D primitives; Rob on leave, follow‑up planned after return.</li><li>RCC25 wiki created to collect papers.</li><li>Paper in progress on existing RCC25 relations.</li><li>AC to add existing database (PostGIS, SpatialLite, H2GIS) functions.</li></ul>{:/} |
+| 20:15 | Other updates | TH | {::nomarkdown}<ul><li>Frans has joined the GeoSPARQL 3D white paper and is working on the introduction.</li><li>GitHub project being created for the 3D white paper.</li></ul>{:/} |
+| 20:36 | PRs | All | {::nomarkdown}<ul><li>Geocoding Vocabulary PR #537 merged after two approvals.</li><li>PR #616 (geometry extrusion) discussed.</li><li>Discussion on how units of measure (UoM) should be handled.</li></ul>{:/} |
+| 21:00 | Other business | All | {::nomarkdown}<ul><li>Discussion on which issues to prioritise next.</li><li>Agreement to prioritise 3D use cases where possible.</li></ul>{:/} |
+| 21:00 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Follow up with Anthony Cohn (no response so far) | PC | Carried forward |

--- a/_posts/2025-04-30-notes.md
+++ b/_posts/2025-04-30-notes.md
@@ -1,0 +1,54 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/04/30
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 04/30/2025  
+**Meeting Time:** 2005–2050  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Arkadiusz Chadzynski | AC |
+| Timo Homburg | TH |
+
+## Apologies
+- Paul Cripps (PC)
+
+## Absent
+- Nicholas Car (NC)  
+- Joseph Abhayaratna (JA)
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Follow up with Anthony Cohn | PC | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:08 | Other updates | TH, AC | {::nomarkdown}<ul><li>TH provided an update on the GeoSPARQL 3D white paper.</li><li>Section in progress on BIM and IFC.</li><li>Contributors assigned to sections and GitHub issues created.</li><li>Ph.D. student working on GeoSPARQL 3D requirements.</li><li>AC advised the 3D function table is being added to the white paper, to be placed in the capabilities section.</li><li>Issues noted: function URI vs preferred name; some functions missing from functions.ttl.</li><li>Discussion on whether to list only GeoSPARQL functions present in spatial databases or also those not present.</li><li>AC reported no movement on separation of appearance ontology since last meeting.</li></ul>{:/} |
+| 20:29 | PRs | All | {::nomarkdown}<ul><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/614 — open issues discussed; updates made in PR comments.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/616 — naming ambiguities discussed; updates made in PR comments.</li></ul>{:/} |
+| 20:40 | Issues | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/619 — typo in SHACL shape for geo:dggsLiteral; TH to raise a PR.</li><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/617 — TH to raise a PR.</li></ul>{:/} |
+| 20:45 | Previous actions | All | {::nomarkdown}<ul><li>Carry‑over actions reviewed.</li><li>NC to follow up with Rob Atkinson on review of 3D primitives; Rob currently on leave, follow‑up planned upon return.</li><li>RCC25: Wiki created to collect papers; AC to add existing database (PostGIS, SpatialLite, H2GIS) functions.</li></ul>{:/} |
+| 20:49 | Other business | All | {::nomarkdown}<ul><li>Discussion on priorities moving forward: white paper vs specification.</li><li>Consensus that the white paper is the shorter task and should be completed first.</li><li>3D white paper repository referenced: https://github.com/opengeospatial/geosparql3dwhitepaper</li><li>TH working on auto‑generation of specification from CSV for CRS working group: https://github.com/opengeospatial/ontology-crs</li></ul>{:/} |
+| 20:50 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Follow up with Anthony Cohn (no response so far) | PC | Carried forward |

--- a/_posts/2025-05-14-notes.md
+++ b/_posts/2025-05-14-notes.md
@@ -1,0 +1,54 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/05/14
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 05/14/2025  
+**Meeting Time:** 2005–2103  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Arkadiusz Chadzynski | AC |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+| Joseph Abhayaratna | JA |
+
+## Apologies
+- None
+
+## Absent
+- Paul Cripps (PC)
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Follow up with Anthony Cohn | PC | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:08 | Other updates | JA, NC | {::nomarkdown}<ul><li>Update provided on ISO/OGC JAG presentation.</li></ul>{:/} |
+| 20:09 | PRs | All | {::nomarkdown}<ul><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/614 — updates provided.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/616 — discussion of naming ambiguities; updates made in PR comments.</li></ul>{:/} |
+| 20:50 | Issues | All | {::nomarkdown}<ul><li>No new issues raised.</li><li>Closed issues addressed by PRs closed during the session.</li></ul>{:/} |
+| 21:02 | Other business | All | {::nomarkdown}<ul><li>No additional business.</li></ul>{:/} |
+| 21:03 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Follow up with Anthony Cohn (no response so far) | PC | Carried forward |

--- a/_posts/2025-05-28-notes.md
+++ b/_posts/2025-05-28-notes.md
@@ -1,0 +1,49 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/05/28
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 05/28/2025  
+**Meeting Time:** 2005–2055  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Timo Homburg | TH |
+| Joseph Abhayaratna | JA |
+
+## Apologies
+- Arkadiusz Chadzynski (AC)  
+- Paul Cripps (PC)
+
+## Absent
+- Nicholas Car (NC)
+
+## Note Takers
+- Joseph Abhayaratna
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Follow up with Anthony Cohn | PC | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | ISO publication discussion | All | {::nomarkdown}<ul><li>Various discussions regarding ISO publication.</li><li>Three new issues captured as part of this discussion:</li><li>https://github.com/opengeospatial/ogc-geosparql/issues/630</li><li>https://github.com/opengeospatial/ogc-geosparql/issues/629</li><li>https://github.com/opengeospatial/ogc-geosparql/issues/628</li></ul>{:/} |
+| 20:55 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Follow up with Anthony Cohn (no response so far) | PC | Carried forward |

--- a/_posts/2025-06-11-notes.md
+++ b/_posts/2025-06-11-notes.md
@@ -1,0 +1,55 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/06/11
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 06/11/2025  
+**Meeting Time:** 2005–2020  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Timo Homburg | TH |
+| Arkadiusz Chadzynski | AC |
+| Paul Cripps | PC |
+
+## Apologies
+- None
+
+## Absent
+- Nicholas Car (NC)  
+- Joseph Abhayaratna (JA)
+
+## Note Takers
+- Matthew Perry
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Follow up with Anthony Cohn | Paul Cripps | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:10 | Recap of ISO publication discussion | TH | {::nomarkdown}<ul><li>TH provided a recap of the previous discussion on ISO publication.</li></ul>{:/} |
+| 20:10 | Previous actions | PC | {::nomarkdown}<ul><li>PC reported being back from Australia and will check for any information from Anthony Cohn.</li></ul>{:/} |
+| 20:12 | Any PRs | All | {::nomarkdown}<ul><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/611 — AC to work on this.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/620 — TH to make updates based on MP review; TH to work on a 3D issue if time permits.</li><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/614 — TH to review updates to the function table.</li></ul>{:/} |
+| 20:20 | Other topics | All | {::nomarkdown}<ul><li>3D White Paper discussed.</li><li>TH identified a better way to manage bibliography for AsciiDoc; may not be applicable given low citation count in the spec.</li><li>Good progress reported on related work.</li><li>AC provided an update on progress with 3D functions and the motivation section.</li><li>TH shared an outline for the paper structure and requested feedback: https://github.com/opengeospatial/geosparql3dwhitepaper/issues/14</li></ul>{:/} |
+| 20:20 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Follow up with Anthony Cohn (no response so far) | PC | Carried forward |
+``

--- a/_posts/2025-08-06-notes.md
+++ b/_posts/2025-08-06-notes.md
@@ -1,0 +1,52 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/08/06
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 08/06/2025  
+**Meeting Time:** 2010–2050  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Timo Homburg | TH |
+| Arkadiusz Chadzynski | AC |
+| Matthew Perry | MP |
+| Nicholas Car | NC |
+
+## Apologies
+- Paul Cripps (PC)
+
+## Note Takers
+- Joseph Abhayaratna
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Follow up with Anthony Cohn | Paul Cripps | Carried forward |
+| ⬜ | Follow up with Scott Simmons regarding Extended WKB and ISO standard style expert | Joseph Abhayaratna | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:10 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:13 | Previous actions | JA | {::nomarkdown}<ul><li>JA to work with NC to fill in tickets for ISO alignment, pending clarity from OGC on style requirements.</li><li>Contact made with Anthony Cohn; meeting to be arranged.</li><li>Anthony Cohn’s work to be considered (noted in issues #416 and #518).</li></ul>{:/} |
+| 20:25 | Any PRs | All | {::nomarkdown}<ul><li>PR discussed: https://github.com/opengeospatial/ogc-geosparql/pull/631</li><li>TH and PC to review.</li><li>PR discussed: https://github.com/ogcincubator/cityrdf/pull/16</li><li>Team to review and provide feedback.</li></ul>{:/} |
+| 20:50 | Other topics | All | {::nomarkdown}<ul><li>No additional topics raised.</li></ul>{:/} |
+| 20:50 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Follow up with Anthony Cohn | PC | Carried forward |
+| <span name="action_2">2</span> | Follow up with Scott Simmons regarding Extended WKB and ISO standard style expert | JA | Carried forward |

--- a/_posts/2025-08-20-notes.md
+++ b/_posts/2025-08-20-notes.md
@@ -1,0 +1,53 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/08/20
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 08/20/2025  
+**Meeting Time:** 2005–2038  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Timo Homburg | TH |
+| Arkadiusz Chadzynski | AC |
+| Matthew Perry | MP |
+
+## Apologies
+- Nicholas Car (NC)  
+- Paul Cripps (PC)
+
+## Note Takers
+- Matthew Perry
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Follow up with ISO style contact | Nicholas Car | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:07 | Previous actions | JA | {::nomarkdown}<ul><li>JA to follow up with Scott Simmons regarding Extended WKB and ISO standard style expert.</li><li>OGC has all required information and is awaiting documents.</li><li>Vote required to submit EWKB documents.</li><li>Contact made with Anthony Cohn; meeting to be arranged.</li><li>Anthony Cohn’s work to be considered (noted in issues #416 and #518).</li></ul>{:/} |
+| 20:12 | Extended WKB document | JA | {::nomarkdown}<ul><li>JA to initiate an email vote for submission to OGC TC.</li></ul>{:/} |
+| 20:20 | Any PRs | All | {::nomarkdown}<ul><li>EWKB Community Standard Work Item first draft reviewed and approved by MP.</li><li>TH to review after the meeting.</li></ul>{:/} |
+| 20:24 | Issues | JA | {::nomarkdown}<ul><li>Issue raised to add a homepage to the GitHub project description.</li><li>JA updated project metadata and closed the issue.</li></ul>{:/} |
+| 20:28 | Other topics | All | {::nomarkdown}<ul><li>Texture ontology and JavaScript demo for Wouter Beek discussed.</li><li>AC to work on the texture ontology and demo.</li><li>Status update on TH’s work on GeoSPARQL 1.1 benchmark queries.</li><li>TH reported work is still in progress.</li></ul>{:/} |
+| 20:38 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Follow up with Anthony Cohn | PC | Carried forward |
+| <span name="action_2">2</span> | Follow up with Scott Simmons regarding Extended WKB and ISO standard style expert | JA | — |

--- a/_posts/2025-09-03-notes.md
+++ b/_posts/2025-09-03-notes.md
@@ -1,0 +1,52 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/09/03
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 09/03/2025  
+**Meeting Time:** 2005–2038  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+| Paul Cripps | PC |
+| Matthew Perry | MP |
+
+## Apologies
+- None
+
+## Note Takers
+- Joseph Abhayaratna
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Get in touch with ISO style contact | Nicholas Car | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:07 | Previous actions | JA, NC | {::nomarkdown}<ul><li>NC to get in touch with ISO style contact.</li></ul>{:/} |
+| 20:12 | Extended WKB document | All | {::nomarkdown}<ul><li>Vote passed unanimously.</li></ul>{:/} |
+| 20:20 | Any PRs | All | {::nomarkdown}<ul><li>EWKB Community Standard Work Item first draft (PR #631) merged following vote.</li></ul>{:/} |
+| 20:24 | Issues | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/634</li><li>Issue tested in PowerShell 7 and Ubuntu and found to be working.</li><li>Recommendation to close the issue.</li></ul>{:/} |
+| 20:28 | Other topics | All | {::nomarkdown}<ul><li>No additional topics raised.</li></ul>{:/} |
+| 20:38 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Get in touch with ISO style contact | NC | Carried forward |

--- a/_posts/2025-09-17-notes.md
+++ b/_posts/2025-09-17-notes.md
@@ -1,0 +1,52 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/09/17
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 09/17/2025  
+**Meeting Time:** 2005–2038  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+| Matthew Perry | MP |
+
+## Apologies
+- Paul Cripps (PC)
+
+## Note Takers
+- Joseph Abhayaratna
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Get in touch with ISO style contact | Nicholas Car | Carried forward |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:07 | Previous actions | JA, NC | {::nomarkdown}<ul><li>NC to get in touch with ISO style contact.</li><li>NC confirmed use of Metanorma style form.</li></ul>{:/} |
+| 20:08 | Agenda items from NC | NC, TH, JA | {::nomarkdown}<ul><li>Status update on GeoSPARQL 1.2.</li><li>Resolved AsciiDoc issues that previously caused Metanorma build errors.</li><li>Explicit anchors added to sections; 1.2 now in better shape than 1.1 regarding documentation errors.</li><li>Diagram updated to UML style.</li><li>Discussion on two ISO geometry definitions (geometry as superclass vs geometry as object).</li><li>NC did not consider this an actual issue.</li><li>TH raised a problem identified on page 102.</li><li>SWG review of 1.2 requested before next meeting.</li><li>Agreement to create issues tagged “ISO Alignment” for any findings.</li><li>Intention to forward 1.2 to ISO after SWG review.</li><li>ISO plenary noted as upcoming in November.</li><li>Proposal to move vocabularies to the GeoSemantics repository: https://github.com/opengeospatial/geosemantics-vocabs/</li><li>TH asked how to mark vocabularies as experimental.</li><li>NC advised applying a status indicator.</li><li>NC recommended removing vocabularies from the GeoSPARQL repository once migration is complete to avoid duplication.</li><li>JA stated that vocabularies forming part of the GeoSPARQL standard (e.g. ontology) should remain in the GeoSPARQL repository, while ancillary vocabularies may move.</li></ul>{:/} |
+| 20:12 | Extended WKB document | All | {::nomarkdown}<ul><li>Vote passed unanimously.</li></ul>{:/} |
+| 20:20 | Any PRs | All | {::nomarkdown}<ul><li>EWKB Community Standard Work Item first draft (PR #631) merged following vote.</li></ul>{:/} |
+| 20:24 | Issues | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/634</li><li>Issue tested in PowerShell 7 and Ubuntu and found to be working.</li><li>Recommendation to close the issue.</li></ul>{:/} |
+| 20:51 | Other topics | All | {::nomarkdown}<ul><li>TH working on an examples page to demonstrate elements of the standard in use.</li></ul>{:/} |
+| 20:38 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Get in touch with ISO style contact | NC | Carried forward |

--- a/_posts/2025-10-01-notes.md
+++ b/_posts/2025-10-01-notes.md
@@ -1,0 +1,49 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/10/01
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 10/01/2025  
+**Meeting Time:** 2005–2042  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+| Matthew Perry | MP |
+
+## Apologies
+- Paul Cripps (PC)
+
+## Note Takers
+- Matthew Perry
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:15 | General discussion | JA | {::nomarkdown}<ul><li>JA reported that two documents for EWKB normative reference work have been sent to Scott and are ready to proceed to public comment.</li></ul>{:/} |
+| 20:15 | Issues | All | {::nomarkdown}<ul><li>Issue discussed: https://github.com/opengeospatial/ogc-geosparql/issues/637</li><li>PC to review the issue.</li></ul>{:/} |
+| 20:23 | Other topics | TH, PC | {::nomarkdown}<ul><li>New repository for vocabularies identified: https://github.com/opengeospatial/geosemantics-vocabs</li><li>TH working on a 3D example.</li><li>PC reported a meeting with Anthony Cohn.</li><li>Positive feedback that RCC is being used in GeoSPARQL.</li><li>Interest expressed in compiling a list of implementations.</li><li>View expressed that RCC9 work will likely suffice for 3D and cover most use cases.</li><li>Relevant paper referenced: https://www.mdpi.com/2220-9964/13/1/25</li><li>TH proposed next steps to extract property definitions for RCC9 relations.</li><li>TH suggested examining how RCC9 relates to Simple Features relations and whether new SF relations are needed.</li><li>PC advised he would be out of the country until November.</li><li>PC noted GeoSPARQL has been integrated into the information exchange standard.</li></ul>{:/} |
+| 20:42 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Develop a 3D example | TH | — |
+

--- a/_posts/2025-10-29-notes.md
+++ b/_posts/2025-10-29-notes.md
@@ -1,0 +1,48 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/10/29
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 10/29/2025  
+**Meeting Time:** 2005–2042  
+**Meeting Location:** Microsoft Teams  
+
+> Note: No quorum was present.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+| Matthew Perry | MP |
+
+## Apologies
+- Paul Cripps (PC)  
+- Joseph Abhayaratna (JA)
+
+## Note Takers
+- Matthew Perry
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:05 | Roll call and call for patents | All | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 20:23 | Other topics | All | {::nomarkdown}<ul><li>No additional topics raised.</li></ul>{:/} |
+| 20:33 | General discussion | NC, TH | {::nomarkdown}<ul><li>NC noted no response yet from Scott Simmons regarding GeoSPARQL ISO submission.</li><li>NC highlighted the need for GeoSPARQL vocabulary assets to be published in OGC Rainbow, requiring action by the OGC Naming Authority.</li><li>TH advised that an update on the CRS ontology should be available at the next meeting.</li></ul>{:/} |
+| 20:44 | Issues | All | {::nomarkdown}<ul><li>Issue discussed: <a href=\"https://github.com/opengeospatial/ogc-geosparql/issues/642\">ogc-geosparql#642</a></li></ul>{:/} |
+| 20:42 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| — | No new action items recorded | — | — |

--- a/_posts/2025-11-26-notes.md
+++ b/_posts/2025-11-26-notes.md
@@ -1,0 +1,48 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/11/26
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 11/26/2025 (UTC)  
+**Meeting Time:** 2000–2100 UTC  
+**Meeting Location:** Microsoft Teams  
+
+> Note: This meeting was not transcribed. Times below reflect agenda‑aligned estimates within the scheduled one‑hour window.
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Matthew Perry | MP |
+| Timo Homburg | TH |
+
+*(Only participants who spoke during the meeting are listed.)*
+
+## Note Takers
+- Joseph Abhayaratna (informal minutes; no transcript available)
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+
+## Discussion Items
+
+| Time (UTC) | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:00 | Opening, roll call, call for patents | JA, TH, MP | {::nomarkdown}<ul><li>Meeting opened and quorum checked.</li><li>No patents declared.</li></ul>{:/} |
+| 20:05 | GeoSPARQL status check‑in | JA | {::nomarkdown}<ul><li>Light status discussion given proximity to end‑of‑year period.</li><li>No major decisions taken.</li></ul>{:/} |
+| 20:15 | Standards and coordination updates | TH, MP | {::nomarkdown}<ul><li>General coordination discussion across GeoSPARQL, ISO, and OGC activities.</li><li>No formal resolutions.</li></ul>{:/} |
+| 20:30 | Forward planning (December / January) | All | {::nomarkdown}<ul><li>Awareness raised that upcoming meetings would fall near holiday period.</li><li>Expectation that some meetings may be cancelled or lightly attended.</li></ul>{:/} |
+| 20:45 | Open discussion | All | {::nomarkdown}<ul><li>Informal discussion only.</li><li>No new action items raised.</li></ul>{:/} |
+| 21:00 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| — | No new action items recorded | — | — |
+``

--- a/_posts/2025-12-10-notes.md
+++ b/_posts/2025-12-10-notes.md
@@ -1,0 +1,51 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2025/12/10
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 12/10/2025  
+
+**Meeting Time:** 2000–2105 UTC  
+
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Matthew Perry | MP |
+| Timo Homburg | TH |
+
+## Note Takers
+- Joseph Abhayaratna (discussion‑heavy meeting; relied on transcript rather than formal note taking)
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+
+## Discussion Items
+
+| Time (UTC) | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 20:00 | Informal check‑in and roll call | JA, TH, MP | {::nomarkdown}<ul><li>Meeting opened with informal discussion.</li><li>Quorum not fully reached; meeting treated as a light update session.</li></ul>{:/} |
+| 20:06 | OGC Innovation Days / Odyssey Innovation Days | TH | {::nomarkdown}<ul><li>TH reported attendance at OGC Innovation Days.</li><li>Strong emphasis across talks on semantics, interoperability, and data quality as enablers for AI.</li><li>Consensus that better semantic modelling reduces LLM hallucination but remains costly to implement.</li></ul>{:/} |
+| 20:18 | AI, semantics, and knowledge graph trends | JA, TH, MP | {::nomarkdown}<ul><li>Discussion on growing interest in pre‑packaged knowledge graphs for AI and analytics.</li><li>JA noted increased commercial traction and internal engineering interest.</li><li>Debate on RDF‑based semantics vs lighter‑weight annotation approaches.</li></ul>{:/} |
+| 20:32 | Extended WKB (EWKB) public comment update | JA | {::nomarkdown}<ul><li>Public comment period nearing close.</li><li>No comments received; considered uncontroversial.</li><li>Expectation that TC vote would proceed early in the new year.</li></ul>{:/} |
+| 20:38 | OGC Rainbow updates | TH, JA | {::nomarkdown}<ul><li>Rainbow implementation work progressing as previously outlined.</li><li>GeoSPARQL being used as a key use case for ontology rendering improvements.</li></ul>{:/} |
+| 20:43 | GeoSPARQL 3D White Paper status | TH | {::nomarkdown}<ul><li>Participation uneven due to scheduling conflicts.</li><li>Rolf Yonko continuing to drive completion via individual follow‑ups.</li><li>Target publication timeframe discussed as early 2026.</li></ul>{:/} |
+| 20:48 | ISO GeoSPARQL 1.2 fast‑track process | TH | {::nomarkdown}<ul><li>Fast‑track process initiated.</li><li>Expected duration approximately six months.</li><li>ISO timelines acknowledged.</li></ul>{:/} |
+| 20:51 | December / January scheduling | All | {::nomarkdown}<ul><li>Christmas Eve meeting cancelled.</li><li>New Year’s Day meeting avoided.</li><li>Provisional next meeting identified as Jan 8 (Jan 7 UTC).</li></ul>{:/} |
+| 20:56 | OGC membership status (Germany) | TH | {::nomarkdown}<ul><li>Update on German geospatial authority engagement with OGC.</li><li>Positive signals that organisational membership will continue.</li></ul>{:/} |
+| 21:02 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Cancel Christmas Eve meeting and notify group | Joseph Abhayaratna | Completed |
+| <span name="action_2">2</span> | Poll group on preferred January restart date | Joseph Abhayaratna | Before Next Meeting |
+| <span name="action_3">3</span> | Continue individual follow‑ups to complete GeoSPARQL 3D White Paper | Timo Homburg | Ongoing |

--- a/_posts/2026-01-07-notes.md
+++ b/_posts/2026-01-07-notes.md
@@ -1,0 +1,55 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2026/01/07
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 01/07/2026
+
+**Meeting Time:** 2000 UTC
+
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Matthew Perry | MP |
+| Timo Homburg | TH |
+
+## Note Takers
+- Joseph Abhayaratna (meeting relied on transcription / AI notes rather than manual note taking)
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ⬜ | Arrange / coordinate discussion with Rob Atkinson about OGC Building Blocks | Joseph Abhayaratna | Next Meeting |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2000 | Call for patents and roll call | JA, TH, MP | {::nomarkdown}<ul><li>No patents declared.</li><li>Roll call completed.</li></ul>{:/} |
+| 2010 | Fix WKT examples axis order | TH, JA, MP | {::nomarkdown}<ul><li>Identified incorrect X/Y axis order in WKT examples.</li><li>Clarified CRS84 vs EPSG:4326 axis order expectations.</li><li>Agreed to apply fixes across additional branches after review.</li></ul>{:/} |
+| 2020 | Bibliography management (BibTeX workflow) | TH, JA, MP | {::nomarkdown}<ul><li>Proposal to consolidate citations into a single BibTeX file.</li><li>Use metadata to separate normative and non‑normative references.</li><li>Consensus that this simplifies editing and reduces errors.</li></ul>{:/} |
+| 2025 | Editor guidance documentation | TH, JA | {::nomarkdown}<ul><li>Decision to add a top‑level “notes / notes for editors” folder.</li><li>Include README explaining BibTeX and Metanorma workflow.</li></ul>{:/} |
+| 2030 | RCC‑9 relations and functions | TH, JA, MP | {::nomarkdown}<ul><li>TH completed addition of RCC‑9 functions alongside properties.</li><li>Requested reviews from additional domain experts.</li></ul>{:/} |
+| 2035 | GeoSPARQL 3D paper (architecture / BIM) | TH, JA, MP | {::nomarkdown}<ul><li>Reviewed newly published paper extending GeoSPARQL with 3D functions.</li><li>Paper seen as useful justification and inspiration for standard work.</li></ul>{:/} |
+| 2040 | Function comparison table cleanup | TH, JA, MP | {::nomarkdown}<ul><li>Plan to reduce overly long comparison tables to relevant 3D functions.</li><li>Align white paper and future spec comparisons.</li></ul>{:/} |
+| 2045 | OGC Building Blocks exploration | TH, JA, MP | {::nomarkdown}<ul><li>TH presented early work on using Building Blocks for ontologies and functions.</li><li>Main open question: appropriate granularity (ontology vs class/function).</li></ul>{:/} |
+| 2100 | “Easy to add” functions and grouping | TH, JA, MP | {::nomarkdown}<ul><li>Reviewed candidate transformation functions (translate, scale, rotate).</li><li>Discussed better grouping and marking functions as “3D‑aware”.</li></ul>{:/} |
+| 2115 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Apply WKT axis‑order fixes across additional branches after approvals | Timo Homburg | Next Meeting |
+| <span name="action_2">2</span> | Create “notes / notes for editors” folder with BibTeX workflow guidance | Timo Homburg | Next Meeting |
+| <span name="action_3">3</span> | Request and incorporate review feedback on RCC‑9 relations/functions PR | Timo Homburg | Next Meeting |
+| <span name="action_4">4</span> | Reduce function‑comparison tables to relevant 3D content | Timo Homburg | Next Meeting |
+| <span name="action_5">5</span> | Introduce Rob Atkinson to advise on applying OGC Building Blocks to GeoSPARQL | Joseph Abhayaratna | Next Meeting |
+| <span name="action_6">6</span> | Collect feedback on proposed “easy to add” function signatures and grouping | Matthew Perry, Timo Homburg | Next Meeting |

--- a/_posts/2026-01-21-notes.md
+++ b/_posts/2026-01-21-notes.md
@@ -1,0 +1,53 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2026/01/21
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 01/21/2026  
+
+**Meeting Time:** 2000 UTC  
+
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Jo Abhayaratna | JA |
+| Matthew Perry | MP |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+| Paul Cripps | PC |
+| Thomas (IFC / Linked Building Data) | TS |
+
+## Note Takers
+- JA (assisted by Teams transcription)
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ✅ | Contact Rob Atkinson regarding OGC Building Blocks discussion | JA | Completed |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2000 | Meeting setup and roll call | JA | {::nomarkdown}<ul><li>Meeting opened with roll call.</li><li>Recording and transcription confirmed.</li><li>No patents declared.</li></ul>{:/} |
+| 2010 | Building Blocks status and CRS ontology | TH | {::nomarkdown}<ul><li>TH reported progress on publishing CRS ontology Building Blocks.</li><li>Discussed challenges publishing Building Blocks alongside existing GitHub Pages content.</li><li>Shared links to deployed Building Blocks for review.</li></ul>{:/} |
+| 2025 | Granularity of Building Blocks documentation | TH, NC | {::nomarkdown}<ul><li>Discussion on whether Building Blocks should document individual classes/functions or reusable groupings.</li><li>Consensus that Building Blocks should align with reusable “chunks” rather than every class individually.</li></ul>{:/} |
+| 2040 | GeoSPARQL 3D and IFC use cases | TS | {::nomarkdown}<ul><li>TS presented background on IFC geometry, 3D complexity, and challenges aligning IFC with GeoSPARQL.</li><li>Outlined a draft questionnaire intended to capture IFC community perspectives on GeoSPARQL 3D scope.</li><li>Emphasised the need to distinguish what is actually used vs theoretically possible.</li></ul>{:/} |
+| 2100 | GeoSPARQL–IFC alignment discussion | NC, JA, PC, TH | {::nomarkdown}<ul><li>Discussion focused on GeoSPARQL providing fundamental 3D geometry and topological relations rather than deep IFC semantics.</li><li>Examples raised from hydrology and building models to illustrate lightweight alignment benefits.</li><li>Agreement that tolerances and geometric fuzziness are challenging and may not belong in core GeoSPARQL.</li></ul>{:/} |
+| 2140 | Questionnaire refinement and distribution | All | {::nomarkdown}<ul><li>Agreement to refine questionnaire to capture current usage and barriers to adoption.</li><li>Target communities identified: GeoSemantics DWG, implementers group, and Linked Building Data community (via Arcadios).</li></ul>{:/} |
+| 2155 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Coordinate meeting with Rob Atkinson on OGC Building Blocks | JA | Next Meeting |
+| <span name="action_2">2</span> | Share CRS ontology Building Blocks for feedback on granularity and structure | TH | Next Meeting |
+| <span name="action_3">3</span> | Refine IFC–GeoSPARQL questionnaire to include current usage and adoption barriers | TS | Next Meeting |
+| <span name="action_4">4</span> | Distribute questionnaire to identified communities (GeoSemantics DWG, implementers, Linked Building Data) | TH, JA | Following Refinement |

--- a/_posts/2026-02-04-notes.md
+++ b/_posts/2026-02-04-notes.md
@@ -1,0 +1,51 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2026/02/04
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 02/04/2026  
+
+**Meeting Time:** 2000 UTC  
+
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Jo Abhayaratna | JA |
+| Matthew Perry | MP |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+
+## Note Takers
+- MP (assisted by Teams transcription)
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2000 | Meeting setup and administration | JA, MP | {::nomarkdown}<ul><li>JA confirmed the meeting is now scheduled in UTC to avoid daylight savings issues.</li><li>Recording and transcription confirmed.</li><li>Chairing handed over to MP for the main part of the meeting.</li></ul>{:/} |
+| 2005 | Roll call and call for patents | MP | {::nomarkdown}<ul><li>Roll call completed.</li><li>No patents declared.</li></ul>{:/} |
+| 2010 | Building Blocks and compliance benchmark update | TH | {::nomarkdown}<ul><li>TH reported on follow‑up discussions with Rob Atkinson regarding Building Blocks.</li><li>Outlined proposed approach for documenting GeoSPARQL functions as Building Blocks, including examples, queries, and validation assets.</li><li>Agreement that function representation in Building Blocks is an open design question requiring further experimentation.</li></ul>{:/} |
+| 2030 | ISO GeoSPARQL standardisation progress | NC | {::nomarkdown}<ul><li>NC reported ongoing work on the ISO version of GeoSPARQL.</li><li>Identified broken links and minor administrative issues in GeoSPARQL 1.1 requiring correction.</li><li>Confirmed that changes are non‑normative and primarily structural and terminological.</li></ul>{:/} |
+| 2040 | Repository hygiene and Rainbow alignment | NC, TH | {::nomarkdown}<ul><li>Discussion on aligning GitHub repository structure with resources deployed to OGC Rainbow.</li><li>Agreement to group RDF artefacts consistently and introduce manifest files per version.</li><li>TH confirmed feasibility of updating CI scripts to support the new structure.</li></ul>{:/} |
+| 2100 | Implementation experience and performance concerns | NC, TH, MP, JA | {::nomarkdown}<ul><li>NC reported that several triple stores implement GeoSPARQL functions non‑performantly at scale.</li><li>Consensus that this is primarily an implementation issue rather than a standards compliance issue.</li><li>Discussion on whether performance benchmarks should exist alongside compliance benchmarks.</li></ul>{:/} |
+| 2120 | Governance, Rainbow, and OGC engagement | JA | {::nomarkdown}<ul><li>JA discussed the need for clearer governance and resourcing around OGC Rainbow.</li><li>Highlighted the importance of demonstrating real usage to secure continued investment.</li><li>Planned follow‑up discussions with OGC leadership to raise awareness of GeoSPARQL needs.</li></ul>{:/} |
+| 2155 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Create initial Building Blocks examples for GeoSPARQL functions | TH | Next Meeting |
+| <span name="action_2">2</span> | Circulate draft ISO GeoSPARQL content highlighting non‑normative changes | NC | Next Meeting |
+| <span name="action_3">3</span> | Audit GeoSPARQL 1.1 RDF resources and align repository structure with Rainbow deployments | NC, TH | Next Meeting |
+| <span name="action_4">4</span> | Engage OGC leadership on Rainbow governance, resourcing, and roadmap visibility | JA | Ongoing |

--- a/_posts/2026-02-18-notes.md
+++ b/_posts/2026-02-18-notes.md
@@ -1,0 +1,51 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2026/02/18
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 02/18/2026  
+
+**Meeting Time:** 2000 UTC  
+
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Matthew Perry | MP |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+| Jo Abhayaratna | JA |
+
+## Note Takers
+- MP
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2000 | Meeting opening and handover | JA, MP | {::nomarkdown}<ul><li>JA opened the meeting but handed facilitation to MP due to illness.</li><li>Recording and transcription were confirmed to be running.</li></ul>{:/} |
+| 2005 | Roll call and administrative items | MP | {::nomarkdown}<ul><li>Roll call completed.</li><li>Call for patents – none declared.</li></ul>{:/} |
+| 2010 | Pull Requests and ISO content status | NC, TH, MP | {::nomarkdown}<ul><li>NC reported on two open PRs.</li><li>TH provided verbal approval due to GitHub UI issues.</li><li>NC to merge PRs and circulate ISO content separately once internal review permits.</li></ul>{:/} |
+| 2020 | GeoSPARQL 1.1 artefact audit and Rainbow issues | NC, MP, TH | {::nomarkdown}<ul><li>NC described an audit of all GeoSPARQL 1.1 artefacts to ensure correct delivery via OGC Rainbow.</li><li>Intermittent IRI resolution and missing HTML/RDF representations were demonstrated.</li><li>Decision to create a dedicated “GeoSPARQL 1.1 mappings” ontology to manage alignment triples.</li></ul>{:/} |
+| 2040 | ISO standardisation progress | NC, TH | {::nomarkdown}<ul><li>NC walked through ISO document structure and editorial changes.</li><li>Clarified that RDF content remains unchanged; work is administrative and harmonisation-focused.</li><li>Discussion on how definitions, diagrams, and requirements differ between OGC and ISO conventions.</li></ul>{:/} |
+| 2100 | Documentation tooling and bibliography management | NC, TH, MP | {::nomarkdown}<ul><li>Discussion on BibTeX usage, normative vs non-normative references, and compatibility between AsciiDoc and Metanorma.</li><li>TH suggested splitting bibliographies to avoid custom scripting.</li><li>NC to investigate feasibility.</li></ul>{:/} |
+| 2115 | Close | All | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Circulate ISO GeoSPARQL content for SWG review once internal ISO editing is complete | NC | Next Meeting |
+| <span name="action_2">2</span> | Complete audit of GeoSPARQL 1.1 artefacts and raise Naming Authority tickets where needed | NC | Next Meeting |
+| <span name="action_3">3</span> | Create a dedicated GeoSPARQL 1.1 mappings ontology for alignment triples | NC | Next Meeting |
+| <span name="action_4">4</span> | Investigate support for separate normative and non-normative bibliographies in tooling | NC, TH | Next Meeting |
+``

--- a/_posts/2026-03-04-notes.md
+++ b/_posts/2026-03-04-notes.md
@@ -1,0 +1,54 @@
+---
+title: GeoSPARQL Standards Working Group Meeting Minutes 2026/03/04
+---
+
+# GeoSPARQL Standards Working Group Meeting Minutes
+
+## Meeting Details
+**Meeting Date:** 03/04/2026  
+
+**Meeting Time:** 2000 UTC  
+
+**Meeting Location:** Microsoft Teams  
+
+## Attendees
+
+| Attendee | Moniker |
+| ---- | ---- |
+| Joseph Abhayaratna | JA |
+| Timo Homburg | TH |
+| Nicholas Car | NC |
+| Matthew Perry | MP |
+
+## Note Takers
+- JA
+
+## Action Items From Last Meetings
+
+| Done? | Item | Responsible | Due Date |
+| ---- | ---- | ---- | --- |
+| ✅ | Add missing meeting notes to GitHub | JA | Completed |
+
+## Discussion Items
+
+| Time | Item | Who | Notes |
+| ---- | ---- | ---- | ---- |
+| 2000 | Opening, roll call, and procedural items | JA | {::nomarkdown}<ul><li>Roll call completed</li><li>Patent call and recording acknowledged</li></ul>{:/} |
+| 2005 | EWKB motion and TC plenary preparation | All | {::nomarkdown}<ul><li>Discussion of motion to advance Extended WKB (EWKB) as an OGC Community Standard</li><li>Agreement that Scott will present rationale at TC plenary due to time zone constraints</li><li>Review of justification slides and required refinements</li></ul>{:/} |
+| 2025 | GeoSPARQL roadmap and priorities | All | {::nomarkdown}<ul><li>GeoSPARQL 1.3 priorities: improved 3D support and additional literal types</li><li>Status update on GeoSPARQL 1.1 heading toward ISO co-publication</li></ul>{:/} |
+| 2035 | ISO co-adoption status | NC | {::nomarkdown}<ul><li>Overview of ISO draft based on GeoSPARQL 1.1</li><li>Structural and formatting changes for ISO compliance</li><li>Request for SWG members to review and provide feedback</li></ul>{:/} |
+| 2045 | Meeting notes automation | JA | {::nomarkdown}<ul><li>Demonstration of automated transcription and Copilot-generated meeting notes</li><li>Comparison with manually maintained notes</li><li>Agreement to proceed with automated notes with light human review</li></ul>{:/} |
+| 2055 | OGC Building Blocks and validation | TH | {::nomarkdown}<ul><li>Integration of SHACL shapes and examples into Building Blocks register</li><li>Discussion of topology properties and validation gaps</li></ul>{:/} |
+| 2105 | Reference implementation and tooling | TH, NC | {::nomarkdown}<ul><li>Presentation of GeoSPARQL implementation for RDFLib using Shapely</li><li>Discussion of test suite, aggregates, and future publication</li><li>Question raised on publishing under RDFLibGeoSPARQL repository</li></ul>{:/} |
+| 2120 | Rainbow / Naming Authority governance | JA, NC | {::nomarkdown}<ul><li>Rainbow identified as critical platform for publishing standards-related resources</li><li>Discussion of governance and review challenges for normative resources</li><li>Agreement to continue coordination and clarify governance expectations</li></ul>{:/} |
+| 2130 | Close | JA | MEETING ENDS |
+
+## Action Items
+
+| # | Item | Responsible | Due Date |
+| ---- | ---- | ---- | ---- |
+| <span name="action_1">1</span> | Review ISO GeoSPARQL draft and provide feedback | All | Within 1–2 weeks |
+| <span name="action_2">2</span> | Merge outstanding PRs (RDF tidy, WebVOWL link fixes) | NC | Next meeting |
+| <span name="action_3">3</span> | Decide publication location for RDFLib GeoSPARQL implementation | TH, NC | Next meeting |
+| <span name="action_4">4</span> | Publish reviewed meeting notes | JA | End of week |
+


### PR DESCRIPTION
This update adds missing meetings notes.

Several of these have been taken by AI transcription.
Others have been converted to markdown using AI.